### PR TITLE
update template local to include data_dir and data_files kwargs

### DIFF
--- a/templates/template_local.py
+++ b/templates/template_local.py
@@ -14,31 +14,35 @@
 # limitations under the License.
 
 """
-This is a template on how to implement a dataset in the biomedical repo.
+This is a template on how to implement a local dataset loader in the biomedical
+repo. A local dataset loader reads files that are already available on ths users
+machine as opposed to providing a method to download the files. This is typically
+used when the licensing of a dataset prevents it from being easily downloaded.
 
 A thorough walkthrough on how to implement a dataset can be found here:
 https://huggingface.co/docs/datasets/add_dataset.html
 
 This script corresponds to Step 4 in the Biomedical Hackathon guide.
 
-To start, copy this template file and save it as <your_dataset_name>.py in an appropriately named folder within datasets. Then, modify this file as necessary to implement your own method of extracting, and generating examples for your dataset. 
-
 There are 3 key elements to implementing a dataset:
 
-(1) `_info`: Create a skeletal structure that describes what is in the dataset and the nature of the features.
+(1) `_info`: Create a skeletal structure that describes what is in the dataset and
+    the nature of the features.
 
-(2) `_split_generators`: Download and extract data for each split of the data (ex: train/dev/test)
+(2) `_split_generators`: Download and extract data for each split of the data
+    (ex: train/dev/test)
 
-(3) `_generate_examples`: From downloaded + extracted data, process files for the data in a feature format specified in "info".
+(3) `_generate_examples`: From downloaded + extracted data, process files for the
+    data in a feature format specified in "info".
 
 ----------------------
 Step 1: Declare imports
-Your imports go here; the only mandatory one is `datasets`, as methods and attributes from this library will be used throughout the script.
+Your imports go here; the only mandatory one is `datasets`, as methods and attributes
+from this library will be used throughout the script.
 
-We have provided some import statements that we strongly recommend. Feel free to adapt; so long as the style-guide requirements are satisfied (Step 5), then you should be able to push your code.
 """
 import datasets
-import os  # useful for paths
+import os
 from typing import Iterable, Dict, List
 import logging
 
@@ -80,15 +84,17 @@ _HOMEPAGE = "Homepage of the dataset"
 
 _LICENSE = "License"
 
-_URLs = {'your_dataset_name': "your_dataset_URL"}
-
 _VERSION = "1.0.0"
 
 """
-Step 3: Change the class name to correspond to your <Your_Dataset_Name> 
+Step 3: Change the class name to correspond to your <Your_Dataset_Name>
 ex: "CellFinderDataset".
 
-Then, fill all relevant information to `BuilderConfig` which populates information about the class. You may have multiple builder configs (ex: a large dataset separated into multiple partitions) if you populate for different dataset names + descriptions. The following is setup for just 1 dataset, but can be adjusted.
+Then, fill all relevant information to `BuilderConfig` which populates
+information about the class. You may have multiple builder configs
+(ex: a large dataset separated into multiple partitions) if you populate for
+different dataset names + descriptions. The following is setup for just 1
+dataset, but can be adjusted.
 
 NOTE - train/test/dev splits can be handled in `_split_generators`.
 """
@@ -110,19 +116,26 @@ class YourDatasetName(datasets.GeneratorBasedBuilder):
     DEFAULT_CONFIG_NAME = _DATASETNAME
 
     """
-    Step 4: Populate "information" about the dataset that creates a skeletal structure for an example within the dataset looks like.
+    Step 4: Populate "information" about the dataset that creates a skeletal
+    structure for an example within the dataset looks like.
 
     The following data structures are useful:
 
-    datasets.Features - An instance that defines all descriptors within a feature in an arbitrary nested manner; the "feature" class must strictly adhere to this format. 
+    datasets.Features - An instance that defines all descriptors within a feature
+    in an arbitrary nested manner; the "feature" class must strictly adhere to this
+    format.
 
     datasets.Value - the type of the data structure (ex: useful for text, PMIDs)
 
-    datasets.Sequence - for information that must be in a continuous sequence (ex: spans in the text, offsets)
+    datasets.Sequence - for information that must be in a continuous sequence
+    (ex: spans in the text, offsets)
 
     An example is as follows for an ENTITY + RELATION dataset.
 
-    Your format may differ depending on what the dataset is. Please try to keep the extraction as close to the original dataset as possible. If you're having trouble adapting your dataset, please contact the community channels and an organizer will reach out!
+    Your format may differ depending on what the dataset is. Please try to keep the
+    extraction as close to the original dataset as possible. If you're having trouble
+    adapting your dataset, please contact the community channels and an organizer will
+    reach out!
     """
 
     def _info(self):
@@ -173,26 +186,45 @@ class YourDatasetName(datasets.GeneratorBasedBuilder):
         """
         Step 5: Access the dataset
 
-        No explicit downloading is required for this version of a dataloder; the expectation is that the `load_dataset` command of the `datasets` library is called within the folder that contains the files of interest.
+        No explicit downloading is required for this version of a dataloder.
+        The expectation is that the `load_dataset` command of the `datasets`
+        library is called with one of the following kwargs,
 
-        If the user has the dataset properly downloaded, they may simply use `os.getcwd()` to get the string-formatted path of the current working directory. This can be used to reference the dataset subsequently.
+        * data_dir
+        * data_files
 
-        Fill the arguments of "SplitGenerator" with `name` and `gen_kwargs`. 
+        These will then be available in this class as `self.config.datadir` and/or
+        self.config.data_files`. For example,
+
+          dataset = datasets.load_dataset("my_script", data_dir="/path/to/data")
+
+        will cause `self.config.data_dir` to be equal to "/path/to/data".
+        You can use whichever kwarg makes the most sense for your dataset.
+
+        You can read more
+          * in the BuilderConfig docs
+            https://huggingface.co/docs/datasets/package_reference/builder_classes.html#datasets.BuilderConfig
+          * in the first "Note" of the Downloading data files and organizing splits"
+            section of the huggingface add_dataset docs.
+            https://huggingface.co/docs/datasets/add_dataset.html#downloading-data-files-and-organizing-splits
+
+
+        Next, fill the arguments of "SplitGenerator" with `name` and `gen_kwargs`.
 
         Note:
 
         - `name` can be: datasets.Split.<TRAIN/TEST/VALIDATION> or a string
-        - all keys in `gen_kwargs` can be passed to `_generate_examples()`. If your dataset has multiple files, you can make a separate key for each file, as shown below:
+        - all keys in `gen_kwargs` are passed to `_generate_examples()`.
+
+        If your dataset has multiple files, you can make a separate key for each
+        file, as shown below:
 
         """
-
-        data_dir = os.getcwd()
-
         return [
             datasets.SplitGenerator(
                 name="DatasetSplit",
                 gen_kwargs={
-                    "filepath": data_dir,
+                    "filepath": self.config.data_dir,
                     "abstract_file": os.path.join(data_dir, "abstract.txt"),
                     "entity_file": os.path.join(data_dir, "entities.txt"),
                     "relation_file": os.path.join(data_dir, "relations.txt"),
@@ -209,7 +241,8 @@ class YourDatasetName(datasets.GeneratorBasedBuilder):
 
         The arguments to this function come from `gen_kwargs` returned in `_split_generators()`
 
-        The goal of this function is to perform operations on any of the keys of `gen_kwargs` that allow you to extract and process the data.
+        The goal of this function is to perform operations on any of the keys of `gen_kwargs`
+        that allow you to extract and process the data.
 
         The following skeleton does the following:
 
@@ -217,7 +250,8 @@ class YourDatasetName(datasets.GeneratorBasedBuilder):
         - "extracts" entities, assuming the output is of the form specified in `_info`
         - "extracts" relations, assuming similarly the output in the form specified in `_info`.
 
-        An assumption in this pseudo code is that the abstract, entity, and relation file all have linking keys.
+        An assumption in this pseudo code is that the abstract, entity, and relation file all
+        have linking keys.
         """
         if self.config.name == _DATASETNAME:
 
@@ -236,9 +270,11 @@ class YourDatasetName(datasets.GeneratorBasedBuilder):
                 }
 
     """
-    These methods are optional helper functions. You may make any number of helper functions to assist in extracting and working with the data.
+    These methods are optional helper functions. You may make any number of helper
+    functions to assist in extracting and working with the data.
 
-    It may be helpful to use static methods (via the decorator "@staticmethod") for these functions.
+    It may be helpful to use static methods (via the decorator "@staticmethod")
+    for these functions.
     """
     @staticmethod
     def _get_abstract(abstract_file: str) -> Dict[int, str]:

--- a/templates/template_local.py
+++ b/templates/template_local.py
@@ -193,7 +193,7 @@ class YourDatasetName(datasets.GeneratorBasedBuilder):
         * data_dir
         * data_files
 
-        These will then be available in this class as `self.config.datadir` and/or
+        These will then be available in this class as `self.config.data_dir` and
         self.config.data_files`. For example,
 
           dataset = datasets.load_dataset("my_script", data_dir="/path/to/data")


### PR DESCRIPTION
Added some more details around the `data_dir` and `data_files` kwargs that can be used to pass path information into the `datasets.load_dataset` for datasets that are only available on the users hard drive. 

Also shorted up some long lines and did a bit of copy editing (not super opinionated on any of it so feel free to suggest edits, reversions, deletions, ...) 