### PR TITLE
add helper parsing for BioC annotations: amend existing examples

### DIFF
--- a/biodatasets/chemdner/chemdner.py
+++ b/biodatasets/chemdner/chemdner.py
@@ -22,6 +22,7 @@ import datasets
 from utils import schemas
 from utils.configs import BigBioConfig
 from utils.constants import Tasks
+from utils.parsing import get_texts_and_offsets_from_bioc_ann
 
 _CITATION = """\
 @Article{Krallinger2015,
@@ -106,7 +107,7 @@ abstract={
     the BioC format has been generated as well. We propose a standard for required minimum information about
     entity annotations for the construction of domain specific corpora on chemical and drug entities.
     The CHEMDNER corpus and annotation guidelines are available at:
-    http://www.biocreative.org/resources/biocreative-iv/chemdner-corpus/
+    ttp://www.biocreative.org/resources/biocreative-iv/chemdner-corpus/
 },
 issn={1758-2946},
 doi={10.1186/1758-2946-7-S1-S2},
@@ -171,9 +172,7 @@ class CHEMDNERDataset(datasets.GeneratorBasedBuilder):
         ),
     ]
 
-    DEFAULT_CONFIG_NAME = (
-        "chemdner_source"  # It's not mandatory to have a default configuration. Just use one if it make sense.
-    )
+    DEFAULT_CONFIG_NAME = "chemdner_source"  # It's not mandatory to have a default configuration. Just use one if it make sense.
 
     def _info(self):
 
@@ -231,7 +230,9 @@ class CHEMDNERDataset(datasets.GeneratorBasedBuilder):
                 name=datasets.Split.TRAIN,
                 # These kwargs will be passed to _generate_examples
                 gen_kwargs={
-                    "filepath": os.path.join(data_dir, "BC7T2-CHEMDNER-corpus-training.BioC.xml"),
+                    "filepath": os.path.join(
+                        data_dir, "BC7T2-CHEMDNER-corpus-training.BioC.xml"
+                    ),
                     "split": "train",
                 },
             ),
@@ -239,7 +240,9 @@ class CHEMDNERDataset(datasets.GeneratorBasedBuilder):
                 name=datasets.Split.TEST,
                 # These kwargs will be passed to _generate_examples
                 gen_kwargs={
-                    "filepath": os.path.join(data_dir, "BC7T2-CHEMDNER-corpus-evaluation.BioC.xml"),
+                    "filepath": os.path.join(
+                        data_dir, "BC7T2-CHEMDNER-corpus-evaluation.BioC.xml"
+                    ),
                     "split": "test",
                 },
             ),
@@ -247,13 +250,17 @@ class CHEMDNERDataset(datasets.GeneratorBasedBuilder):
                 name=datasets.Split.VALIDATION,
                 # These kwargs will be passed to _generate_examples
                 gen_kwargs={
-                    "filepath": os.path.join(data_dir, "BC7T2-CHEMDNER-corpus-development.BioC.xml"),
+                    "filepath": os.path.join(
+                        data_dir, "BC7T2-CHEMDNER-corpus-development.BioC.xml"
+                    ),
                     "split": "dev",
                 },
             ),
         ]
 
-    def _get_passages_and_entities(self, d: bioc.BioCDocument) -> Tuple[List[Dict], List[List[Dict]]]:
+    def _get_passages_and_entities(
+        self, d: bioc.BioCDocument
+    ) -> Tuple[List[Dict], List[List[Dict]]]:
 
         passages: List[Dict] = []
         entities: List[List[Dict]] = []
@@ -287,22 +294,23 @@ class CHEMDNERDataset(datasets.GeneratorBasedBuilder):
 
                 a_type = a.infons.get("type")
 
-                if self.config.schema == "bigbio_kb" and a_type == "MeSH_Indexing_Chemical":
+                if (
+                    self.config.schema == "bigbio_kb"
+                    and a_type == "MeSH_Indexing_Chemical"
+                ):
                     continue
 
-                if (a.text == None or a.text == "") and self.config.schema == "bigbio_kb":
+                if (
+                    a.text == None or a.text == ""
+                ) and self.config.schema == "bigbio_kb":
                     continue
+
+                offsets, text = get_texts_and_offsets_from_bioc_ann(a)
 
                 da = {
                     "type": a_type,
-                    "offsets": [
-                        (
-                            loc.offset - eo,
-                            loc.offset + loc.length - eo,
-                        )
-                        for loc in a.locations
-                    ],
-                    "text": (a.text,),
+                    "offsets": [(start - eo, end - eo) for (start, end) in offsets],
+                    "text": text,
                     "id": a.id,
                     "normalized": self._get_normalized(a),
                 }
@@ -328,7 +336,9 @@ class CHEMDNERDataset(datasets.GeneratorBasedBuilder):
 
             normalized = [i.split(":") for i in identifiers]
 
-            normalized = [{"db_name": elems[0], "db_id": elems[1]} for elems in normalized]
+            normalized = [
+                {"db_name": elems[0], "db_id": elems[1]} for elems in normalized
+            ]
 
         else:
 

--- a/examples/bc5cdr.py
+++ b/examples/bc5cdr.py
@@ -27,11 +27,12 @@ import itertools
 import os
 
 import bioc
-
 import datasets
+
 from utils import schemas
 from utils.configs import BigBioConfig
 from utils.constants import Tasks
+from utils.parsing import get_texts_and_offsets_from_bioc_ann
 
 _CITATION = """\
 @article{DBLP:journals/biodb/LiSJSWLDMWL16,
@@ -74,7 +75,11 @@ _URLs = {
     "bigbio_kb": "http://www.biocreative.org/media/store/files/2016/CDR_Data.zip",
 }
 
-_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION, Tasks.RELATION_EXTRACTION]
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.NAMED_ENTITY_DISAMBIGUATION,
+    Tasks.RELATION_EXTRACTION,
+]
 _SOURCE_VERSION = "01.05.16"
 _BIGBIO_VERSION = "1.0.0"
 
@@ -164,7 +169,9 @@ class Bc5cdrDataset(datasets.GeneratorBasedBuilder):
                 name=datasets.Split.TRAIN,
                 # These kwargs will be passed to _generate_examples
                 gen_kwargs={
-                    "filepath": os.path.join(data_dir, "CDR_Data/CDR.Corpus.v010516/CDR_TrainingSet.BioC.xml"),
+                    "filepath": os.path.join(
+                        data_dir, "CDR_Data/CDR.Corpus.v010516/CDR_TrainingSet.BioC.xml"
+                    ),
                     "split": "train",
                 },
             ),
@@ -172,7 +179,9 @@ class Bc5cdrDataset(datasets.GeneratorBasedBuilder):
                 name=datasets.Split.TEST,
                 # These kwargs will be passed to _generate_examples
                 gen_kwargs={
-                    "filepath": os.path.join(data_dir, "CDR_Data/CDR.Corpus.v010516/CDR_TestSet.BioC.xml"),
+                    "filepath": os.path.join(
+                        data_dir, "CDR_Data/CDR.Corpus.v010516/CDR_TestSet.BioC.xml"
+                    ),
                     "split": "test",
                 },
             ),
@@ -206,8 +215,9 @@ class Bc5cdrDataset(datasets.GeneratorBasedBuilder):
         dict
             entity information
         """
-        offsets = [(loc.offset, loc.offset + loc.length) for loc in span.locations]
-        texts = [doc_text[i:j] for i, j in offsets]
+        # offsets = [(loc.offset, loc.offset + loc.length) for loc in span.locations]
+        # texts = [doc_text[i:j] for i, j in offsets]
+        offsets, texts = get_texts_and_offsets_from_bioc_ann(span)
         db_ids = span.infons[db_id_key] if db_id_key else "-1"
         normalized = [
             # some entities are linked to multiple normalized ids
@@ -285,7 +295,10 @@ class Bc5cdrDataset(datasets.GeneratorBasedBuilder):
                             "document_id": xdoc.id,
                             "type": passage.infons["type"],
                             "text": passage.text,
-                            "entities": [self._get_bioc_entity(span, doc_text) for span in passage.annotations],
+                            "entities": [
+                                self._get_bioc_entity(span, doc_text)
+                                for span in passage.annotations
+                            ],
                             "relations": [
                                 {
                                     "id": rel.id,

--- a/examples/nlmchem.py
+++ b/examples/nlmchem.py
@@ -22,7 +22,6 @@ import datasets
 from utils import schemas
 from utils.configs import BigBioConfig
 from utils.constants import Tasks
-from utils.parsing import get_texts_and_offsets_from_bioc_ann
 
 _CITATION = """\
 @Article{islamaj2021nlm,
@@ -53,8 +52,13 @@ _LICENSE = " CC0 1.0 Universal (CC0 1.0) Public Domain Dedication"
 _URLs = {
     "source": "https://ftp.ncbi.nlm.nih.gov/pub/lu/BC7-NLM-Chem-track/BC7T2-NLMChem-corpus_v2.BioC.xml.gz",
     "bigbio_kb": "https://ftp.ncbi.nlm.nih.gov/pub/lu/BC7-NLM-Chem-track/BC7T2-NLMChem-corpus_v2.BioC.xml.gz",
+    "bigbio_text": "https://ftp.ncbi.nlm.nih.gov/pub/lu/BC7-NLM-Chem-track/BC7T2-NLMChem-corpus_v2.BioC.xml.gz",
 }
-_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION]
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.NAMED_ENTITY_DISAMBIGUATION,
+    Tasks.TEXT_CLASSIFICATION,
+]
 _SOURCE_VERSION = "1.0.0"
 _BIGBIO_VERSION = "1.0.0"
 
@@ -76,8 +80,15 @@ class NLMChemDataset(datasets.GeneratorBasedBuilder):
         BigBioConfig(
             name="nlmchem_bigbio_kb",
             version=BIGBIO_VERSION,
-            description="NLM_Chem BigBio schema",
+            description="NLM_Chem BigBio schema (KB)",
             schema="bigbio_kb",
+            subset_id="nlmchem",
+        ),
+        BigBioConfig(
+            name="nlmchem_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="NLM_Chem BigBio schema (TEXT)",
+            schema="bigbio_text",
             subset_id="nlmchem",
         ),
     ]
@@ -117,6 +128,8 @@ class NLMChemDataset(datasets.GeneratorBasedBuilder):
 
         elif self.config.schema == "bigbio_kb":
             features = schemas.kb_features
+        elif self.config.schema == "bigbio_text":
+            features = schemas.text_features
 
         return datasets.DatasetInfo(
             # This is the description that will appear on the datasets page.
@@ -178,6 +191,20 @@ class NLMChemDataset(datasets.GeneratorBasedBuilder):
             ),
         ]
 
+    def _get_textcls_example(self, d: bioc.BioCDocument) -> Dict:
+
+        example = {"document_id": d.id, "text": [], "labels": []}
+
+        for p in d.passages:
+            example["text"].append(p.text)
+            for a in p.annotations:
+                if a.infons.get("type") == "MeSH_Indexing_Chemical":
+                    example["labels"].append(a.infons.get("identifier"))
+
+        example["text"] = " ".join(example["text"])
+
+        return example
+
     def _get_passages_and_entities(
         self, d: bioc.BioCDocument
     ) -> Tuple[List[Dict], List[List[Dict]]]:
@@ -219,15 +246,22 @@ class NLMChemDataset(datasets.GeneratorBasedBuilder):
                 a_type = a.infons.get("type")
 
                 # no in-text annotation: only for document indexing
-                if a_type in ["MeSH_Indexing_Chemical", "OTHER"]:
+                if (
+                    self.config.schema == "bigbio_kb"
+                    and a_type == "MeSH_Indexing_Chemical"
+                ):
                     continue
-
-                offsets, text = get_texts_and_offsets_from_bioc_ann(a)
 
                 da = {
                     "type": a_type,
-                    "offsets": [(start - eo, end - eo) for (start, end) in offsets],
-                    "text": text,
+                    "offsets": [
+                        (
+                            loc.offset - eo,
+                            loc.offset + loc.length - eo,
+                        )
+                        for loc in a.locations
+                    ],
+                    "text": (a.text,),
                     "id": a.id,
                     "normalized": self._get_normalized(a),
                 }
@@ -286,6 +320,17 @@ class NLMChemDataset(datasets.GeneratorBasedBuilder):
                     p["entities"] = pe  # BioC has per passage entities
 
                 yield uid, {"passages": passages}
+
+        elif self.config.schema == "bigbio_text":
+            uid = 0
+            for idx, doc in enumerate(reader):
+
+                example = self._get_textcls_example(doc)
+                example["id"] = uid
+                # global id
+                uid += 1
+
+                yield idx, example
 
         elif self.config.schema == "bigbio_kb":
             uid = 0


### PR DESCRIPTION
This PR is similar in content to #373.

It adds a helper function in `utils.parsing`to correctly extract offsets and text from a BioC annotation, w/o making the offsets checks pass trivially as it is happens [here](https://github.com/bigscience-workshop/biomedical/blob/master/examples/bc5cdr.py#L210):

```python
texts = [doc_text[i:j] for i, j in offsets]
```
I verified that the code works with the existing datasets using `bioc`, i.e.: `examples/bc5cdr`, `examples/nlmchem` and `biodatasets/chemdner/chemdner`.

I will modify the `biodatasets/bc5cdr/bc5cdr` and `biodatasets/nlmchem/nlmchem` it this gets approved.