### PR TITLE
feat: adds NLI template based on SciTail

### DIFF
--- a/templates/template_nli.py
+++ b/templates/template_nli.py
@@ -1,0 +1,13 @@
+# Based on predictor format of Sci-Tail
+
+# this is the BARE MINIMUM; it can be super-setted into the overall schema.
+features = datasets.Features(
+    {
+        "question": datasets.Value("string"),
+        "text1": datasets.Value("string"),  # Passage/sentence 1
+        "text2": datasets.Value("string"),  # Passage/sentence 
+        "label": datasets.Value("string"),  # entails/etc
+    }
+)
+
+## We may want to consider cases where metadata (i.e. "number of volunteers that annotated this answer") etc. for gold labeling - I also couldn't find something but happy to keep a hierarchical structure


### PR DESCRIPTION
Adds the "NLI" template; this is intended to be a minimal skeleton of the view expected based on SciTail; it will need to be adapted for the overall schema.