### PR TITLE
feat: adds chemprot prompts

### DIFF
--- a/prompts/chemprot.py
+++ b/prompts/chemprot.py
@@ -1,0 +1,261 @@
+"""
+Date: 2021.10.10
+
+ChemProt Corpus (https://biocreative.bioinformatics.udel.edu/resources/corpora/chemprot-corpus-biocreative-vi/) prompting annotation
+
+This script does the following:
+
+(1) If the ChemProt corpus is unavailable/unspecified - will download it
+(2) Converts the ChemProt corpus into the BRAT/Standoff format to use pybrat
+(3) Creates the appropriate Example/Relations
+(4) Creates prompts
+
+More details about the dataset can be found in the readme's in the respective datasets.
+
+Overall:
+
+Entities include:
+Chemicals: Chemical entities
+Gene-Y: Gene/protein annotation with a known biological identifier in a DB (as of 2017)
+Gene-N: Gene/protein annotation without a known biological identifier in a database (as of 2017)
+
+Relations Include (exactly quoted from the Readme):
+
+CPR-3: Upregulator, activator, indirect upregulator
+CPR-4: downregulator, inhibitor, indirect downregulator
+CPR-5: agonist, agonist-activator, agonist inhibitor
+CPR-6: antagonist
+CPR-9: sybstrate, product of, substrate product of
+
+**NOTE, the implementation here uses the GOLD STANDARD, as this is canonically evaluated against. There are relations outside these annotations provided but were not group-evaluated (ex: CPR:1, CPR:2, CPR:7, CPR:8, and CPR:10 labels)
+
+Some notes:
+i) The ChemProt dataset is a zipped folder of zipped folders. The individual train/test/sample/dev folders must be also unzipped
+
+ii) The ChemProt dataset needs to be first compiled into standoff format, thus utils_chemprot handles the TSV -> standoff conversion.
+"""
+
+import os
+import argparse
+from pathlib import Path
+from loguru import logger
+from functools import partial
+from typing import List, Callable
+from pybrat.parser import BratParser, Example, Relation
+from utils import download, uncompress
+from prompts import DatasetPrompts
+
+from utils_chemprot import chemprot_2_standoff
+
+# Some prompts can be borrowed for template
+from ddi import (
+    list_entity_template,
+    list_comma_separated_entity_mentions,
+    bulleted_list_entity_mentions,
+    list_relation_template,
+    list_comma_separated_relations,
+    bulleted_list_relations,
+)
+
+# TODO: Implement proper Hugging Face's Datasets version of ChemProt??
+
+# URL with ChemProt Corpus Data
+_URL = "https://biocreative.bioinformatics.udel.edu/media/store/files/2017/ChemProt_Corpus.zip"
+
+# Train/Dev/Test dataset prefix; additional "sample" file for quick tests
+_TRAIN = "chemprot_training"
+_DEV = "chemprot_development"
+_TEST = "chemprot_test_gs"
+_SAMPLE = "chemprot_sample"
+
+# Standoff + Brat parser
+_BRAT_PARSER = BratParser(error="ignore")
+
+
+def load_chemprot(data_root: str, split: str) -> List[Example]:
+    """
+    Load the data split (ex: train/test/dev) for ChemProt.
+    If BRAT annotation not provided, will create it and process it.
+    """
+    data_dir = os.path.join(data_root, split)
+    brat_path = os.path.join(data_root, split, "brat")
+
+    # If no standoff annotations exist, make it
+    if not os.path.exists(brat_path):
+        chemprot_2_standoff(data_dir, brat_path)
+
+    logger.info(f"Loading ChemProt Standoff format from {brat_path}")
+
+    return _BRAT_PARSER.parse(brat_path)
+
+
+class ChemProtPrompts(DatasetPrompts):
+    """
+    Create prompts with the ChemProt corpus (https://biocreative.bioinformatics.udel.edu/resources/corpora/chemprot-corpus-biocreative-vi/).
+    """
+
+    def __init__(self, data_root: str):
+        """Instantiate ChemProt Prompts.
+
+        :param data_root: Root folder containing target dataset
+        """
+        self.data_root = Path(data_root).resolve()
+        self.path = self.data_root / _URL.split("/")[-1]
+        self._init_dataset()
+        self._init_prompts()
+
+    def _init_dataset(self):
+        """
+        Download (if unavailable) and prepare the ChemProt dataset
+
+        """
+        # confirm dataset dir exist
+        if not os.path.exists(self.data_root):
+            os.makedirs(self.data_root)
+            logger.info(f"Directory {self.data_root} successfully created")
+
+        # download dataset file
+        if not os.path.exists(self.path):
+            download(_URL, self.path)
+            logger.info("Dataset successfully downloaded")
+            logger.info(self.path)
+
+        # uncompress file
+        full_path = self.data_root / "ChemProt_Corpus"
+        if not os.path.exists(full_path):
+            uncompress(self.path, self.data_root)
+
+        # Specific to ChemProt, unpack each data split
+        data_splits = {"train": _TRAIN, "dev": _DEV, "test": _TEST, "sample": _SAMPLE}
+
+        for dtype in data_splits.values():
+            dtype_path = self.data_root / "ChemProt_Corpus" / dtype
+            if not os.path.exists(dtype_path):
+                logger.info("Unpacking " + str(dtype))
+                uncompress(str(dtype_path) + ".zip", full_path)
+            else:
+                logger.info(str(dtype) + " data is already unzipped.")
+
+        # Create train/dev/test and sample data
+        self.splits = {
+            split: load_chemprot(full_path, fname)
+            for split, fname in data_splits.items()
+        }
+
+    def _init_prompts(self):
+        """Initialize prompts."""
+        self._prompts = {}
+        self._metadata = {}
+
+
+def main(args):
+
+    # Make output directory if it doesn't exist
+    outpath = Path(args.outdir)
+    os.makedirs(outpath, exist_ok=True)
+
+    # Create dataset
+    dataset = ChemProtPrompts(args.datadir)
+
+    # ------------------
+    # Add NER prompts
+    # ------------------
+    # ChemProt entities include
+    # CHEMICAL - Chemical entity mention type
+    # GENE-Y - Gene/Protein mention type with a bio database identifier
+    # GENE-N - Gene/Protein mention type w/o bio database identifier
+    prompts = {
+        "list_chemicals": partial(
+            list_comma_separated_entity_mentions, entity_type="CHEMICAL"
+        ),
+        "list_gene_y": partial(
+            list_comma_separated_entity_mentions, entity_type="GENE-Y"
+        ),
+        "list_gene_n": partial(
+            list_comma_separated_entity_mentions, entity_type="GENE-N"
+        ),
+        "bulleted_list_chemicals": partial(
+            bulleted_list_entity_mentions, entity_type="CHEMICAL"
+        ),
+        "bulleted_list_gene_y": partial(
+            bulleted_list_entity_mentions, entity_type="GENE-Y"
+        ),
+        "bulleted_list_gene_n": partial(
+            bulleted_list_entity_mentions, entity_type="GENE-N"
+        ),
+    }
+
+    for name in prompts:
+        dataset.add_prompt(
+            prompts[name],
+            name,
+            answer_keys=None,
+            original_task=True,
+            answers_in_prompt=True,
+            metrics=["f1", "accuracy"],
+        )
+
+    # ------------------
+    # Add Relational prompts
+    # ------------------
+    # ChemProt relationships that were group annotated (CPR-3-6, CPR:9)
+    # CPR-3: Activator (See above for full annotation)
+    # CPR-4: Inhibitor
+    # CPR-5: Agonist
+    # CPR-6: Antagonist
+    # CPR-9: Substrate
+
+    prompts = {
+        "list_relations_cpr3": partial(
+            list_comma_separated_relations, relation_type="CPR:3"
+        ),
+        "list_relations_cpr4": partial(
+            list_comma_separated_relations, relation_type="CPR:4"
+        ),
+        "list_relations_cpr5": partial(
+            list_comma_separated_relations, relation_type="CPR:5"
+        ),
+        "list_relations_cpr6": partial(
+            list_comma_separated_relations, relation_type="CPR:6"
+        ),
+        "list_relations_cpr9": partial(
+            list_comma_separated_relations, relation_type="CPR:9"
+        ),
+        "bulleted_list_relations_cpr3": partial(
+            bulleted_list_relations, relation_type="CPR:3"
+        ),
+        "bulleted_list_relations_cpr4": partial(
+            bulleted_list_relations, relation_type="CPR:4"
+        ),
+        "bulleted_list_relations_cpr5": partial(
+            bulleted_list_relations, relation_type="CPR:5"
+        ),
+        "bulleted_list_relations_cpr6": partial(
+            bulleted_list_relations, relation_type="CPR:6"
+        ),
+        "bulleted_list_relations_cpr9": partial(
+            bulleted_list_relations, relation_type="CPR:9"
+        ),
+    }
+    for name in prompts:
+        dataset.add_prompt(
+            prompts[name],
+            name,
+            answer_keys=None,
+            original_task=True,
+            answers_in_prompt=True,
+            metrics=["f1", "accuracy"],
+        )
+
+    df = dataset.get_prompts()
+
+    # Save the dataset
+    df.to_csv(outpath / "chemprot_corpus_prompts.tsv", sep="\t", index=False)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--outdir", type=str, default=None)
+    parser.add_argument("--datadir", type=str, default="datasets")
+    args = parser.parse_args()
+    main(args)

--- a/prompts/chemprot.py
+++ b/prompts/chemprot.py
@@ -33,6 +33,14 @@ Some notes:
 i) The ChemProt dataset is a zipped folder of zipped folders. The individual train/test/sample/dev folders must be also unzipped
 
 ii) The ChemProt dataset needs to be first compiled into standoff format, thus utils_chemprot handles the TSV -> standoff conversion.
+
+Call this script from the head of the biomedical directory
+
+Usage:
+
+python chemprot.py --outdir your/output/dir
+python chemprot.py --outdir your/output/dir --datadir your/chemprot/corpus
+
 """
 
 import os
@@ -76,6 +84,9 @@ def load_chemprot(data_root: str, split: str) -> List[Example]:
     """
     Load the data split (ex: train/test/dev) for ChemProt.
     If BRAT annotation not provided, will create it and process it.
+
+    :param data_root: Location of the ChemProt data directory
+    :param split: Name of the data split (train/test/dev/sample)
     """
     data_dir = os.path.join(data_root, split)
     brat_path = os.path.join(data_root, split, "brat")
@@ -146,6 +157,15 @@ class ChemProtPrompts(DatasetPrompts):
         """Initialize prompts."""
         self._prompts = {}
         self._metadata = {}
+
+    def _get_pmid(self):
+        """
+        To analyze ChemProt, the PMIDs are saved in the "BRAT" folder.
+        This is useful to keep track of which text files match the inputs, as this may differ from the row order of the original dataset.
+
+        :returns: Dictionary with PMID in order of the data
+        """
+        return {key: [i.id for i in value] for key, value in self.splits.items()}
 
 
 def main(args):
@@ -244,13 +264,13 @@ def main(args):
             answer_keys=None,
             original_task=True,
             answers_in_prompt=True,
-            metrics=["f1", "accuracy"],
+            metrics=["accuracy"],
         )
 
     df = dataset.get_prompts()
 
     # Save the dataset
-    df.to_csv(outpath / "chemprot_corpus_prompts.tsv", sep="\t", index=False)
+    df.to_csv(outpath / "chemprot_prompts.tsv", sep="\t", index=False)
 
 
 if __name__ == "__main__":

--- a/prompts/utils_chemprot.py
+++ b/prompts/utils_chemprot.py
@@ -17,6 +17,10 @@ The relations should be explicitly the "Gold" standard, as this was explicitly m
 
 This script is largely based on John Giogri's version found here:
 https://github.com/JohnGiorgi/ChemProt-to-Standoff/blob/master/chemprot_to_standoff.py
+
+Usage:
+
+python utils_chemprot -i /dir/to/chemprot/corpus/datasplit -o output_dir
 """
 import re
 from glob import glob

--- a/prompts/utils_chemprot.py
+++ b/prompts/utils_chemprot.py
@@ -1,0 +1,213 @@
+"""
+2020.10.10
+
+Chemprot helper functions to extract relevant information.
+The following script converts the ChemProt dataset into a Standoff format for easier processing.
+
+There are several components to the ChemProt dataset:
+
+Note, for Relations in particular, there is a GROUP annotation Y/N - it might be worth filtering for ONLY those that have "Y" as this was the explicitly criteria used for evaluations.
+
+(1) Abstracts - the actual natural text (PMID, Title, Abstract)
+(2) Entities - a list of entities (PMID, Entity, Type of entity, start char, end char, text of entity)
+(3) Relations (PMID, Chem Protein relation CPR group, Eval Type, CPR Type, Interactor Arg 1, Interactor Arg 2)
+(4) Gold Standard Relations - Similar to (3) but manually annotated and confirmed.
+
+The relations should be explicitly the "Gold" standard, as this was explicitly manually annotated (hence "ground truth")
+
+This script is largely based on John Giogri's version found here:
+https://github.com/JohnGiorgi/ChemProt-to-Standoff/blob/master/chemprot_to_standoff.py
+"""
+import re
+from glob import glob
+
+import os
+import argparse
+from typing import Dict
+
+
+def chemprot_2_standoff(data_dir: str, output_dir: str):
+    """
+    Convert the ChemProt dataset into a BRAT-Standoff format.
+
+    :param data_dir: Unzipped ChemProt corpus files directory
+    :param output_dir: Location to store data
+    """
+    if not os.path.exists(output_dir):
+        print("Output dir does not exist, making it")  # TODO convert to log
+        os.makedirs(output_dir)
+
+    for filepath in glob(os.path.join(data_dir, "*.tsv")):
+
+        # Get abstracts
+        if re.search("abstract", filepath):
+            abstracts = get_abstract(filepath)
+
+            # Create txt files
+            write_data(abstracts, output_dir, "txt")
+
+        # Get entities
+        elif re.search("entities", filepath):
+            ents = get_entities(filepath)
+
+        elif re.search("gold_standard", filepath):
+            relns = get_relations(filepath)
+
+    # Concatenate the Entities + Relations files together
+    for pmid in ents:
+        if pmid in relns:
+            ents[pmid] = f"{ents[pmid]}\n{relns[pmid]}"
+
+    write_data(ents, output_dir, "ann")
+
+
+def write_data(data_dict: Dict[str, str], output_dir: str, ext: str = "txt"):
+    """
+    For each PMID, save the record to txt or ann file.
+
+    :param data_dict: Dictionary of abstracts/entities/relations
+    :param output_dir: Directory to save data in
+    :param ext: Type of file extension (text for abstracts and ann for else)
+
+    :returns: None; Prints the dictionary, per PMID, to file.
+    """
+    for pmid, item in data_dict.items():
+
+        filename = os.path.join(output_dir, f"{pmid}.{ext}")
+
+        with open(filename, "w") as f:
+            f.write(item)
+
+
+def get_abstract(abs_filename: str) -> Dict[str, str]:
+    """
+    For each document in PubMed ID (PMID) in the ChemProt abstract data file, return the abstract. Data is tab-separated.
+
+    :param filename: `*_abstracts.tsv from ChemProt
+
+    :returns Dictionary with PMID keys and abstract text as values.
+    """
+    with open(abs_filename, "r") as f:
+        contents = [i.strip() for i in f.readlines()]
+
+    # PMID is the first column, Abstract is last
+    return {
+        doc.split("\t")[0]: "\n".join(doc.split("\t")[1:]) for doc in contents
+    }  # Includes title as line 1
+
+
+def get_entities(ents_filename: str) -> Dict[str, str]:
+    """
+    For each document in the corpus, return entity annotations per PMID.
+    Each column in the entity file is as follows:
+    (1) PMID
+    (2) Entity Number
+    (3) Entity Type (Chemical, Gene-Y, Gene-N)
+    (4) Start index
+    (5) End index
+    (6) Actual text of entity
+
+    :param ents_filename: `_*entities.tsv` file from ChemProt
+
+    :returns: Dictionary with PMID keys and entity annotations.
+    """
+    with open(ents_filename, "r") as f:
+        contents = [i.strip() for i in f.readlines()]
+
+    entities = {}
+
+    for line in contents:
+
+        pmid, idx, label, start_offset, end_offset, name = line.split("\t")
+
+        # If no PMID in dict, add empty container
+        if pmid not in entities:
+            entities[pmid] = []
+
+        # If PMID already available, add new entities
+        ann = f"{idx}\t{label} {start_offset} {end_offset}\t{name}"
+        entities[pmid].append(ann)
+
+    return {pmid: "\n".join(ann) for pmid, ann in entities.items()}
+
+
+def get_relations(rel_filename: str) -> Dict[str, str]:
+    """
+    For each document in the ChemProt corpus, create an annotation for the gold-standard relationships. 
+
+    The columns include:
+    (1) PMID
+    (2) Relationship Label (CPR)
+    (3) Interactor Argument 1 + Identifier
+    (4) Interactor Argument 2 + Identifier
+
+    Gold standard includes CPRs 3-9. Relationships are always Gene + Protein.
+    Unlike entities, there is no counter, hence once must be made
+
+    :param rel_filename: Gold standard file name
+    """
+    with open(rel_filename, "r") as f:
+        contents = [i.strip() for i in f.readlines()]
+
+    ridx = 1  # Counter for relations index
+    relations = {}
+
+    for line in contents:
+        pmid, label, arg1, arg2 = line.split("\t")
+
+        if pmid not in relations:
+            ridx = 1
+            relations[pmid] = []
+
+        ann = f"R{ridx}\t{label} {arg1} {arg2}"
+        relations[pmid].append(ann)
+
+        ridx += 1
+
+    return {pmid: "\n".join(ann) for pmid, ann in relations.items()}
+
+
+# https://stackoverflow.com/questions/273192/how-can-i-create-a-directory-if-it-does-not-exist#273227
+def make_dir(directory):
+    """Creates a directory at `directory` if it does not already exist.
+    """
+    try:
+        os.makedirs(directory)
+    except OSError as err:
+        if err.errno != errno.EEXIST:
+            raise
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description=())
+    parser.add_argument(
+        "-i", "--input", help="Path to ChemProt corpus.", type=str, required=True
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Directory to save converted corpus.",
+        type=str,
+        required=True,
+    )
+
+    kwargs = vars(parser.parse_args())
+
+    chemprot_2_standoff(kwargs["input"], kwargs["output"])
+
+
+# Note in the ChemProt dataset, the gold standard is generally equal to the relations with manual annotation as a group labeled as "Y"
+
+# import pandas as pd
+#
+# for i in ["_development", "_sample", "_training", "_test_gs"]:
+#    file1 = 'chemprot' + i + '/chemprot' + i + '_relations.tsv'
+#    file2 = 'chemprot' + i + '/chemprot' + i + '_gold_standard.tsv'
+#    x = pd.read_csv(file1, sep="\t", header=None)
+#    y = pd.read_csv(file2, sep="\t", header=None)
+#
+#    x.loc[:, 2] = x.loc[:, 2].apply(lambda x: x.split()[0])
+#    print("\n\n" + i)
+#    print("Relations with Y=", x[x.loc[:, 2]=="Y"].shape[0])
+#    print("Gold Standard=", y.shape[0])


### PR DESCRIPTION
Adds the ChemProt dataset prompts.

ChemProt highlights a list of gene and protein interactions. The dataset has entities, annotated as "Chemical", "Gene-Y" (gene/protein with known identifier), and "Gene-N" (gene/protein without known identifier).

The "gold-standard" relations have labels such as CPR:3, 4, 5, 6, and 9. I have made comments as to what these pertain to.

Two scripts are necessary to run chemprot: `utils_chemprot` which converts the ChemProt data into a Standoff format, and `chemprot` the dataset prompt generator. 

Update: 2021.10.13 - Switched to formal PR
Update 2021.10.10 - I am making some final touches/quality control to make sure this is in good form. Still left TODO is making a DataLoader. This is a Draft PR for transparency and will convert to a regular PR when ready/reviewed. 