### PR TITLE
Update UPLOADING.md

### DIFF
--- a/UPLOADING.md
+++ b/UPLOADING.md
@@ -30,7 +30,7 @@ With the requirements downloaded, run the following command:
 huggingface-cli login
 ```
 
-Login with your 🤗 Hub account username and password. 
+Login with your 🤗 Hub token generated from https://huggingface.co/settings/token. 
 
 ### 3. Create a dataset repository
 


### PR DESCRIPTION
```
        To login, `huggingface_hub` now requires a token generated from https://huggingface.co/settings/token.
        (Deprecated, will be removed in v0.3.0) To login with username and password instead, interrupt with Ctrl+C.

Token:
Username: bwang482
Password:
ERROR:root:HfApi.login: This method is deprecated in favor of `set_access_token`.
```