### PR TITLE
Fix parsing of entities in bigbio schema

### DIFF
--- a/biodatasets/ncbi_disease/ncbi_disease.py
+++ b/biodatasets/ncbi_disease/ncbi_disease.py
@@ -220,28 +220,23 @@ class NCBIDiseaseDataset(datasets.GeneratorBasedBuilder):
                     },
                 ]
 
-                unified_entities = {}
-                for entity in doc.annotations:
+                unified_entities = []
+                for i, entity in enumerate(doc.annotations):
                     # We need a unique identifier for this entity, so build it from the document id and entity id
-                    unified_entity_id = doc.pmid + "_" + entity.id
+                    unified_entity_id = "_".join([doc.pmid, entity.id, str(i)])
                     # The user can provide a callable that returns the database name.
                     db_name = "omim" if "OMIM" in entity.id else "mesh"
-                    if unified_entity_id not in unified_entities:
-                        unified_entities[unified_entity_id] = {
+                    unified_entities.append(
+                        {
                             "id": unified_entity_id,
                             "type": entity.type,
                             "text": [entity.text],
                             "offsets": [[entity.start, entity.end]],
                             "normalized": [{"db_name": db_name, "db_id": entity.id}],
                         }
-                    else:
-                        unified_entities[unified_entity_id]["text"].append(entity.text)
-                        unified_entities[unified_entity_id]["offsets"].append([entity.start, entity.end])
-                        unified_entities[unified_entity_id]["normalized"].append(
-                            {"db_name": db_name, "db_id": entity.id}
-                        )
+                    )
 
-                unified_example["entities"] = list(unified_entities.values())
+                unified_example["entities"] = unified_entities
                 unified_example["relations"] = []
                 unified_example["events"] = []
                 unified_example["coreferences"] = []


### PR DESCRIPTION
I had made a mistake in how I parsed entities for the `bigbio_kb` schema that was pointed out in another data loader (https://github.com/bigscience-workshop/biomedical/pull/335#discussion_r848938732). This fixes that here.

- **Name:** NCBI Disease
- **Description:** The NCBI disease corpus is fully annotated at the mention and concept level to serve as a research
resource for the biomedical natural language processing community.
- **Paper:** http://www.ncbi.nlm.nih.gov/pubmed/24393765
- **Data:** https://www.ncbi.nlm.nih.gov/CBBresearch/Dogan/DISEASE/

### Checkbox

- [X] Confirm that this PR is linked to the dataset issue.
- [X] Create the dataloader script `biodatasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [X] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_BIGBIO_VERSION` variables.
- [X] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [X] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `BigBioConfig` for the source schema and one for a bigbio schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_bigbio biodatasets/my_dataset/my_dataset.py`.
