### PR TITLE
text/offset iterables update

### DIFF
--- a/schemas/kb.py
+++ b/schemas/kb.py
@@ -26,14 +26,14 @@ features = datasets.Features(
                 "id": datasets.Value("string"),
                 "type": datasets.Value("string"),
                 "text": datasets.Value("string"),
-                "offsets": datasets.Sequence([datasets.Value("int32")]),
+                "offsets": datasets.Sequence(datasets.Value("int32")),
             }
         ],
         "entities": [
             {
                 "id": datasets.Value("string"),
                 "offsets": datasets.Sequence([datasets.Value("int32")]),
-                "text": datasets.Sequence([datasets.Value("string")]),
+                "text": datasets.Sequence(datasets.Value("string")),
                 "type": datasets.Value("string"),
                 "normalized": [
                     {


### PR DESCRIPTION
The text field should have one less level of nesting than the offsets.
For passages, 
offsets = (lo,hi) and text = str 
For entities,
offsets = [(lo,hi), (lo,hi)] and text = ["txt1", "txt2"]

Sequence([...]) is an iterable inside an iterable. Sequence() is just an iterable.