### PR TITLE
add choices to qa schema

### DIFF
--- a/biodatasets/bioasq/bioasq.py
+++ b/biodatasets/bioasq/bioasq.py
@@ -576,6 +576,7 @@ class BioasqDataset(datasets.GeneratorBasedBuilder):
                             "question_id": record["id"],
                             "question": record["body"],
                             "type": record["type"],
+                            "choices": [],
                             "context": snippet["text"],
                             "answer": self._get_exact_answer(record),
                         }

--- a/biodatasets/medhop/medhop.py
+++ b/biodatasets/medhop/medhop.py
@@ -202,7 +202,7 @@ class MedHopDataset(datasets.GeneratorBasedBuilder):
                         "type": record["type"],
                         "context": " ".join(record["supports"]),
                         "answer": [record["answer"]],
-                        # "choices": record["candidates"],
+                        "choices": record["candidates"],
                     }
 
                     uid += 1

--- a/examples/bioasq.py
+++ b/examples/bioasq.py
@@ -576,6 +576,7 @@ class BioasqDataset(datasets.GeneratorBasedBuilder):
                             "question_id": record["id"],
                             "question": record["body"],
                             "type": record["type"],
+                            "choices": [],
                             "context": snippet["text"],
                             "answer": self._get_exact_answer(record),
                         }

--- a/task_schemas.md
+++ b/task_schemas.md
@@ -168,7 +168,7 @@ Passages capture document structure, such as the title and abstact sections of a
 	"question_id": "55031181e9bde69634000014",
 	"question": "Is RANKL secreted from the cells?",
 	"type": "yesno",
-    "choices": [],
+	"choices": [],
 	"context": "Osteoprotegerin (OPG) is a soluble secreted factor that acts as a decoy receptor for receptor activator of NF-\u03baB ligand (RANKL)",
 	"answer": ["yes"],
 }

--- a/task_schemas.md
+++ b/task_schemas.md
@@ -168,6 +168,7 @@ Passages capture document structure, such as the title and abstact sections of a
 	"question_id": "55031181e9bde69634000014",
 	"question": "Is RANKL secreted from the cells?",
 	"type": "yesno",
+    "choices": [],
 	"context": "Osteoprotegerin (OPG) is a soluble secreted factor that acts as a decoy receptor for receptor activator of NF-\u03baB ligand (RANKL)",
 	"answer": ["yes"],
 }

--- a/tests/test_bigbio.py
+++ b/tests/test_bigbio.py
@@ -135,6 +135,11 @@ class TestDataLoader(unittest.TestCase):
                 with self.subTest("Check coref offsets"):
                     self.test_coref_ids(dataset_bigbio)
 
+            elif schema == "QA":
+                with self.subTest("Check multiple choice"):
+                    self.test_multiple_choice(dataset_bigbio)
+
+
     def setUp(self) -> None:
         """Load original and big-bio schema views"""
 
@@ -491,6 +496,32 @@ class TestDataLoader(unittest.TestCase):
                             assert (
                                 entity_id in entity_lookup
                             ), f"Split:{split} - Example:{example_id} - Entity:{entity_id} not found!"
+
+
+    def test_multiple_choice(self, dataset_bigbio: DatasetDict):
+        """
+        Verify that each answer in a multiple choice Q/A task is in choices.
+        """  # noqa
+        logger.info("QA ONLY: Checking multiple choice")
+        for split in dataset_bigbio:
+
+            for example in dataset_bigbio[split]:
+
+                if len(example["choices"]) > 0:
+                    assert(
+                        example["type"] == "multiple_choice"  # can change this to "in" if we include ranking
+                    ), f"example has populated choices, but is not type 'multiple_choice' {example}"
+
+                if example["type"] == "multiple_choice":
+                    assert(
+                        len(example["choices"]) > 0
+                    ), f"example has type 'multiple_choice' but no values in 'choices' {example}"
+
+                    for answer in example["answer"]:
+                        assert(
+                            answer in example["choices"]
+                        ), f"example has an answer that is not present in 'choices' {example}"
+
 
     def test_schema(self, schema: str):
         """Search supported tasks within a dataset and verify big-bio schema"""

--- a/utils/schemas/qa.py
+++ b/utils/schemas/qa.py
@@ -10,6 +10,7 @@ features = datasets.Features(
         "document_id": datasets.Value("string"),
         "question": datasets.Value("string"),
         "type": datasets.Value("string"),
+        "choices": [datasets.Value("string")],
         "context": datasets.Value("string"),
         "answer": datasets.Sequence(datasets.Value("string")),
     }


### PR DESCRIPTION
* adds a new attribute to qa schema called `choices` which is a `List[str]`
* updates medhop to use it
* updates task_schemas.md

[x] TODO: add test to assert that answer is in choices for question type="multiple_choice"
TODO (future PR): make yes/no questions multiple choice? 