### PR TITLE
Multiple unittest updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ Run these commands within the `biomedical` repo, not in `biomedical/examples` as
 Once this is done, please also check if your dataloader satisfies our unit tests as follows by using this command in the terminal:
 
 ```bash
-python -m tests.test_bigbio --path examples/<dataset_name>.py [--data_dir /path/to/local/data]
+python -m tests.test_bigbio examples/<dataset_name>.py [--data_dir /path/to/local/data]
 ```
 
 Your particulr dataset may require use of some of the other command line args in the test script.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,8 +132,15 @@ Run these commands within the `biomedical` repo, not in `biomedical/examples` as
 
 Once this is done, please also check if your dataloader satisfies our unit tests as follows by using this command in the terminal:
 
+```bash
+python -m tests.test_bigbio --path examples/<dataset_name>.py [--data_dir /path/to/local/data]
 ```
-python -m tests.test_bigbio --path examples/<dataset_name>.py --schema <schema> [--data_dir /path/to/local/data]
+
+Your particulr dataset may require use of some of the other command line args in the test script.
+To view full usage instructions you can use the `--help` command,
+
+```bash
+python -m tests.test_bigbio --help
 ```
 
 ### 5. Format your code

--- a/examples/bioasq.py
+++ b/examples/bioasq.py
@@ -61,7 +61,7 @@ The file contains the data of the first nine editions of the challenge: 4234
 questions [1] with their relevant documents, snippets, concepts and RDF
 triples, exact and ideal answers.
 
-Differences with BioASQ-training9b.json 
+Differences with BioASQ-training9b.json
 - 492 new questions added from BioASQ9
     - The question with id 56c1f01eef6e394741000046 had identical body with
     602498cb1cb411341a00009e. All relevant elements from both questions
@@ -93,7 +93,7 @@ exact and ideal answers.
 
 Differences with BioASQ-training8b.json
 - 499 new questions added from BioASQ8
-    - The question with id 5e30e689fbd6abf43b00003a had identical body with 
+    - The question with id 5e30e689fbd6abf43b00003a had identical body with
     5880e417713cbdfd3d000001. All relevant elements from both questions
     are available in the merged question with id 5880e417713cbdfd3d000001.
 
@@ -235,7 +235,7 @@ Differences with BioASQ-trainingDataset5b.json
 - 500 new questions added from BioASQ5
     - 48 pairs of questions with identical bodies have been merged into one
     question having only one question-id, but all the documents, snippets,
-    concepts, RDF triples and answers of both questions of the pair. 
+    concepts, RDF triples and answers of both questions of the pair.
         - This normalization lead to the removal of 48 deprecated question
         ids [2] from the dataset and to the update of the 48 remaining
         questions [3].
@@ -250,7 +250,7 @@ Differences with BioASQ-trainingDataset5b.json
         530b01a6970c65fa6b000008, 530cf54dab4de4de0c000009,
         531b2fc3b166e2b80600003c, 532819afd6d3ac6a3400000f,
         532aad53d6d3ac6a34000010, 5710ade4cf1c32585100002c,
-        52f65f372059c6d71c000027 
+        52f65f372059c6d71c000027
 		- In 6 questions the ideal answer has been revised :
         532aad53d6d3ac6a34000010, 5710ade4cf1c32585100002c,
         53147b52e3eabad021000015, 5147c8a6d24251bc05000027,
@@ -275,7 +275,7 @@ Differences with BioASQ-trainingDataset5b.json
     list of lists. Each internal list represents one element of the answer
     as a set of synonyms
     (i.e. [[`ans1`, `syn11`, `syn12`], [`ans2`], [`ans3`, `syn31`] ...]).
-    - Empty elements, e.g. empty lists of documents have been removed. 
+    - Empty elements, e.g. empty lists of documents have been removed.
 
 [1] 2251 questions : 619 factoid, 616 yesno, 531 summary, 485 list
 [2] The 48 deprecated question ids are : 52f8b2902059c6d71c000053,
@@ -295,8 +295,8 @@ Differences with BioASQ-trainingDataset5b.json
     52ffbddf2059c6d71c00007d, 56bc932aac7ad1001900001c, 56c02883ef6e394741000017,
     52d2b75403868f1b06000035, 52f118aa2059c6d71c000003, 52e929eb98d0239505000023,
     532c12f2d6d3ac6a3400001d, 52d8466298d0239505000006'
-[3] The 48 questions resulting from merging with their pair have the 
-    following ids: 5149aafcd24251bc05000045, 515db020298dcd4e51000011, 
+[3] The 48 questions resulting from merging with their pair have the
+    following ids: 5149aafcd24251bc05000045, 515db020298dcd4e51000011,
     515db54c298dcd4e51000016, 51680a49298dcd4e51000062, 52b06a68f828ad283c000005,
     52bf1aa503868f1b06000006, 52bf1af803868f1b06000008, 52bf1d6003868f1b0600000e,
     52cb9b9b03868f1b0600002d, 52d2818403868f1b06000033, 52df887498d023950500000c,
@@ -498,9 +498,10 @@ class BioasqDataset(datasets.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
         """Returns SplitGenerators."""
-        train_dir, test_dir = dl_manager.download_and_extract(
-            _URLs[self.config.subset_id]
-        )
+        train_dir, test_dir = dl_manager.download_and_extract([
+            os.path.join(self.config.data_dir, _url)
+            for _url in _URLs[self.config.subset_id]
+        ])
         gold_fpath = self._dump_gold_json(test_dir)
 
         # older versions of bioasq have different folder formats
@@ -600,4 +601,3 @@ class BioasqDataset(datasets.GeneratorBasedBuilder):
                             "answer": self._get_exact_answer(record),
                         }
                         uid += 1
-

--- a/tests/test_bigbio.py
+++ b/tests/test_bigbio.py
@@ -91,21 +91,22 @@ class TestDataLoader(unittest.TestCase):
     def runTest(self):
         """
          Run all tests that check:
-         (1) test_name: Checks if dataloading script has correct path format
+         (1) [removed - full path to script is now passed in] test_name: Checks if
+             dataloading script has correct path format
          (2) setUp: Checks data and _SUPPORTED_TASKS can be loaded
          (3) print_statistics: Counts number of all possible schema keys/instances of the examples
          (4) test_schema: confirms big-bio keys present
          (5) test_are_ids_globally_unique: Checks if all examples have a unique identifier
 
          # KB-Specific tests
-         (6) test_do_all_referenced_ids_exist: Check if any sub-key (ex: entities/events etc.) have referenced keys
+         (6) test_do_all_referenced_ids_exist: Check if any sub-key (ex: entities/events etc.)
+             have referenced keys
          (7) test_passages_offsets: Check if text matches offsets in passages
          (8) test_entities_offsets: Check if text matches offsets in entities
          (9) test_events_offsets: Check if text matches offsets in events
         (10) test_coref_ids: Check if text matches offsets in coreferences
 
         """  # noqa
-        self.test_name()
         self.setUp()
         self.test_are_ids_globally_unique()
 
@@ -358,21 +359,6 @@ class TestDataLoader(unittest.TestCase):
                         for entity_id in coref["entity_ids"]:
                             assert entity_id in entity_lookup
 
-    def test_name(self):
-        """
-        Checks if the dataloader script is in the right nested structure.
-        All dataloader scripts must be of the following format:
-
-        biomedical/biomeddatasets/<name_of_dataset>/<name_of_dataloader_script>
-        """  # noqa
-        datafolder = Path("examples")
-        datascript = (datafolder / self.NAME).with_suffix(".py")
-        self.assertTrue(datafolder.exists(), "Folder not named " + self.NAME)
-
-        self.assertTrue(
-            datascript.exists(),
-            "Script not named " + self.NAME + ".py",
-        )
 
     def test_schema(self, task: str):
         """Search supported tasks within a dataset and verify big-bio schema"""
@@ -619,12 +605,22 @@ if __name__ == "__main__":
         choices=list(_VALID_SCHEMA),
         help="specific bigbio schema to test.",
     )
+    parser.add_argument(
+        "--name",
+        default=None,
+        help="use to override a config name"
+    ),
     parser.add_argument("--data_dir", type=str, default=None)
     parser.add_argument("--use_auth_token", default=None)
 
     args = parser.parse_args()
+    logger.info(f"args: {args}")
 
-    name = args.path.split(".py")[0].split("/")[-1]
+    if args.name is None:
+        name = args.path.split(".py")[0].split("/")[-1]
+    else:
+        name = args.name
+
 
     TestDataLoader.PATH = args.path
     TestDataLoader.NAME = name

--- a/tests/test_bigbio.py
+++ b/tests/test_bigbio.py
@@ -580,7 +580,7 @@ if __name__ == "__main__":
         description="Unit tests for BigBio datasets. Args are passed to `datasets.load_dataset`"
     )
 
-    parser.add_argument("--path", type=str, required=True, help="path to dataloader script")
+    parser.add_argument("path", type=str, help="path to dataloader script (e.g. examples/n2c2_2011.py)")
     parser.add_argument(
         "--schema",
         type=str,
@@ -593,7 +593,7 @@ if __name__ == "__main__":
         "--subset_id",
         default=None,
         required=False,
-        help="by default, subset_id will be generated from path and used to create the config name (e.g. path=examples/<subset_id>.py, config_name=<subset_id>_bigbio_<schema>). use this to explicitly set the subset_id (and therefore the config name).",
+        help="by default, subset_id will be generated from path (e.g. if path=examples/n2c2_2011.py then subset_id=n2c2_2011). the config name is then constructed as config_name=<subset_id>_bigbio_<schema>. use this to explicitly set the subset_id for the config name you want to test (e.g. bioasq9b).",
     ),
     parser.add_argument("--data_dir", type=str, default=None)
     parser.add_argument("--use_auth_token", default=None)

--- a/tests/test_bigbio.py
+++ b/tests/test_bigbio.py
@@ -5,7 +5,7 @@ import sys
 import warnings
 
 import datasets
-from datasets import load_dataset, Features
+from datasets import load_dataset, Features, DatasetDict
 from schemas import (
     kb_features,
     qa_features,
@@ -48,7 +48,7 @@ _TASK_TO_SCHEMA = {
 }
 
 _VALID_TASKS = set(_TASK_TO_SCHEMA.keys())
-_VALID_SCHEMA = set(_TASK_TO_SCHEMA.values())
+_VALID_SCHEMAS = set(_TASK_TO_SCHEMA.values())
 
 _SCHEMA_TO_FEAUTURES = {
     "KB": kb_features,
@@ -84,7 +84,7 @@ class TestDataLoader(unittest.TestCase):
     """
 
     PATH: str
-    NAME: str
+    SUBSET_ID: str
     DATA_DIR: Optional[str]
     USE_AUTH_TOKEN: Optional[Union[bool, str]]
 
@@ -108,27 +108,35 @@ class TestDataLoader(unittest.TestCase):
 
         """  # noqa
         self.setUp()
-        self.test_are_ids_globally_unique()
 
-        # KB-specific unit-tests
-        for task in self._SUPPORTED_TASKS:
-            self.test_schema(task)
+        # check the schemas implied by _SUPPORTED_TASKS
+        if self.SCHEMA is None:
+            schemas_to_check = self._MAPPED_SCHEMAS
+        # check the schema forced in unit test args
+        else:
+            schemas_to_check = [self.SCHEMA]
 
-            mapped_features = _SCHEMA_TO_FEAUTURES[_TASK_TO_SCHEMA[task]]
-            self.print_statistics(mapped_features)
+        for schema in schemas_to_check:
 
-            if _TASK_TO_SCHEMA[task] == "KB":
-                self.test_do_all_referenced_ids_exist()
-                self.test_passages_offsets()
-                self.test_entities_offsets()
-                self.test_events_offsets()
-                self.test_coref_ids()
+            dataset_bigbio = self.datasets_bigbio[schema]
+            self.test_are_ids_globally_unique(dataset_bigbio)
+            self.test_schema(schema)
+
+            mapped_features = _SCHEMA_TO_FEAUTURES[schema]
+            self.print_statistics(mapped_features, schema)
+
+            if schema == "KB":
+                self.test_do_all_referenced_ids_exist(dataset_bigbio)
+                self.test_passages_offsets(dataset_bigbio)
+                self.test_entities_offsets(dataset_bigbio)
+                self.test_events_offsets(dataset_bigbio)
+                self.test_coref_ids(dataset_bigbio)
 
     def setUp(self) -> None:
         """Load original and big-bio schema views"""
 
         logger.info(f"self.PATH: {self.PATH}")
-        logger.info(f"self.NAME: {self.NAME}")
+        logger.info(f"self.SUBSET_ID: {self.SUBSET_ID}")
         logger.info(f"self.SCHEMA: {self.SCHEMA}")
         logger.info(f"self.DATA_DIR: {self.DATA_DIR}")
 
@@ -140,12 +148,14 @@ class TestDataLoader(unittest.TestCase):
         module = module.replace("/", ".")
         self._SUPPORTED_TASKS = importlib.import_module(module)._SUPPORTED_TASKS
         logger.info(f"Found _SUPPORTED_TASKS={self._SUPPORTED_TASKS}")
-
         invalid_tasks = set(self._SUPPORTED_TASKS) - _VALID_TASKS
         if len(invalid_tasks) > 0:
             raise ValueError(f"Found invalid supported tasks {invalid_tasks}. Must be one of {_VALID_TASKS}")
 
-        config_name = f"{self.NAME}_source"
+        self._MAPPED_SCHEMAS = set([_TASK_TO_SCHEMA[task] for task in self._SUPPORTED_TASKS])
+        logger.info(f"_SUPPORTED_TASKS implies _MAPPED_SCHEMAS={self._MAPPED_SCHEMAS}")
+
+        config_name = f"{self.SUBSET_ID}_source"
         logger.info(f"Checking load_dataset with config name {config_name}")
         self.dataset_source = datasets.load_dataset(
             self.PATH,
@@ -154,16 +164,18 @@ class TestDataLoader(unittest.TestCase):
             use_auth_token=self.USE_AUTH_TOKEN,
         )
 
-        config_name = f"{self.NAME}_bigbio_{self.SCHEMA.lower()}"
-        logger.info(f"Checking load_dataset with config name {config_name}")
-        self.dataset_bigbio = datasets.load_dataset(
-            self.PATH,
-            name=config_name,
-            data_dir=self.DATA_DIR,
-            use_auth_token=self.USE_AUTH_TOKEN,
-        )
+        self.datasets_bigbio = {}
+        for schema in self._MAPPED_SCHEMAS:
+            config_name = f"{self.SUBSET_ID}_bigbio_{schema.lower()}"
+            logger.info(f"Checking load_dataset with config name {config_name}")
+            self.datasets_bigbio[schema] = datasets.load_dataset(
+                self.PATH,
+                name=config_name,
+                data_dir=self.DATA_DIR,
+                use_auth_token=self.USE_AUTH_TOKEN,
+            )
 
-    def print_statistics(self, schema: Features):
+    def print_statistics(self, features: Features, schema: str):
         """
         Gets sample statistics, for each split and sample of the number of
         features in the schema present; only works for the big-bio schema.
@@ -171,299 +183,23 @@ class TestDataLoader(unittest.TestCase):
         :param schema_type: Type of schema to reference features from
         """  # noqa
         logger.info("Gathering schema statistics")
-        for split_name, split in self.dataset_bigbio.items():
+        for split_name, split in self.datasets_bigbio[schema].items():
             print(split_name)
             print("=" * 10)
 
             counter = defaultdict(int)
             for example in split:
-                for feature_name, feature in schema.items():
+                for feature_name, feature in features.items():
                     if example.get(feature_name, None) is not None:
                         if isinstance(feature, datasets.Value):
                             if example[feature_name]:
                                 counter[feature_name] += 1
                         else:
-                            counter[feature_name] += len(
-                                example[feature_name]
-                            )
+                            counter[feature_name] += len(example[feature_name])
 
             for k, v in counter.items():
                 print(f"{k}: {v}")
             print()
-
-    def test_are_ids_globally_unique(self):
-        """
-        Tests each example in a split has a unique ID.
-        """
-        logger.info("Checking global ID uniqueness")
-        for split in self.dataset_bigbio.values():
-            ids_seen = set()
-            for example in split:
-                self._assert_ids_globally_unique(example, ids_seen=ids_seen)
-
-    def test_do_all_referenced_ids_exist(self):
-        """
-        Checks if referenced IDs are correctly labeled.
-        """
-        logger.info("Checking if referenced IDs are properly mapped")
-        for split in self.dataset_bigbio.values():
-            for example in split:
-                referenced_ids = set()
-                existing_ids = set()
-
-                referenced_ids.update(self._get_referenced_ids(example))
-                existing_ids.update(
-                    self._get_existing_referable_ids(example)
-                )
-
-                for ref_id, ref_type in referenced_ids:
-                    if ref_type == "event_arg":
-                        if not (
-                            (ref_id, "entity") in existing_ids
-                            or (ref_id, "event") in existing_ids
-                        ):
-                            logger.warning(f"Referenced element ({ref_id}, entity/event) could not be found in existing ids {existing_ids}. Please make sure that this is not because of a bug in your data loader.")
-                    else:
-                        logger.warning(f"Referenced element {(ref_id, ref_type)} could not be found in existing ids {existing_ids}. Please make sure that this is not because of a bug in your data loader.")
-
-    def test_passages_offsets(self):
-        """
-        Verify that the passages offsets are correct,
-        i.e.: passage text == text extracted via the passage offsets
-        """  # noqa
-        logger.info("KB ONLY: Checking passage offsets")
-        for split in self.dataset_bigbio:
-
-            if "passages" in self.dataset_bigbio[split].features:
-
-                for example in self.dataset_bigbio[split]:
-
-                    example_text = _get_example_text(example)
-
-                    for passage in example["passages"]:
-
-                        text = passage["text"]
-                        offsets = passage["offsets"]
-
-                        self._test_is_list(
-                            msg="Text in passages must be a list", field=text
-                        )
-
-                        self._test_is_list(
-                            msg="Offsets in passages must be a list",
-                            field=offsets,
-                        )
-
-                        self._test_has_only_one_item(
-                            msg="Offsets in passages must have only one element",
-                            field=offsets,
-                        )
-
-                        self._test_has_only_one_item(
-                            msg="Text in passages must have only one element",
-                            field=text,
-                        )
-
-                        for idx, (start, end) in enumerate(offsets):
-                            msg = f" text:`{example_text[start:end]}` != text_by_offset:`{text[idx]}`"
-                            self.assertEqual(
-                                example_text[start:end], text[idx], msg
-                            )
-
-    def test_entities_offsets(self):
-        """
-        Verify that the entities offsets are correct,
-        i.e.: entity text == text extracted via the entity offsets
-        """  # noqa
-        logger.info("KB ONLY: Checking entity offsets")
-        errors = []
-
-        for split in self.dataset_bigbio:
-
-            if "entities" in self.dataset_bigbio[split].features:
-
-                for example in self.dataset_bigbio[split]:
-
-                    example_id = example["id"]
-                    example_text = _get_example_text(example)
-
-                    for entity in example["entities"]:
-
-                        for msg in self._check_offsets(
-                            example_text=example_text,
-                            offsets=entity["offsets"],
-                            texts=entity["text"],
-                        ):
-
-                            entity_id = entity["id"]
-                            errors.append(
-                                f"Example:{example_id} - entity:{entity_id} "
-                                + msg
-                            )
-
-        if len(errors) > 0:
-            logger.warning(msg="\n".join(errors) + OFFSET_ERROR_MSG)
-
-    # UNTESTED: no dataset example
-    def test_events_offsets(self):
-        """
-        Verify that the events' trigger offsets are correct,
-        i.e.: trigger text == text extracted via the trigger offsets
-        """
-        logger.info("KB ONLY: Checking event offsets")
-        errors = []
-
-        for split in self.dataset_bigbio:
-
-            if "events" in self.dataset_bigbio[split].features:
-
-                for example in self.dataset_bigbio[split]:
-
-                    example_id = example["id"]
-                    example_text = _get_example_text(example)
-
-                    for event in example["events"]:
-
-                        for msg in self._check_offsets(
-                            example_text=example_text,
-                            offsets=event["trigger"]["offsets"],
-                            texts=event["trigger"]["text"],
-                        ):
-
-                            event_id = event["id"]
-                            errors.append(
-                                f"Example:{example_id} - event:{event_id} "
-                                + msg
-                            )
-
-        logger.warning(msg="\n".join(errors) + OFFSET_ERROR_MSG)
-
-    def test_coref_ids(self):
-        """
-        Verify that coreferences ids are entities
-
-        from `examples/test_n2c2_2011_coref.py`
-        """  # noqa
-        logger.info("KB ONLY: Checking coref offsets")
-        for split in self.dataset_bigbio:
-
-            if "coreferences" in self.dataset_bigbio[split].features:
-
-                for example in self.dataset_bigbio[split]:
-                    entity_lookup = {
-                        ent["id"]: ent for ent in example["entities"]
-                    }
-
-                    # check all coref entity ids are in entity lookup
-                    for coref in example["coreferences"]:
-                        for entity_id in coref["entity_ids"]:
-                            assert entity_id in entity_lookup
-
-
-    def test_schema(self, task: str):
-        """Search supported tasks within a dataset and verify big-bio schema"""
-
-        mapped_schema = _TASK_TO_SCHEMA[task]
-        logger.info(f"task={task}, mapped_schema={mapped_schema}")
-
-        if mapped_schema == "KB":
-
-            features = kb_features
-            logger.info(f"all feature names: {set(features.keys())}")
-
-            # construct task specific required keys
-            opt_keys = [
-                "entities",
-                "events",
-                "coreferences",
-                "relations",
-            ]
-
-            needed_keys = [key for key in features.keys() if key not in opt_keys]
-
-            if task == "NER":
-                sub_keys = ["entities"]
-            elif task == "RE":
-                sub_keys = ["entities", "relations"]
-            elif task == "NED":
-                sub_keys = ["entities"]
-            elif task == "COREF":
-                sub_keys = ["entities", "coreferences"]
-            elif task == "EE":
-                sub_keys = ["events"]
-            else:
-                raise ValueError(f"Task {task} not recognized")
-
-
-            logger.info(f"needed_keys: {needed_keys}")
-            logger.info(f"sub_keys: {sub_keys}")
-
-
-            for split in self.dataset_bigbio.keys():
-                example = self.dataset_bigbio[split][0]
-
-                # Check for mandatory keys
-                missing_keys = set(needed_keys) - set(example.keys())
-                self.assertTrue(
-                    len(missing_keys) == 0,
-                    f"{missing_keys} are missing from bigbio view",
-                )
-
-                for key in sub_keys:
-                    for attrs in features[key]:
-                        self.assertTrue(self._check_subkey(example[key][0], attrs))
-
-                # miscellaneous keys not affiliated with a type (ex: NER dataset with events)
-                extra_keys = set(example.keys()) - set(needed_keys) - set(sub_keys)
-                logger.info(f"extra_keys in {split}: {extra_keys}")
-                for key in extra_keys:
-                    if key in features.keys():
-                        for attrs in features[key]:
-                            self.assertTrue(self._check_subkey(example[key][0], attrs))
-
-        elif mapped_schema == "QA":
-            logger.info("Question-Answering Schema")
-            self._check_keys(_SCHEMA_TO_FEAUTURES[mapped_schema], mapped_schema)
-
-        elif mapped_schema == "TE":
-            logger.info("Textual Entailment Schema")
-            self._check_keys(_SCHEMA_TO_FEAUTURES[mapped_schema], mapped_schema)
-
-        elif mapped_schema == "T2T":
-            logger.info("Text to Text Schema")
-            self._check_keys(_SCHEMA_TO_FEAUTURES[mapped_schema], mapped_schema)
-
-        elif mapped_schema == "TEXT":
-            logger.info("Text Schema")
-            self._check_keys(_SCHEMA_TO_FEAUTURES[mapped_schema], mapped_schema)
-
-        elif mapped_schema == "PAIRS":
-            logger.info("Text Pair Schema")
-            self._check_keys(_SCHEMA_TO_FEAUTURES[mapped_schema], mapped_schema)
-
-        else:
-            raise ValueError(
-                f"{mapped_schema} not recognized. must be one of {set(_TASK_TO_SCHEMA.values())}"
-            )
-
-    @staticmethod
-    def _check_subkey(inp, attrs):
-        """Checks if subkeys (esp. in KB) have necessary criteria"""
-        return all([k in inp for k in attrs.keys()])
-
-    def _check_keys(self, schema: Features, schema_name: str):
-        """Check if necessary keys are present in a given schema"""
-        for split in self.dataset_bigbio.keys():
-            example = self.dataset_bigbio[split][0]
-
-            # Check for mandatory keys
-            mandatory_keys = all([key in example for key in schema.keys()])
-            self.assertTrue(
-                mandatory_keys,
-                "/".join(schema.keys())
-                + " keys missing from bigbio view for schema_type = "
-                + schema_name,
-            )
 
     def _assert_ids_globally_unique(
         self,
@@ -498,13 +234,24 @@ class TestDataLoader(unittest.TestCase):
             for elem in collection:
                 self._assert_ids_globally_unique(elem, ids_seen)
 
+    def test_are_ids_globally_unique(self, dataset_bigbio: DatasetDict):
+        """
+        Tests each example in a split has a unique ID.
+        """
+        logger.info("Checking global ID uniqueness")
+        for split in dataset_bigbio.values():
+            ids_seen = set()
+            for example in split:
+                self._assert_ids_globally_unique(example, ids_seen=ids_seen)
+        logger.info("Found {} unique IDs".format(len(ids_seen)))
+
     def _get_referenced_ids(self, example):
         referenced_ids = []
 
         if example.get("events", None) is not None:
             for event in example["events"]:
                 for argument in event["arguments"]:
-                    referenced_ids.append((argument["ref_id"], "event_arg"))
+                    referenced_ids.append((argument["ref_id"], "event"))
 
         if example.get("coreferences", None) is not None:
             for coreference in example["coreferences"]:
@@ -530,19 +277,64 @@ class TestDataLoader(unittest.TestCase):
 
         return existing_ids
 
-    def _test_is_list(self, msg: str, field: list):
-        with self.subTest(
-            msg,
-            field=field,
-        ):
-            self.assertIsInstance(field, list)
+    def test_do_all_referenced_ids_exist(self, dataset_bigbio: DatasetDict):
+        """
+        Checks if referenced IDs are correctly labeled.
+        """
+        logger.info("Checking if referenced IDs are properly mapped")
+        for split in dataset_bigbio.values():
+            for example in split:
+                referenced_ids = set()
+                existing_ids = set()
 
-    def _test_has_only_one_item(self, msg: str, field: list):
-        with self.subTest(
-            msg,
-            field=field,
-        ):
-            self.assertEqual(len(field), 1)
+                referenced_ids.update(self._get_referenced_ids(example))
+                existing_ids.update(self._get_existing_referable_ids(example))
+
+                for ref_id, ref_type in referenced_ids:
+                    if not (ref_id, ref_type) in existing_ids:
+                        logger.warning(
+                            f"Referenced element {(ref_id, ref_type)} could not be found in existing ids {existing_ids}. Please make sure that this is not because of a bug in your data loader."
+                        )
+
+    def test_passages_offsets(self, dataset_bigbio: DatasetDict):
+        """
+        Verify that the passages offsets are correct,
+        i.e.: passage text == text extracted via the passage offsets
+        """  # noqa
+        logger.info("KB ONLY: Checking passage offsets")
+        for split in dataset_bigbio:
+
+            if "passages" in dataset_bigbio[split].features:
+
+                for example in dataset_bigbio[split]:
+
+                    example_text = _get_example_text(example)
+
+                    for passage in example["passages"]:
+
+                        text = passage["text"]
+                        offsets = passage["offsets"]
+
+                        self._test_is_list(msg="Text in passages must be a list", field=text)
+
+                        self._test_is_list(
+                            msg="Offsets in passages must be a list",
+                            field=offsets,
+                        )
+
+                        self._test_has_only_one_item(
+                            msg="Offsets in passages must have only one element",
+                            field=offsets,
+                        )
+
+                        self._test_has_only_one_item(
+                            msg="Text in passages must have only one element",
+                            field=text,
+                        )
+
+                        for idx, (start, end) in enumerate(offsets):
+                            msg = f" text:`{example_text[start:end]}` != text_by_offset:`{text[idx]}`"
+                            self.assertEqual(example_text[start:end], text[idx], msg)
 
     def _check_offsets(
         self,
@@ -559,7 +351,9 @@ class TestDataLoader(unittest.TestCase):
         """  # noqa
 
         if len(texts) != len(offsets):
-            logger.warning(f"Number of texts {len(texts)} != number of offsets {len(offsets)}. Please make sure that this error already exists in the original data and was not introduced in the data loader.")
+            logger.warning(
+                f"Number of texts {len(texts)} != number of offsets {len(offsets)}. Please make sure that this error already exists in the original data and was not introduced in the data loader."
+            )
 
         self._test_is_list(
             msg="Text fields paired with offsets must be in the form [`text`, ...]",
@@ -584,6 +378,200 @@ class TestDataLoader(unittest.TestCase):
             if by_offset_text != text:
                 yield f" text:`{text}` != text_by_offset:`{by_offset_text}`"
 
+    def test_entities_offsets(self, dataset_bigbio: DatasetDict):
+        """
+        Verify that the entities offsets are correct,
+        i.e.: entity text == text extracted via the entity offsets
+        """  # noqa
+        logger.info("KB ONLY: Checking entity offsets")
+        errors = []
+
+        for split in dataset_bigbio:
+
+            if "entities" in dataset_bigbio[split].features:
+
+                for example in dataset_bigbio[split]:
+
+                    example_id = example["id"]
+                    example_text = _get_example_text(example)
+
+                    for entity in example["entities"]:
+
+                        for msg in self._check_offsets(
+                            example_text=example_text,
+                            offsets=entity["offsets"],
+                            texts=entity["text"],
+                        ):
+
+                            entity_id = entity["id"]
+                            errors.append(f"Example:{example_id} - entity:{entity_id} " + msg)
+
+        if len(errors) > 0:
+            logger.warning(msg="\n".join(errors) + OFFSET_ERROR_MSG)
+
+    # UNTESTED: no dataset example
+    def test_events_offsets(self, dataset_bigbio: DatasetDict):
+        """
+        Verify that the events' trigger offsets are correct,
+        i.e.: trigger text == text extracted via the trigger offsets
+        """
+        logger.info("KB ONLY: Checking event offsets")
+        errors = []
+
+        for split in dataset_bigbio:
+
+            if "events" in dataset_bigbio[split].features:
+
+                for example in dataset_bigbio[split]:
+
+                    example_id = example["id"]
+                    example_text = _get_example_text(example)
+
+                    for event in example["events"]:
+
+                        for msg in self._check_offsets(
+                            example_text=example_text,
+                            offsets=event["trigger"]["offsets"],
+                            texts=event["trigger"]["text"],
+                        ):
+
+                            event_id = event["id"]
+                            errors.append(f"Example:{example_id} - event:{event_id} " + msg)
+
+        if len(errors) > 0:
+            logger.warning(msg="\n".join(errors) + OFFSET_ERROR_MSG)
+
+    def test_coref_ids(self, dataset_bigbio: DatasetDict):
+        """
+        Verify that coreferences ids are entities
+
+        from `examples/test_n2c2_2011_coref.py`
+        """  # noqa
+        logger.info("KB ONLY: Checking coref offsets")
+        for split in dataset_bigbio:
+
+            if "coreferences" in dataset_bigbio[split].features:
+
+                for example in dataset_bigbio[split]:
+                    entity_lookup = {ent["id"]: ent for ent in example["entities"]}
+
+                    # check all coref entity ids are in entity lookup
+                    for coref in example["coreferences"]:
+                        for entity_id in coref["entity_ids"]:
+                            assert entity_id in entity_lookup
+
+    def test_schema(self, schema: str):
+        """Search supported tasks within a dataset and verify big-bio schema"""
+
+        if schema == "KB":
+
+            features = kb_features
+            logger.info(f"all feature names: {set(features.keys())}")
+
+            # construct task specific required keys
+            opt_keys = [
+                "entities",
+                "events",
+                "coreferences",
+                "relations",
+            ]
+
+            needed_keys = [key for key in features.keys() if key not in opt_keys]
+
+            sub_keys = []
+            if "NER" in self._SUPPORTED_TASKS:
+                sub_keys += ["entities"]
+            elif "RE" in self._SUPPORTED_TASKS:
+                sub_keys += ["entities", "relations"]
+            elif "NED" in self._SUPPORTED_TASKS:
+                sub_keys = ["entities"]
+            elif "COREF" in self._SUPPORTED_TASKS:
+                sub_keys = ["entities", "coreferences"]
+            elif "EE" in self._SUPPORTED_TASKS:
+                sub_keys = ["events"]
+            else:
+                raise ValueError(f"Task {task} not recognized")
+
+            logger.info(f"needed_keys: {needed_keys}")
+            logger.info(f"sub_keys: {sub_keys}")
+
+            for split in self.datasets_bigbio[schema].keys():
+                example = self.datasets_bigbio[schema][split][0]
+
+                # Check for mandatory keys
+                missing_keys = set(needed_keys) - set(example.keys())
+                self.assertTrue(
+                    len(missing_keys) == 0,
+                    f"{missing_keys} are missing from bigbio view",
+                )
+
+                for key in sub_keys:
+                    for attrs in features[key]:
+                        self.assertTrue(self._check_subkey(example[key][0], attrs))
+
+                # miscellaneous keys not affiliated with a type (ex: NER dataset with events)
+                extra_keys = set(example.keys()) - set(needed_keys) - set(sub_keys)
+                logger.info(f"extra_keys in {split}: {extra_keys}")
+                for key in extra_keys:
+                    if key in features.keys():
+                        for attrs in features[key]:
+                            self.assertTrue(self._check_subkey(example[key][0], attrs))
+
+        elif schema == "QA":
+            logger.info("Question-Answering Schema")
+            self._check_keys(_SCHEMA_TO_FEAUTURES[schema], schema)
+
+        elif schema == "TE":
+            logger.info("Textual Entailment Schema")
+            self._check_keys(_SCHEMA_TO_FEAUTURES[schema], schema)
+
+        elif schema == "T2T":
+            logger.info("Text to Text Schema")
+            self._check_keys(_SCHEMA_TO_FEAUTURES[schema], schema)
+
+        elif schema == "TEXT":
+            logger.info("Text Schema")
+            self._check_keys(_SCHEMA_TO_FEAUTURES[schema], schema)
+
+        elif schema == "PAIRS":
+            logger.info("Text Pair Schema")
+            self._check_keys(_SCHEMA_TO_FEAUTURES[schema], schema)
+
+        else:
+            raise ValueError(f"{schema} not recognized. must be one of {set(_TASK_TO_SCHEMA.values())}")
+
+    @staticmethod
+    def _check_subkey(inp, attrs):
+        """Checks if subkeys (esp. in KB) have necessary criteria"""
+        return all([k in inp for k in attrs.keys()])
+
+    def _check_keys(self, features: Features, schema_name: str):
+        """Check if necessary keys are present in a given schema"""
+        dataset_bigbio = self.datasets_bigbio[schema_name]
+        for split in dataset_bigbio.keys():
+            example = dataset_bigbio[split][0]
+
+            # Check for mandatory keys
+            mandatory_keys = all([key in example for key in features.keys()])
+            self.assertTrue(
+                mandatory_keys,
+                "/".join(features.keys()) + " keys missing from bigbio view for schema_type = " + schema_name,
+            )
+
+    def _test_is_list(self, msg: str, field: list):
+        with self.subTest(
+            msg,
+            field=field,
+        ):
+            self.assertIsInstance(field, list)
+
+    def _test_has_only_one_item(self, msg: str, field: list):
+        with self.subTest(
+            msg,
+            field=field,
+        ):
+            self.assertEqual(len(field), 1)
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
@@ -592,23 +580,20 @@ if __name__ == "__main__":
         description="Unit tests for BigBio datasets. Args are passed to `datasets.load_dataset`"
     )
 
-    parser.add_argument(
-        "--path",
-        type=str,
-        required=True,
-        help="path to dataloader script"
-    )
+    parser.add_argument("--path", type=str, required=True, help="path to dataloader script")
     parser.add_argument(
         "--schema",
         type=str,
-        required=True,
-        choices=list(_VALID_SCHEMA),
-        help="specific bigbio schema to test.",
+        default=None,
+        required=False,
+        choices=list(_VALID_SCHEMAS),
+        help="by default, bigbio schemas will be discovered from _SUPPORTED_TASKS. use this to explicitly test only one schema.",
     )
     parser.add_argument(
-        "--name",
+        "--subset_id",
         default=None,
-        help="use to override a config name"
+        required=False,
+        help="by default, subset_id will be generated from path and used to create the config name (e.g. path=examples/<subset_id>.py, config_name=<subset_id>_bigbio_<schema>). use this to explicitly set the subset_id (and therefore the config name).",
     ),
     parser.add_argument("--data_dir", type=str, default=None)
     parser.add_argument("--use_auth_token", default=None)
@@ -616,14 +601,13 @@ if __name__ == "__main__":
     args = parser.parse_args()
     logger.info(f"args: {args}")
 
-    if args.name is None:
-        name = args.path.split(".py")[0].split("/")[-1]
+    if args.subset_id is None:
+        subset_id = args.path.split(".py")[0].split("/")[-1]
     else:
-        name = args.name
-
+        subset_id = args.subset_id
 
     TestDataLoader.PATH = args.path
-    TestDataLoader.NAME = name
+    TestDataLoader.SUBSET_ID = subset_id
     TestDataLoader.SCHEMA = args.schema
     TestDataLoader.DATA_DIR = args.data_dir
     TestDataLoader.USE_AUTH_TOKEN = args.use_auth_token


### PR DESCRIPTION
* black formatting 
* made it so that bioasq uses a passed in `data_dir` argument
* bigbio schema is now discovered from `_SUPPORTED_TASKS` and so does not need to be passed as an arg to unit tests (although you can if you want to explicitly force testing one schema)
* if a dataset supports multiple bigbio schemas (via supporting tasks that map to multiple schemas) all of those schemas will be tested by default.
* subset_id can now be passed in as an arg to handle things like bioasq. 
* fixed some bugs with the logging for entities offsets 
* checked that this works for 
  * n2c2_2011
  * bioasq
  * scitail
  * bc5cdr