### PR TITLE
Fix mapping from task to keys: ner -> entities, re -> entities/relations

### DIFF
--- a/tests/test_bigbio.py
+++ b/tests/test_bigbio.py
@@ -384,7 +384,9 @@ class TestDataLoader(unittest.TestCase):
 
             needed_keys = [key for key in features.keys() if key not in opt_keys]
 
-            if task == "ner" or task == "re":
+            if task == "ner":
+                sub_keys = ["entities"]
+            elif task == "re":
                 sub_keys = ["entities", "relations"]
             elif task == "ned":
                 sub_keys = ["entities"]


### PR DESCRIPTION
Fix mapping from task to keys: ner -> entities, re -> entities/relations

Previous mapping was ner -> entities/relations, re -> entities/relations