### PR TITLE
normalize schema and task names 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,24 +99,9 @@ To start, copy [templates/template.py](templates/template.py) to your in `biomed
 
 
 For the `_info_` function, you will need to define `features` for your
-`DatasetInfo` object. For the `big-bio` config, copy the right schema from our list of examples. You can find them as follows:
-
-1. [Named entity recognition (NER)](https://github.com/bigscience-workshop/biomedical/blob/master/schemas/kb.py)
-2. [Relation Extraction (RE)](https://github.com/bigscience-workshop/biomedical/blob/master/schemas/kb.py)
-3. [Event Extraction](https://github.com/bigscience-workshop/biomedical/blob/master/schemas/kb.py)
-4. [Named entity disambiguation/canonicalization/normalization (NED)](https://github.com/bigscience-workshop/biomedical/blob/master/schemas/kb.py)
-5. [Co-reference resolution](https://github.com/bigscience-workshop/biomedical/blob/master/schemas/kb.py)
-6. [Question-Answering](https://github.com/bigscience-workshop/biomedical/blob/aster/schemas/qa.py)
-7. [Entailment](https://github.com/bigscience-workshop/biomedical/blob/master/schemas/entailment.py)
-8. [Translation](https://github.com/bigscience-workshop/biomedical/blob/master/schemas/text_to_text.py)
-9. [Summarization](https://github.com/bigscience-workshop/biomedical/blob/master/schemas/text_to_text.py)
-10. [Paraphrasing](https://github.com/bigscience-workshop/biomedical/blob/master/schemas/text_to_text.py)
-11. [Sentence/Phrase/Text classification](https://github.com/bigscience-workshop/biomedical/blob/master/schemas/text.py)
-12. [Pair Labels](https://github.com/bigscience-workshop/biomedical/blob/master/schemas/pairs.py)
+`DatasetInfo` object. For the `bigbio` config, copy the right schema from our list of examples. You can find a description of these in the [Task Schemas Document](task_schemas.md). You can find the actual schemas in the [schemas directory](https://github.com/bigscience-workshop/biomedical/tree/master/schemas).
 
 You will use this schema in the `_generate_examples` return value.
-
-Please read the [Task Schemas](task_schemas.md) to understand how each key should behave.
 
 Populate the information in the dataset according to this schema; some fields may be empty.
 
@@ -124,17 +109,9 @@ To enable quality control, please add the following line in your file before the
 ```python
 _SUPPORTED_TASKS = ["task1", "task2", ...]
 ```
-Refer to the following list to find the correct task identifier:
-1. **Named Entity Recognition**: `"ner"`
-1. **Relation Extraction**: `"re"`
-1. **Named Entity Disambiguation**: `"ned"`
-1. **Coreference Resolution**: `"coref"`
-1. **Event Extraction**: `"events"`
-1. **Question-Answering**:`"qa"`
-1. **Entailment**: `"entailment"`
-1. **Translation, Summarization, Paraphrasing**: `"text_to_text"`
-1. **Sentence/Phrase/Text Classification**: `"text"`
-1. **Pair Labels**: `"pairs"`
+
+Please refer to the [Task Schemas Document](task_schemas.md) to find the correct task identifier.
+
 
 ##### Example scripts:
 To help you implement a dataset, we offer a template and example scripts.
@@ -148,15 +125,15 @@ Make sure your dataset is implemented correctly by checking in python the follow
 import datasets
 from datasets import load_dataset
 
-data = load_dataset('biomeddatasets/<your_dataset_name>', name="bigbio")
+data = load_dataset('examples/<dataset_name>'.py, name="<dataset_name>_bigbio_<schema>")
 ```
 
-Run these commands within the `biomedical` repo, not in `biomedical/datasets` as the relative path will not work.
+Run these commands within the `biomedical` repo, not in `biomedical/examples` as the relative path will not work.
 
 Once this is done, please also check if your dataloader satisfies our unit tests as follows by using this command in the terminal:
 
 ```
-python -m tests/test_bigbio --path biomeddatasets/<your_dataset_name>/<your_dataset_name>.py [--data_dir /path/to/local/data]
+python -m tests.test_bigbio --path examples/<dataset_name>.py --schema <schema> [--data_dir /path/to/local/data]
 ```
 
 ### 5. Format your code
@@ -173,7 +150,7 @@ This runs the black formatter, isort, and lints to ensure that the code is reada
 
 First, commit your changes to the branch to "add" the work:
 
-    git add datasets/<name_of_my_dataset>/<name_of_my_dataset>.py
+    git add examples/<dataset_name>.py
     git commit
 
 *Ideally, run* `git commit -m "A message of your commits"`

--- a/examples/n2c2_2011.py
+++ b/examples/n2c2_2011.py
@@ -71,7 +71,7 @@ from dataclasses import dataclass
 from datasets import Features, Sequence, Value
 
 
-_DATASETNAME = "n2c2_2011_coref"
+_DATASETNAME = "n2c2_2011"
 
 # https://academic.oup.com/jamia/article/19/5/786/716138
 _CITATION = """\
@@ -114,7 +114,7 @@ _LICENSE = "Data User Agreement"
 _SOURCE_VERSION = "1.0.0"
 _BIGBIO_VERSION = "1.0.0"
 
-_SUPPORTED_TASKS = ["coref"]
+_SUPPORTED_TASKS = ["COREF"]
 
 
 def _read_tar_gz(file_path, samples=None):

--- a/task_schemas.md
+++ b/task_schemas.md
@@ -1,7 +1,7 @@
 # BigBio Schema Documentation
 We have defined a set of lightwieght, task-specific schema to help simplify programmatic access to common biomedical datasets. This schema should be implemented for each dataset in addition to a schema that preserves the original dataset format.
 
-### Example Schemas and Tasks
+### Example Schema and Associated Tasks
 
 - [Knowledge Base (KB)](#knowledge-base)
   - Named entity recognition (NER)

--- a/task_schemas.md
+++ b/task_schemas.md
@@ -1,33 +1,39 @@
 # BigBio Schema Documentation
 We have defined a set of lightwieght, task-specific schema to help simplify programmatic access to common biomedical datasets. This schema should be implemented for each dataset in addition to a schema that preserves the original dataset format.
 
-### Example Schemas by Task
-- [Information Extraction](#information-extraction)
+### Example Schemas and Tasks
+
+- [Knowledge Base (KB)](#knowledge-base)
   - Named entity recognition (NER)
   - Named entity disambiguation/normalization/linking (NED)
   - Event extraction (EE)
   - Relation extraction (RE)
   - Coreference resolution (COREF)
-- [Textual Entailment (TE)](#textual-entailment)
 - [Question Answering (QA)](#question-answering)
-- [Text Pairs](#translation,-paraphasing,-summarization)
+  - Question answering (QA)
+- [Textual Entailment (TE)](#textual-entailment)
+  - Textual entailment (TE)
+- [Text Pairs (PAIRS)](#text-pairs)
+  - Semantic Similarity (STS)
+- [Text to Text (T2T)](#text-to-text)
   - Paraphasing (PARA)
   - Translation (TRANSL)
-  - Summarization (SUM) 	 
-- [Semantic Similarity (STS)](#semantic-similarity)
-- [Text Classification (TEXT)](#text-classification)
+  - Summarization (SUM)
+- [Text (TEXT)](#text)
+  - Text classification (TXTCLASS)
 
-## Information Extraction
+
+## Knowledge Base
 
 [Schema Template](schemas/kb.py)
 
-This is a simple container format with minimal nesting that supports a range of common information extraction/knowledge base construction tasks.
+This is a simple container format with minimal nesting that supports a range of common knowledge base construction / information extraction tasks.
 
 - Named entity recognition (NER)
 - Named entity disambiguation/normalization/linking (NED)
-- Event extraction
+- Event extraction (EE)
 - Relation extraction (RE)
-- Coreference resolution
+- Coreference resolution (COREF)
 
 ```
 {
@@ -50,7 +56,7 @@ This is a simple container format with minimal nesting that supports a range of 
 - `offsets` contain character offsets into the string that would be created from `" ".join([passage["text"] for passage in passages])`
 - `offsets` and `text` are always lists to support discontinous spans. For continuous spans, they will have the form `offsets=[(lo,hi)], text=["text span"]`. For discontinuous spans, they will have the form `offsets=[(lo1,hi1), (lo2,hi2), ...], text=["text span 1", "text span 2", ...]`
 - `normalized` sub-component may contain 1 or more normalized links to database entity identifiers.
-- `passages` captures document structure such as named sections. 
+- `passages` captures document structure such as named sections.
 - `entities`,`events`,`coreferences`,`relations` may be empty fields depending on the dataset and specific task.
 
 
@@ -106,7 +112,7 @@ TBD
 
 ### Coreferences
 
-- Examples: [n2c2 2011: Coreference Challenge](examples/n2c2_2011_coref.py)
+- Examples: [n2c2 2011: Coreference Challenge](examples/n2c2_2011.py)
 
 ```
 "coreferences": [
@@ -164,7 +170,23 @@ TBD
 }
 ```
 
-## Translation, Paraphasing, Summarization
+## Text Pairs
+
+- [Schema Template](schema/pairs.py)
+- Examples: [MQP](examples/mqp.py)
+
+```
+{
+	"id": "0",
+	"document_id": "NULL",
+	"text_1": "Am I over weight (192.9) for my age (39)?",
+	"text_2": "I am a 39 y/o male currently weighing about 193 lbs. Do you think I am overweight?",
+	"label": 1,
+}
+```
+
+
+## Text to Text
 
 - [Schema Template](schema/text_to_text.py)
 - Examples: [ParaMed](examples/paramed.py)
@@ -181,21 +203,7 @@ TBD
 ```
 
 
-## Semantic Similarity
-- [Schema Template](schema/pairs.py)
-- Examples: [MQP](examples/mqp.py)
-
-```
-{
-	"id": "0",
-	"document_id": "NULL",
-	"text_1": "Am I over weight (192.9) for my age (39)?",
-	"text_2": "I am a 39 y/o male currently weighing about 193 lbs. Do you think I am overweight?",
-	"label": 1,
-}
-```
-
-## Text Classification
+## Text
 - [Schema Template](schema/text.py)
 
 ```

--- a/tests/test_bigbio.py
+++ b/tests/test_bigbio.py
@@ -455,7 +455,7 @@ class TestDataLoader(unittest.TestCase):
 
         else:
             raise ValueError(
-                f"{mapped_schame} not recognized. must be one of {set(_TASK_TO_SCHEMA.values())}"
+                f"{mapped_schema} not recognized. must be one of {set(_TASK_TO_SCHEMA.values())}"
             )
 
     @staticmethod


### PR DESCRIPTION
* reorg task_schemas.md so that we have a name for each schema and task 
* update tests to use a fixed set of standardized task and schema names
* change `view` arg to `schema` and force it to be in the list of valid schemas
* remove repeated lists of tasks / schema and redirect to the task_schemas.md file 