### PR TITLE
one bigbio config

### DIFF
--- a/examples/n2c2_2011_coref.py
+++ b/examples/n2c2_2011_coref.py
@@ -403,7 +403,7 @@ class N2C22011CorefDataset(datasets.GeneratorBasedBuilder):
                 }
             )
 
-        elif self.config.schema == "bigbio-kb":
+        elif self.config.schema == "kb":
             features = Features(
                 {
                     "id": Value("string"),
@@ -532,7 +532,7 @@ class N2C22011CorefDataset(datasets.GeneratorBasedBuilder):
                 for sample_id, sample in samples.items():
                     if self.config.schema == "source":
                         yield _id, self._get_source_sample(sample_id, sample)
-                    elif self.config.schema == "bigbio-kb":
+                    elif self.config.schema == "kb":
                         yield _id, self._get_coref_sample(sample_id, sample)
                     _id += 1
 
@@ -551,6 +551,6 @@ class N2C22011CorefDataset(datasets.GeneratorBasedBuilder):
             for sample_id, sample in samples.items():
                 if self.config.schema == "source":
                     yield _id, self._get_source_sample(sample_id, sample)
-                elif self.config.schema == "bigbio-kb":
+                elif self.config.schema == "kb":
                     yield _id, self._get_coref_sample(sample_id, sample)
                 _id += 1

--- a/examples/n2c2_2011_coref.py
+++ b/examples/n2c2_2011_coref.py
@@ -129,7 +129,7 @@ _SUPPORTED_TASKS = ["coref"]
 class BigBioConfig(datasets.BuilderConfig):
     """BuilderConfig for BigBio."""
 
-    schema: str = None  # options = (source|bigbio)
+    schema: str = None  # options = (source|kb|entailment|pairs|qa|text|text2text)
     task: str = None  # e.g, (ner|coref|translation|qa)
     subset: str = None # optional dataset specific subset e.g. "9b" for bioasq
 

--- a/examples/n2c2_2011_coref.py
+++ b/examples/n2c2_2011_coref.py
@@ -52,7 +52,7 @@ The following commands can be used to load the dataset
 
 ```
 ds_orig = load_dataset("n2c2_2011_coref.py", name="bigbio", schema="source", data_dir="/path/to/n2c2_2011_coref")
-ds_bb = load_dataset("n2c2_2011_coref.py", name="bigbio", schema="bigbio-kb", data_dir="/path/to/n2c2_2011_coref")
+ds_bb = load_dataset("n2c2_2011_coref.py", name="bigbio", schema="kb", data_dir="/path/to/n2c2_2011_coref")
 ```
 
 
@@ -130,7 +130,7 @@ class BigBioConfig(datasets.BuilderConfig):
     """BuilderConfig for BigBio."""
 
     schema: str = None  # options = (source|kb|entailment|pairs|qa|text|text2text)
-    task: str = None  # e.g, (ner|coref|translation|qa)
+    task: str = "coref"  # e.g, (ner|coref|translation|qa) default can be dataset specific
     subset: str = None # optional dataset specific subset e.g. "9b" for bioasq
 
 


### PR DESCRIPTION
Example of using a custom BigBioConfig with attributes like, 
* schema  (source|kb|entailment|...)
* task (qa|translation|coref|...)
* subset e.g. 10b for bioasq

In this approach there is only one `name` argument that is ever used and its `bigbio` (i.e. the name of the single config) 
```
    BUILDER_CONFIGS = [
        BigBioConfig(
            name="bigbio",
            version=SOURCE_VERSION,
            description="Bigbio Config",
        )
    ]
```

All other branching logic in the dataset loader script can be handled by accessing the `schema`, `task`, or `subset` args. 
```
ds_orig = load_dataset("n2c2_2011_coref.py", name="bigbio", schema="source", data_dir="/path/to/n2c2_2011_coref")
ds_bb = load_dataset("n2c2_2011_coref.py", name="bigbio", schema="kb", data_dir="/path/to/n2c2_2011_coref")
```