### PR TITLE
allow multilabel text classification

### DIFF
--- a/biodatasets/hallmarks_of_cancer/hallmarks_of_cancer.py
+++ b/biodatasets/hallmarks_of_cancer/hallmarks_of_cancer.py
@@ -29,7 +29,7 @@ _CITATION = """\
                Johan H{\"{o}}gberg and
                Ulla Stenius and
                Anna Korhonen},
-  title     = {Automatic semantic classification of scientific literature 
+  title     = {Automatic semantic classification of scientific literature
                according to the hallmarks of cancer},
   journal   = {Bioinform.},
   volume    = {32},
@@ -45,11 +45,11 @@ _CITATION = """\
 """
 
 _DESCRIPTION = """\
-The Hallmarks of Cancer (HOC) Corpus consists of 1852 PubMed publication 
-abstracts manually annotated by experts according to a taxonomy. The taxonomy 
-consists of 37 classes in a hierarchy. Zero or more class labels are assigned 
-to each sentence in the corpus. The labels are found under the "labels" 
-directory, while the tokenized text can be found under "text" directory. 
+The Hallmarks of Cancer (HOC) Corpus consists of 1852 PubMed publication
+abstracts manually annotated by experts according to a taxonomy. The taxonomy
+consists of 37 classes in a hierarchy. Zero or more class labels are assigned
+to each sentence in the corpus. The labels are found under the "labels"
+directory, while the tokenized text can be found under "text" directory.
 The filenames are the corresponding PubMed IDs (PMID).
 """
 
@@ -175,7 +175,7 @@ class HallmarksOfCancerDataset(datasets.GeneratorBasedBuilder):
                     "id": uid,
                     "document_id": filenname.split(".")[0],
                     "text": text_body,
-                    "label": label_body,
+                    "labels": [label_body],
                 }
 
                 uid += 1

--- a/examples/hallmarks_of_cancer.py
+++ b/examples/hallmarks_of_cancer.py
@@ -29,7 +29,7 @@ _CITATION = """\
                Johan H{\"{o}}gberg and
                Ulla Stenius and
                Anna Korhonen},
-  title     = {Automatic semantic classification of scientific literature 
+  title     = {Automatic semantic classification of scientific literature
                according to the hallmarks of cancer},
   journal   = {Bioinform.},
   volume    = {32},
@@ -45,11 +45,11 @@ _CITATION = """\
 """
 
 _DESCRIPTION = """\
-The Hallmarks of Cancer (HOC) Corpus consists of 1852 PubMed publication 
-abstracts manually annotated by experts according to a taxonomy. The taxonomy 
-consists of 37 classes in a hierarchy. Zero or more class labels are assigned 
-to each sentence in the corpus. The labels are found under the "labels" 
-directory, while the tokenized text can be found under "text" directory. 
+The Hallmarks of Cancer (HOC) Corpus consists of 1852 PubMed publication
+abstracts manually annotated by experts according to a taxonomy. The taxonomy
+consists of 37 classes in a hierarchy. Zero or more class labels are assigned
+to each sentence in the corpus. The labels are found under the "labels"
+directory, while the tokenized text can be found under "text" directory.
 The filenames are the corresponding PubMed IDs (PMID).
 """
 
@@ -175,7 +175,7 @@ class HallmarksOfCancerDataset(datasets.GeneratorBasedBuilder):
                     "id": uid,
                     "document_id": filenname.split(".")[0],
                     "text": text_body,
-                    "label": label_body,
+                    "labels": [label_body],
                 }
 
                 uid += 1

--- a/task_schemas.md
+++ b/task_schemas.md
@@ -229,6 +229,6 @@ Passages capture document structure, such as the title and abstact sections of a
 	"id": "0",
 	"document_id": "NULL",
 	"text": "Am I over weight (192.9) for my age (39)?",
-	"label": "question",
+	"labels": ["question"],
 }
 ```

--- a/utils/schemas/text.py
+++ b/utils/schemas/text.py
@@ -1,5 +1,5 @@
 """
-General Text Schema
+General Text Classification Schema
 """
 import datasets
 
@@ -8,6 +8,6 @@ features = datasets.Features(
         "id": datasets.Value("string"),
         "document_id": datasets.Value("string"),
         "text": datasets.Value("string"),
-        "label": datasets.Value("string"),
+        "labels": [datasets.Value("string")],
     }
 )


### PR DESCRIPTION
Update `label` -> `labels` in the text classification schema and update the hallmarks of cancer dataset. 
