### PR TITLE
Closes #172

### DIFF
--- a/biodatasets/cadec/cadec.py
+++ b/biodatasets/cadec/cadec.py
@@ -37,18 +37,15 @@ from utils import parsing, schemas
 from utils.configs import BigBioConfig
 from utils.constants import Tasks
 
-# TODO: Add BibTeX citation
 _CITATION = """\
 @article{,
-  author    = {},
-  title     = {},
-  journal   = {},
-  volume    = {},
-  year      = {},
-  url       = {},
-  doi       = {},
-  biburl    = {},
-  bibsource = {}
+  title={Cadec: A corpus of adverse drug event annotations},
+  author={Karimi, Sarvnaz and Metke-Jimenez, Alejandro and Kemp, Madonna and Wang, Chen},
+  journal={Journal of biomedical informatics},
+  volume={55},
+  pages={73--81},
+  year={2015},
+  publisher={Elsevier}
 }
 """
 

--- a/biodatasets/cadec/cadec.py
+++ b/biodatasets/cadec/cadec.py
@@ -231,7 +231,7 @@ class CadecDataset(datasets.GeneratorBasedBuilder):
                     i = 0
                     for start, end in ann["offsets"]:
                         chunk_len = end - start
-                        ann["text"].append(text[i:chunk_len+i])
+                        ann["text"].append(text[i : chunk_len + i])
                         i += chunk_len
                         while i < len(text) and text[i] == " ":
                             i += 1

--- a/biodatasets/cadec/cadec.py
+++ b/biodatasets/cadec/cadec.py
@@ -1,0 +1,295 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The CADEC corpus (CSIRO Adverse Drug Event Corpus) is is a new rich annotated corpus of medical forum posts on patient-
+reported Adverse Drug Events (ADEs). The corpus is sourced from posts on social media, and contains text that is 
+largely written in colloquial language and often deviates from formal English grammar and punctuation rules. 
+Annotations contain mentions of concepts such as drugs, adverse events, symptoms, and diseases linked to their 
+corresponding concepts in controlled vocabularies, i.e., SNOMED Clinical Terms and MedDRA. The quality of the 
+annotations is ensured by annotation guidelines, multi-stage annotations, measuring inter-annotator agreement, and 
+final review of the annotations by a clinical terminologist. This corpus is useful for those studies in the area of 
+information extraction, or more generally text mining, from social media to detect possible adverse drug reactions from 
+direct patient reports. The dataset contains three views: original (entities annotated in the posts), meddra (entities 
+normalized with meddra codes), snomedct (entities normalized with SNOMED CT codes).
+"""
+
+import os
+from pathlib import Path
+from typing import List, Tuple, Dict
+
+import datasets
+from utils import schemas, parsing
+from utils.configs import BigBioConfig
+from utils.constants import Tasks
+
+# TODO: Add BibTeX citation
+_CITATION = """\
+@article{,
+  author    = {},
+  title     = {},
+  journal   = {},
+  volume    = {},
+  year      = {},
+  url       = {},
+  doi       = {},
+  biburl    = {},
+  bibsource = {}
+}
+"""
+
+_DATASETNAME = "cadec"
+
+_DESCRIPTION = """\
+The CADEC corpus (CSIRO Adverse Drug Event Corpus) is is a new rich annotated corpus of medical forum posts on patient-
+reported Adverse Drug Events (ADEs). The corpus is sourced from posts on social media, and contains text that is 
+largely written in colloquial language and often deviates from formal English grammar and punctuation rules. 
+Annotations contain mentions of concepts such as drugs, adverse events, symptoms, and diseases linked to their 
+corresponding concepts in controlled vocabularies, i.e., SNOMED Clinical Terms and MedDRA. The quality of the 
+annotations is ensured by annotation guidelines, multi-stage annotations, measuring inter-annotator agreement, and 
+final review of the annotations by a clinical terminologist. This corpus is useful for those studies in the area of 
+information extraction, or more generally text mining, from social media to detect possible adverse drug reactions from 
+direct patient reports. The dataset contains three views: original (entities annotated in the posts), meddra (entities 
+normalized with meddra codes), sct (entities normalized with SNOMED CT codes).
+"""
+
+_HOMEPAGE = "https://data.gov.au/dataset/ds-dap-csiro%3A10948/details?q="
+
+_LICENSE = "https://confluence.csiro.au/display/dap/CSIRO+Data+Licence"
+
+_URLS = {
+    _DATASETNAME: "https://data.csiro.au/dap/ws/v2/collections/17190/data/1904643",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION]
+
+_SOURCE_VERSION = "2.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+class CadecDataset(datasets.GeneratorBasedBuilder):
+    """CADEC is an annoted corpus of patient reported Adverse Drug Events."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name=f"cadec_source",
+            version=SOURCE_VERSION,
+            description=f"CADEC source schema",
+            schema="source",
+            subset_id=f"cadec",
+        ),
+        BigBioConfig(
+            name=f"cadec_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description=f"CADEC BigBio schema",
+            schema="bigbio_kb",
+            subset_id=f"cadec",
+        )
+    ]
+
+    DEFAULT_CONFIG_NAME = "cadec_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value("string"),
+                            "cuid": datasets.Value("string"),
+                            "text": datasets.Value(
+                                "string"
+                            ),
+                        }
+                    ],
+                },
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = schemas.kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "corpus_path": os.path.join(data_dir, "cadec"),
+                },
+            ),
+        ]
+
+    def _generate_examples(self, corpus_path: str,) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        if self.config.schema == "source":
+            for guid, example in self._parse_examples(corpus_path):
+                example["id"] = str(guid)
+                yield guid, example
+        elif self.config.schema == "bigbio_kb":
+            for guid, example in self._parse_examples(corpus_path):
+                example = parsing.brat_parse_to_bigbio_kb(
+                    example, entity_types=self._ENTITY_TYPES
+                )
+                example["id"] = str(guid)
+                yield guid, example
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")
+
+
+    def _parse_examples(self, corpus_path: Path) -> Dict:
+        txt_files = list(Path(corpus_path, "text").glob("*txt"))
+        for guid, txt_file in enumerate(txt_files):
+            example = {}
+            example["document_id"] = txt_file.with_suffix("").name
+            with txt_file.open() as f:
+                example["text"] = f.read()
+
+            example["text_bound_annotations"] = []
+            example["normalizations"] = []
+            for annotation in ["original", "meddra", "sct"]:
+                annotation_path = Path(corpus_path, annotation, txt_file.with_suffix(".ann").name)
+                self._populate_example(example, annotation, annotation_path)
+            yield guid, example
+
+            
+
+    def _populate_example(self, example, code_system: str, annotation_file: Path):
+        ann_lines = []
+        print(annotation_file)
+        if annotation_file.exists():
+            with annotation_file.open() as f:
+                ann_lines.extend(f.readlines())
+
+        for line in ann_lines:
+            line = line.strip()
+            # some lines contain 4 or 5 spaces instead of tabs (f.e. /meddra/DICLOFENAC-SODIUM.7.ann)
+            line = line.replace("     ", "\t")
+            line = line.replace("    ", "\t")
+
+            """
+            if "|+" in line:
+                print(annotation_file)
+                exit(-1)
+            """
+            print(line)
+            if not line:
+                continue
+            elif line.startswith("TT"): # Normalization
+                fields = line.split("\t")
+                ann = self._parse_normalization(fields, code_system)
+                example["normalizations"].extend(ann)
+            elif line.startswith("T"):  # Text bound
+                ann = {}
+                fields = line.split("\t")
+                ann["id"] = fields[0]
+                ann["text"] = [fields[2]]
+                ann["type"], span_str = fields[1].split(maxsplit=1)
+                ann["offsets"] = []
+                for span in span_str.split(";"):
+                    start, end = span.split()
+                    ann["offsets"].append([int(start), int(end)])
+                example["text_bound_annotations"].append(ann)
+            elif line.startswith("#"):
+                continue
+            else:
+                raise ValueError(f"Invalid tag: {line}")
+        return example
+
+    def _parse_normalization(self, fields: List[str], code_system: str):
+        anns = []
+        base_ann = {
+            "id": code_system + "_" + fields[0],
+            "ref_id": fields[0][1:], # here TT1 -> Normalization of T1
+            "type": "Reference"
+        }
+
+        if "CONCEPT_LESS" in fields[1]:
+            ann = base_ann.copy()
+            ann["cuid"], _ = fields[1].split(maxsplit=1)
+            ann["text"] = ""
+            ann["resource_name"] = ""
+            anns = [ann]
+        elif code_system == "sct":
+            if "|" in fields[1]:
+                # some anns contain multiple normalizations, used seperator is very inconsistent
+                sep = None
+                if "|+" in fields[1]: # /sct/ARTHROTEC.112.ann
+                    sep = "|+"
+                elif "| +" in fields[1]: # /sct/ARTHROTEC.113.ann
+                    sep = "| +"
+                elif "| or" in fields[1]: # sct\ARTHROTEC.1.ann
+                    sep = "| or"
+                print(fields)
+                concepts, _ = fields[1].rsplit("|", maxsplit=1)
+                print(concepts)
+                print(sep)
+                if sep:
+                    concepts = concepts.split(sep)
+                else:
+                    concepts = [concepts]
+                print(concepts)
+                anns = []
+                for concept in concepts:
+                    concept = concept.strip()
+                    ann = base_ann.copy()
+                    print(concept)
+                    ann["cuid"], ann["text"] = concept.split("|")
+                    ann["cuid"] = ann["cuid"].strip()
+                    ann["text"] = ann["text"].strip()
+                    ann["resource_name"] = "Snomed CT"
+                    anns.append(ann)
+            elif "31460011000036109  (substance)" in fields[1]: # there is one dirty line 
+                pass
+            else:
+                raise ValueError("Invalid line: " + '\t'.join(fields))
+        elif code_system == "meddra":
+            ann = base_ann.copy()
+            ann["cuid"], _ = fields[1].split(maxsplit=1)
+            ann["text"] = ""
+            ann["resource_name"] = "Meddra"
+            anns = [ann]
+        return anns
+
+


### PR DESCRIPTION
closes #172

### Checkbox

- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `biodatasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_BIGBIO_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `BigBioConfig` for the source schema and one for a bigbio schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_bigbio biodatasets/my_dataset/my_dataset.py`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.

### Remarks

Dataset was a pain to implement due to a lot of dirty data in the Snomed CT source material. 

The following is for documentation purposes:
The dataset is in standoff format, however I think it was created at a time where there were no normalization (<v1.3). The dataset comes with entities `T1	ADR 9 19	bit drowsy` and normalization from two different codesystems (meddra and Snomed CT). 

Meddra normalizations are all fine `TT1	10013649 9 19	bit drowsy`, where the format is `{tag}\t{code} {start} {stop}(;{start} {stop})*\t{text}`. One line can contain multiple normalizations separated by " + " f.e. `TT1	10033371 + 10033374 21 42	horrible stomach pain` (ARTHROTEC.112.ann).

However the format of normalizations from Snomed CT is very inconsistent. Usually they have the format `{tag}\t{code} | {label} | {start} {stop}(;{start} {stop})*\t{text}`. One line can contain multiple codes which are separated normally separated by `|+` f.e.: `TT1	76948002 | Severe pain |+ 21522001 | Abdominal pain | 21 42	horrible stomach pain`

Dirty data in Snomed CT normalizations:
- Some lines use 4 spaces or sometimes more instead of a tab
- seperator | can be padded by random whitespace
- Multiple codes separator "|+" is also sometimes "|or"; padded or split by random amount of whitespace f.e. " | + ", (examples /sct/ARTHROTEC.112.ann, /sct/ARTHROTEC.113.ann, /sct/ARTHROTEC.1.ann)
- Code/label and offsets are normally separated by | however some lines omit this separator f.e. `TT9	21499005|Feeling agitated 232 249	Severe aggitation` (LIPITOR.496.ann)
- Some lines contain an additional " | (substance)" f.e. `TT7	2297011000036108 | magnesium | (substance) 186 195	magnesium` (LIPITOR.598.ANN), which may be due to a processing error as the label should be "magnesium (substance)" see [here](https://browser.ihtsdotools.org/?perspective=full&conceptId1=2297011000036108&edition=MAIN/SNOMEDCT-AU/2022-01-31&release=&languages=en)
- Sometimes there is no | between code and label: `TT2     76948002 | Severe pain | + 57676002 Arthralgia |  43 72 extreme pain in all my joints` (LIPITOR.698.ann)
- Somteimes there are no | at all: `TT2	31460011000036109  (substance) 34 46	acidophilous` (ARTHROTEC.91.ann)
