### PR TITLE
Pin bioc to 2.0.post1

### DIFF
--- a/biodatasets/bc5cdr/bc5cdr.py
+++ b/biodatasets/bc5cdr/bc5cdr.py
@@ -26,9 +26,9 @@ import collections
 import itertools
 import os
 
-import bioc
-
 import datasets
+from bioc import biocxml
+
 from utils import schemas
 from utils.configs import BigBioConfig
 from utils.constants import Tasks
@@ -275,7 +275,7 @@ class Bc5cdrDataset(datasets.GeneratorBasedBuilder):
     ):
         """Yields examples as (key, example) tuples."""
         if self.config.schema == "source":
-            reader = bioc.BioCXMLDocumentReader(str(filepath))
+            reader = biocxml.BioCXMLDocumentReader(str(filepath))
 
             for uid, xdoc in enumerate(reader):
                 doc_text = self._get_document_text(xdoc)
@@ -301,7 +301,7 @@ class Bc5cdrDataset(datasets.GeneratorBasedBuilder):
                 }
 
         elif self.config.schema == "bigbio_kb":
-            reader = bioc.BioCXMLDocumentReader(str(filepath))
+            reader = biocxml.BioCXMLDocumentReader(str(filepath))
             uid = 0  # global unique id
 
             for i, xdoc in enumerate(reader):

--- a/biodatasets/nlmchem/nlmchem.py
+++ b/biodatasets/nlmchem/nlmchem.py
@@ -17,8 +17,9 @@ import re
 from typing import Dict, Iterator, List, Tuple
 
 import bioc
-
 import datasets
+from bioc import biocxml
+
 from utils import schemas
 from utils.configs import BigBioConfig
 from utils.constants import Tasks
@@ -265,7 +266,7 @@ class NLMChemDataset(datasets.GeneratorBasedBuilder):
     ) -> Iterator[Tuple[int, Dict]]:
         """Yields examples as (key, example) tuples."""
 
-        reader = bioc.BioCXMLDocumentReader(str(filepath))
+        reader = biocxml.BioCXMLDocumentReader(str(filepath))
 
         if self.config.schema == "source":
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 loguru==0.5.3
-bioc==2.0
+bioc==2.0.post1
 pandas==1.3.3
 numpy==1.21.2
 pybrat==0.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 loguru==0.5.3
-bioc==1.3.7
+bioc==2.0
 pandas==1.3.3
 numpy==1.21.2
 pybrat==0.1.4


### PR DESCRIPTION
# Overview

This PR updates `bioc` from `1.3.7` to `2.0.post1` in the `requirements.txt`. This allows the use of the new `pubtator` module of this package for parsing datasets in the PubTator format. See the discussion about this change here: https://github.com/bigscience-workshop/biomedical/pull/370#issuecomment-1092917970.

@sg-wbi mind taking a look?

## TODO

- [x] Is there a way to run all the unit tests? Want to make sure this doesn't break anything