### PR TITLE
Tests: iterate over specified --schema in setUp

### DIFF
--- a/tests/test_bigbio.py
+++ b/tests/test_bigbio.py
@@ -158,7 +158,7 @@ class TestDataLoader(unittest.TestCase):
         )
 
         self.datasets_bigbio = {}
-        for schema in self._MAPPED_SCHEMAS:
+        for schema in self.schemas_to_check:
             config_name = f"{self.SUBSET_ID}_bigbio_{schema.lower()}"
             logger.info(f"Checking load_dataset with config name {config_name}")
             self.datasets_bigbio[schema] = datasets.load_dataset(


### PR DESCRIPTION
In #330, some changes were introduced to fix the functionality of `--schema`. However, running that version in #319 still returns the same errors specified in that discussion. 

This can be fixed by replacing `self._MAPPED_SCHEMAS` by `self.schemas_to_check` during BigBio dataset loading 

https://github.com/bigscience-workshop/biomedical/blob/02f02176a8773d7a13d81d443ba7101219669e2d/tests/test_bigbio.py#L161