### PR TITLE
BRAT: Fix entity names for discontiguous entities

### DIFF
--- a/utils/parsing.py
+++ b/utils/parsing.py
@@ -129,13 +129,26 @@ def parse_brat_file(txt_file: Path, annotation_file_suffixes: List[str] = None) 
             fields = line.split("\t")
 
             ann["id"] = fields[0]
-            ann["text"] = [fields[2]]
             ann["type"] = fields[1].split()[0]
             ann["offsets"] = []
             span_str = remove_prefix(fields[1], (ann["type"] + " "))
+            text = fields[2]
             for span in span_str.split(";"):
                 start, end = span.split()
                 ann["offsets"].append([int(start), int(end)])
+
+            # Heuristically split text of discontiguous entities into chunks
+            ann["text"] = []
+            if len(ann["offsets"]) > 1:
+                i = 0
+                for start, end in ann["offsets"]:
+                    chunk_len = end - start
+                    ann["text"].append(text[i:chunk_len+i])
+                    i += chunk_len
+                    while i < len(text) and text[i] == " ":
+                        i += 1
+            else:
+                ann["text"] = [text]
 
             example["text_bound_annotations"].append(ann)
 


### PR DESCRIPTION
Fixes parsing of BRAT for discontiguous entities

Before, entity.text was always a 1-element list with the full name: 
`['diagnostic monoclonal antibodies'],  'offsets': [[700, 710], [726, 747]`

Now, entity.text is split into chunks corresponding to the offsets:
`['diagnostic', 'monoclonal antibodies'], 'type': 'GROUP', 'offsets': [[700, 710], [726, 747]`

I have verified that this does not break brat parsing for merged datasets as `mlee` and `anat_em`.