### PR TITLE
only run on schemas specified with --schema

### DIFF
--- a/tests/test_bigbio.py
+++ b/tests/test_bigbio.py
@@ -100,16 +100,8 @@ class TestDataLoader(unittest.TestCase):
         (10) test_coref_ids: Check if text matches offsets in coreferences
 
         """  # noqa
-        self.setUp()
 
-        # check the schemas implied by _SUPPORTED_TASKS
-        if self.SCHEMA is None:
-            schemas_to_check = self._MAPPED_SCHEMAS
-        # check the schema forced in unit test args
-        else:
-            schemas_to_check = [self.SCHEMA]
-
-        for schema in schemas_to_check:
+        for schema in self.schemas_to_check:
 
             dataset_bigbio = self.datasets_bigbio[schema]
             self.test_are_ids_globally_unique(dataset_bigbio)
@@ -147,6 +139,14 @@ class TestDataLoader(unittest.TestCase):
 
         self._MAPPED_SCHEMAS = set([_TASK_TO_SCHEMA[task] for task in self._SUPPORTED_TASKS])
         logger.info(f"_SUPPORTED_TASKS implies _MAPPED_SCHEMAS={self._MAPPED_SCHEMAS}")
+
+        # check the schemas implied by _SUPPORTED_TASKS
+        if self.SCHEMA is None:
+            self.schemas_to_check = self._MAPPED_SCHEMAS
+        # check the schema forced in unit test args
+        else:
+            self.schemas_to_check = [self.SCHEMA]
+        logger.info(f"schemas_to_check: {self.schemas_to_check}")
 
         config_name = f"{self.SUBSET_ID}_source"
         logger.info(f"Checking load_dataset with config name {config_name}")


### PR DESCRIPTION
* `self.setUp` is called automatically so don't call in `runTest`
* calculate `schemas_to_check` in setup and only read those schemas