### PR TITLE
Requirements fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pandas==1.3.3
 numpy==1.21.2
 pybrat @ git+https://github.com/Yevgnen/pybrat
 datasets==1.18.3
-huggingface_hub>=0.4.0,<1.0.0
+huggingface_hub>=0.1.0,<1.0.0
 black~=22.0
 flake8>=3.8.3
 isort>=5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@ pandas==1.3.3
 numpy==1.21.2
 pybrat @ git+https://github.com/Yevgnen/pybrat
 datasets==1.18.3
-huggingface_hub>=0.1.0,<1.0.0
+huggingface_hub>=0.4.0,<1.0.0
 black~=22.0
 flake8>=3.8.3
 isort>=5.0.0
-huggingface_hub>=0.4.0


### PR DESCRIPTION
pip<=20.3 allows only one top level specification of a requirement. Requirements however specifies `huggingface_hub` two times. fixes #132

Futher info: https://github.com/pypa/pip/issues/2367, https://github.com/pypa/pip/issues/988