### PR TITLE
typing fixes, dedupe entities, text from offsets

### DIFF
--- a/tests/test_bigbio.py
+++ b/tests/test_bigbio.py
@@ -20,7 +20,7 @@ from collections import defaultdict
 from difflib import ndiff
 from pathlib import Path
 from pprint import pformat
-from typing import Iterator, Optional, Union, Iterable
+from typing import Iterator, Optional, Union, Iterable, List
 
 sys.path.append(str(Path(__file__).parent.parent))
 
@@ -590,8 +590,8 @@ class TestDataLoader(unittest.TestCase):
     def _check_offsets(
         self,
         example_text: str,
-        offsets: list[list[int]],
-        texts: list[str],
+        offsets: List[List[int]],
+        texts: List[str],
     ) -> Iterator:
         """
 

--- a/tests/test_kb_dataset.py
+++ b/tests/test_kb_dataset.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from difflib import ndiff
 from pathlib import Path
 from pprint import pformat
-from typing import Iterator, Optional, Union
+from typing import List, Iterator, Optional, Union
 
 sys.path.append(str(Path(__file__).parent.parent))
 
@@ -219,8 +219,8 @@ class TestKBDataset(unittest.TestCase):
     def _check_offsets(
         self,
         example_text: str,
-        offsets: list[list[int]],
-        texts: list[str],
+        offsets: List[List[int]],
+        texts: List[str],
     ) -> Iterator:
 
         with self.subTest(

--- a/tests/test_kb_dataset2.py
+++ b/tests/test_kb_dataset2.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from difflib import ndiff
 from pathlib import Path
 from pprint import pformat
-from typing import Iterator, Optional, Union
+from typing import List, Iterator, Optional, Union
 
 sys.path.append(str(Path(__file__).parent.parent))
 
@@ -227,8 +227,8 @@ class TestKBDataset(unittest.TestCase):
     def _check_offsets(
         self,
         example_text: str,
-        offsets: list[list[int]],
-        texts: list[str],
+        offsets: List[List[int]],
+        texts: List[str],
     ) -> Iterator:
         """
         From a KB instance, check if offsets in the text for a given key matches the actual found text.


### PR DESCRIPTION
great unit tests! :) 

I was able to run all 3 on the n2c2_2011_coref dataset. 
It led me to discover a duplicate entity in the dataset and remove it. 
I also fixed up some entity text choices. Initially I used the text that was provided in the dataset for the entity. This text was lowercased compared to the text in the passages. This caused a lot of text mismatch errors. I switched the text to be from the passages themselves and added some notes in the dataset _loader implementation. 
I also updated the type hints from things like `list[list[int]]` to `List[List[int]]`.
The former was throwing errors in python 3.8 

* python -m tests.test_bigbio --path biomeddatasets/n2c2_2011_coref/n2c2_2011_coref.py --data_dir ~/Data/bigbio/n2c2-2011-coref
* python -m tests.test_kb_dataset --path biomeddatasets/n2c2_2011_coref/n2c2_2011_coref.py --data_dir ~/Data/bigbio/n2c2-2011-coref
* python -m tests.test_kb_dataset2 --path biomeddatasets/n2c2_2011_coref/n2c2_2011_coref.py --data_dir ~/Data/bigbio/n2c2-2011-coref