### PR TITLE
Add tests for bigbio KB datasets

### DIFF
--- a/tests/test_kb_dataset.py
+++ b/tests/test_kb_dataset.py
@@ -5,18 +5,38 @@ from collections import defaultdict
 from difflib import ndiff
 from pathlib import Path
 from pprint import pformat
+from typing import Optional, Union
 
 sys.path.append(str(Path(__file__).parent.parent))
 
 import datasets
+
 from schemas.kb import features
 
 
-
 class TestKBDataset(unittest.TestCase):
+
+    PATH: str
+    DATA_DIR: str
+    USE_AUTH_TOKEN: Optional[Union[bool, str]]
+
     def setUp(self) -> None:
-        self.dataset_source = datasets.load_dataset(sys.argv[1], name="source")
-        self.dataset_bigbio = datasets.load_dataset(sys.argv[1], name="bigbio")
+
+        self.dataset_source = datasets.load_dataset(
+            self.PATH,
+            name="source",
+            data_dir=self.DATA_DIR,
+            use_auth_token=self.USE_AUTH_TOKEN,
+        )
+
+        self.dataset_bigbio = datasets.load_dataset(
+            self.PATH,
+            name="bigbio",
+            data_dir=self.DATA_DIR,
+            use_auth_token=self.USE_AUTH_TOKEN,
+        )
+        # self.dataset_source = datasets.load_dataset(sys.argv[1], name="source")
+        # self.dataset_bigbio = datasets.load_dataset(sys.argv[1], name="bigbio")
 
     def print_statistics(self):
         for split_name, split in self.dataset_bigbio.items():
@@ -125,8 +145,21 @@ class TestKBDataset(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("datset_script")
+    # parser = argparse.ArgumentParser()
+    # parser.add_argument("datset_script")
+    # args = parser.parse_args()
+    parser = argparse.ArgumentParser(
+        description="Unit tests for dataset with KB schema. Args are passed to `datasets.load_dataset`"
+    )
+
+    parser.add_argument("--path", type=str, required=True)
+    parser.add_argument("--data_dir", type=str, default=None)
+    parser.add_argument("--use_auth_token", default=None)
+
     args = parser.parse_args()
+
+    TestKBDataset.PATH = args.path
+    TestKBDataset.DATA_DIR = args.data_dir
+    TestKBDataset.USE_AUTH_TOKEN = args.use_auth_token
 
     unittest.TextTestRunner().run(TestKBDataset())

--- a/tests/test_kb_dataset.py
+++ b/tests/test_kb_dataset.py
@@ -1,0 +1,126 @@
+import argparse
+import sys
+import unittest
+from collections import defaultdict
+
+import datasets
+
+
+
+class TestKBDataset(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dataset_source = datasets.load_dataset(sys.argv[1], name="source")
+        self.dataset_bigbio = datasets.load_dataset(sys.argv[1], name="bigbio")
+
+    def print_statistics(self):
+        for split_name, split in self.dataset_bigbio.items():
+            print(split_name)
+            print("=" * 10)
+
+            counter = defaultdict(int)
+            for example in split:
+                for feature_name, feature in features.items():
+                    if isinstance(feature, datasets.Value) or isinstance(
+                        feature_name, dict
+                    ):
+                        if example[feature_name]:
+                            counter[feature_name] += 1
+                    else:
+                        counter[feature_name] += len(example[feature_name])
+
+            for k, v in counter.items():
+                print(f"{k}: {v}")
+            print()
+
+    def runTest(self):
+        self.print_statistics()
+        self.test_is_bigbio_schema_compatible()
+        self.test_are_ids_globally_unique()
+        self.test_do_all_referenced_ids_exist()
+
+    def test_is_bigbio_schema_compatible(self):
+        for split in self.dataset_bigbio.values():
+            self.assertEqual(split.features, features)
+
+    def test_are_ids_globally_unique(self):
+        for split in self.dataset_bigbio.values():
+            ids_seen = set()
+            for example in split:
+                self._assert_ids_globally_unique(example, ids_seen=ids_seen)
+
+    def test_do_all_referenced_ids_exist(self):
+        for split in self.dataset_bigbio.values():
+            for example in split:
+                referenced_ids = set()
+                existing_ids = set()
+
+                referenced_ids.update(self._get_referenced_ids(example))
+                existing_ids.update(self._get_existing_referable_ids(example))
+
+                for ref_id, ref_type in referenced_ids:
+                    if ref_type == "event_arg":
+                        self.assertTrue(
+                            (ref_id, "entity") in existing_ids
+                            or (ref_id, "event") in existing_ids
+                        )
+                    else:
+                        self.assertIn((ref_id, ref_type), existing_ids)
+
+    def _assert_ids_globally_unique(
+        self, collection, ids_seen: set, ignore_assertion: bool = False
+    ):
+        if isinstance(collection, dict):
+            for k, v in collection.items():
+                if isinstance(v, dict):
+                    self._assert_ids_globally_unique(v, ids_seen)
+                elif isinstance(v, list):
+                    for elem in v:
+                        self._assert_ids_globally_unique(elem, ids_seen)
+                else:
+                    if k == "id":
+                        if not ignore_assertion:
+                            self.assertNotIn(v, ids_seen)
+                        ids_seen.add(v)
+        elif isinstance(collection, list):
+            for elem in collection:
+                self._assert_ids_globally_unique(elem, ids_seen)
+
+    def _get_referenced_ids(self, example):
+        referenced_ids = []
+
+        for event in example["events"]:
+            for argument in event["arguments"]:
+                referenced_ids.append((argument["ref_id"], "event_arg"))
+
+        for coreference in example["coreferences"]:
+            for entity_id in coreference["entity_ids"]:
+                referenced_ids.append((entity_id, "entity"))
+
+        for relation in example["relations"]:
+            referenced_ids.append((relation["arg1_id"], "entity"))
+            referenced_ids.append((relation["arg2_id"], "entity"))
+
+        return referenced_ids
+
+    def _get_existing_referable_ids(self, example):
+        existing_ids = []
+
+        for entity in example["entities"]:
+            existing_ids.append((entity["id"], "entity"))
+
+        for event in example["events"]:
+            existing_ids.append((event["id"], "event"))
+
+        return existing_ids
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("datset_script")
+    parser.add_argument("schema")
+    args = parser.parse_args()
+
+    # Load the schema
+    with open(sys.argv[2]) as f:
+        exec(f.read())
+    unittest.TextTestRunner().run(TestKBDataset())

--- a/tests/test_kb_dataset.py
+++ b/tests/test_kb_dataset.py
@@ -2,7 +2,9 @@ import argparse
 import sys
 import unittest
 from collections import defaultdict
+from difflib import ndiff
 from pathlib import Path
+from pprint import pformat
 
 sys.path.append(str(Path(__file__).parent.parent))
 
@@ -44,7 +46,11 @@ class TestKBDataset(unittest.TestCase):
 
     def test_is_bigbio_schema_compatible(self):
         for split in self.dataset_bigbio.values():
-            self.assertEqual(split.features, features)
+            if not split.features == features:
+                s1 = pformat(split.features).splitlines()
+                s2 = pformat(features).splitlines()
+                print("\n".join(ndiff(s1, s2)))
+                assert split.features == features
 
     def test_are_ids_globally_unique(self):
         for split in self.dataset_bigbio.values():

--- a/tests/test_kb_dataset.py
+++ b/tests/test_kb_dataset.py
@@ -4,7 +4,10 @@ import unittest
 from collections import defaultdict
 from pathlib import Path
 
+sys.path.append(str(Path(__file__).parent.parent))
+
 import datasets
+from schemas.kb import features
 
 
 
@@ -120,8 +123,4 @@ if __name__ == "__main__":
     parser.add_argument("datset_script")
     args = parser.parse_args()
 
-    schema_file = Path(__file__).parent.parent / "schemas" / "kb.py"
-    # Load the schema
-    with open(schema_file) as f:
-        exec(f.read())
     unittest.TextTestRunner().run(TestKBDataset())

--- a/tests/test_kb_dataset.py
+++ b/tests/test_kb_dataset.py
@@ -2,6 +2,7 @@ import argparse
 import sys
 import unittest
 from collections import defaultdict
+from pathlib import Path
 
 import datasets
 
@@ -117,10 +118,10 @@ class TestKBDataset(unittest.TestCase):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("datset_script")
-    parser.add_argument("schema")
     args = parser.parse_args()
 
+    schema_file = Path(__file__).parent.parent / "schemas" / "kb.py"
     # Load the schema
-    with open(sys.argv[2]) as f:
+    with open(schema_file) as f:
         exec(f.read())
     unittest.TextTestRunner().run(TestKBDataset())

--- a/tests/test_kb_dataset.py
+++ b/tests/test_kb_dataset.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 import unittest
 from collections import defaultdict
-from collections.abc import Iterable
 from difflib import ndiff
 from pathlib import Path
 from pprint import pformat
@@ -163,6 +162,20 @@ class TestKBDataset(unittest.TestCase):
 
         return existing_ids
 
+    def _test_is_list(self, msg: str, field: list):
+        with self.subTest(
+            msg,
+            field=field,
+        ):
+            self.assertIsInstance(field, list)
+
+    def _test_has_only_one_item(self, msg: str, field: list):
+        with self.subTest(
+            msg,
+            field=field,
+        ):
+            self.assertEqual(len(field), 1)
+
     def test_passages_offsets(self):
         """
         Verify that the passages offsets are correct,
@@ -182,23 +195,23 @@ class TestKBDataset(unittest.TestCase):
                         text = passage["text"]
                         offsets = passage["offsets"]
 
-                        with self.subTest(
-                            "Offsets in passages must have only one element",
-                            offsets=offsets,
-                        ):
-                            self.assertEqual(len(offsets), 1)
+                        self._test_is_list(
+                            msg="Text in passages must be a list", field=text
+                        )
 
-                        with self.subTest(
-                            "Text in passages must be an Iterable",
-                            text=text,
-                        ):
-                            self.assertIsInstance(text, Iterable)
+                        self._test_is_list(
+                            msg="Offsets in passages must be a list", field=offsets
+                        )
 
-                        with self.subTest(
-                            "Text in passages must have only one element",
-                            text=text,
-                        ):
-                            self.assertEqual(len(text), 1)
+                        self._test_has_only_one_item(
+                            msg="Offsets in passages must have only one element",
+                            field=offsets,
+                        )
+
+                        self._test_has_only_one_item(
+                            msg="Text in passages must have only one element",
+                            field=text,
+                        )
 
                         for idx, (start, end) in enumerate(offsets):
                             self.assertEqual(example_text[start:end], text[idx])
@@ -215,11 +228,10 @@ class TestKBDataset(unittest.TestCase):
         ):
             self.assertEqual(len(texts), len(offsets))
 
-        with self.subTest(
-            "Text fields paired with offsets must be in the form [`text`, ...]",
-            texts=texts,
-        ):
-            self.assertIsInstance(texts, Iterable)
+        self._test_is_list(
+            msg="Text fields paired with offsets must be in the form [`text`, ...]",
+            field=texts,
+        )
 
         with self.subTest(
             "All offsets must be in the form [(lo1, hi1), ...]", offsets=offsets


### PR DESCRIPTION
This adds a few tests for the bigbio KB datasets, which can be called like this:
```bash
python tests/test_kb_dataset.py [dataset_script]
```
* Can datasets be created from `source` and `bigbio`. `datasets` automatically casts values to the type specified in `features`  so we don't need to check for that explicitly.
* Print counts for all schema elements for quick sanity checks
* Test whether the used `features` are *identical* to `schemas/kb.py`. We have to discuss whether we really want identity or whether the used schema can also be a subset of `schemas/kb.py`
* Test whether all referenced ids exist and have the correct type (e.g. entity or event)
* Test whether ids are globally unique