### PR TITLE
Add n2c2_2006 dataset loader

### DIFF
--- a/biodatasets/n2c2_2006/n2c2_2006.py
+++ b/biodatasets/n2c2_2006/n2c2_2006.py
@@ -1,0 +1,229 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+A dataset loader for the n2c2 2006 smoking status dataset.
+
+https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/
+
+The dataset consists of two archive files,
+
+* smokers_surrogate_train_all_version2.zip
+* smokers_surrogate_test_all_groundtruth_version2.zip
+
+The individual data files (inside the zip archives) come in just 1 type:
+
+* xml (*.xml files): contains the id and text of the patient records, 
+and corresponding smoking status labels
+
+
+The files comprising this dataset must be on the users local machine
+in a single directory that is passed to `datasets.load_datset` via
+the `data_dir` kwarg. This loader script will read the archive files
+directly (i.e. the user should not uncompress, untar or unzip any of
+the files). For example, if the following directory structure exists
+on the users local machine,
+
+
+n2c2_2006
+├── smokers_surrogate_train_all_version2.zip
+├── smokers_surrogate_test_all_groundtruth_version2.zip
+
+
+Data Access
+
+from https://www.i2b2.org/NLP/DataSets/Main.php
+
+"As always, you must register AND submit a DUA for access. If you previously
+accessed the data sets here on i2b2.org, you will need to set a new password
+for your account on the Data Portal, but your original DUA will be retained."
+
+
+"""
+
+import os
+import xml.etree.ElementTree as et
+import zipfile
+from typing import Dict, List, Tuple
+
+import datasets
+
+from utils import schemas
+from utils.configs import BigBioConfig
+from utils.constants import Tasks
+
+_DATASETNAME = "n2c2_2006"
+
+# https://academic.oup.com/jamia/article/15/1/14/779738
+_CITATION = """\
+@article{,
+    author = {
+        Uzuner, Ozlem and
+        Goldstein, Ira and
+        Luo, Yuan and
+        Kohane, Isaac
+    },
+    title     = {Identifying Patient Smoking Status from Medical Discharge Records},
+    journal   = {Journal of the American Medical Informatics Association},
+    volume    = {15},
+    number    = {1},
+    pages     = {14-24},
+    year      = {2008},
+    month     = {01},
+    url       = {https://doi.org/10.1197/jamia.M2408},
+    doi       = {10.1136/amiajnl-2011-000784},
+    eprint    = {https://academic.oup.com/jamia/article-pdf/15/1/14/2339646/15-1-14.pdf}
+}
+"""
+
+_DESCRIPTION = """\
+The data for the n2c2 2006 smoking challenge consisted of discharge summaries 
+from Partners HealthCare, which were then de-identified, tokenized, broken into 
+sentences, converted into XML format, and separated into training and test sets. 
+
+Two pulmonologists annotated each record with the smoking status of patients based 
+strictly on the explicitly stated smoking-related facts in the records. These 
+annotations constitute the textual judgments of the annotators. The annotators 
+were asked to classify patient records into five possible smoking status categories: 
+a past smoker, a current smoker, a smoker, a non-smoker and an unknown. A total of 
+502 de-identified medical discharge records were used for the smoking challenge.
+"""
+
+_HOMEPAGE = "https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/"
+
+_LICENSE = "Data User Agreement"
+
+_SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+_CLASS_NAMES = ["current smoker", "non-smoker", "past smoker", "smoker", "unknown"]
+
+
+def _read_zip(file_path):
+    _, filename = os.path.split(file_path)
+    zipped = zipfile.ZipFile(file_path, "r")
+    file = zipped.read(filename.split(".")[0] + ".xml")
+
+    root = et.fromstring(file)
+    ids = []
+    notes = []
+    labels = []
+    documents = root.findall("./RECORD")
+    for document in documents:
+        ids.append(document.attrib["ID"])
+        notes.append(document.findall("./TEXT")[0].text)
+        labels.append(document.findall("./SMOKING")[0].attrib["STATUS"].lower())
+    return [(id, note, label) for id, note, label in zip(ids, notes, labels)]
+
+
+class N2C22006SmokingDataset(datasets.GeneratorBasedBuilder):
+    """n2c2 2006 smoking status identification task"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="n2c2_2006_source",
+            version=SOURCE_VERSION,
+            description="n2c2_2006 source schema",
+            schema="source",
+            subset_id="n2c2_2006",
+        ),
+        BigBioConfig(
+            name="n2c2_2006_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="n2c2_2006 BigBio schema",
+            schema="bigbio_text",
+            subset_id="n2c2_2006",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "n2c2_2006_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "label": datasets.ClassLabel(names=_CLASS_NAMES),
+                }
+            )
+
+        elif self.config.schema == "bigbio_text":
+            features = schemas.text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        if self.config.data_dir is None:
+            raise ValueError("This is a local dataset. Please pass the data_dir kwarg to load_dataset.")
+        else:
+            data_dir = self.config.data_dir
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "split": "test",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, data_dir, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        if split == "train":
+            _id = 0
+            path = os.path.join(data_dir, "smokers_surrogate_train_all_version2.zip")
+            samples = _read_zip(path)
+            for sample in samples:
+                if self.config.schema == "source":
+                    yield _id, {"document_id": sample[0], "text": sample[1], "label": sample[-1]}
+                elif self.config.schema == "bigbio_text":
+                    yield _id, {"id": sample[0], "document_id": sample[0], "text": sample[1], "labels": [sample[-1]]}
+                _id += 1
+
+        elif split == "test":
+            _id = 0
+            path = os.path.join(data_dir, "smokers_surrogate_test_all_groundtruth_version2.zip")
+            samples = _read_zip(path)
+            for sample in samples:
+                if self.config.schema == "source":
+                    yield _id, {"document_id": sample[0], "text": sample[1], "label": sample[-1]}
+                elif self.config.schema == "bigbio_text":
+                    yield _id, {"id": sample[0], "document_id": sample[0], "text": sample[1], "labels": [sample[-1]]}
+                _id += 1


### PR DESCRIPTION
Please name your PR after the issue it closes. You can use the following line: "Closes #ISSUE-NUMBER" where you replace the ISSUE-NUMBER with the one corresponding to your dataset.

If the following information is NOT present in the issue, please populate:

- **Name:** n2c2_2006
- **Description:** n2c2 2006 smoking status identification task
- **Paper:** [*link to the dataset paper*](https://doi.org/10.1197/jamia.M2408)
- **Data:** [*link to the online home of the dataset*](https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/)

### Checkbox

- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `biodatasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_BIGBIO_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `BigBioConfig` for the source schema and one for a bigbio schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_bigbio biodatasets/my_dataset/my_dataset.py`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.


**unit-test output**
```
(bigscience-biomedical) bo@Bos-MacBook-Pro biomedical % python -m tests.test_bigbio biodatasets/n2c2_2006/n2c2_2006.py --data_dir /Users/bo/Downloads
INFO:__main__:args: Namespace(path='biodatasets/n2c2_2006/n2c2_2006.py', schema=None, subset_id=None, data_dir='/Users/bo/Downloads', use_auth_token=None)
INFO:__main__:self.PATH: biodatasets/n2c2_2006/n2c2_2006.py
INFO:__main__:self.SUBSET_ID: n2c2_2006
INFO:__main__:self.SCHEMA: None
INFO:__main__:self.DATA_DIR: /Users/bo/Downloads
INFO:__main__:Checking for _SUPPORTED_TASKS ...
INFO:__main__:Found _SUPPORTED_TASKS=[<Tasks.TEXT_CLASSIFICATION: 'TXTCLASS'>]
INFO:__main__:_SUPPORTED_TASKS implies _MAPPED_SCHEMAS={'TEXT'}
INFO:__main__:schemas_to_check: {'TEXT'}
INFO:__main__:Checking load_dataset with config name n2c2_2006_source
WARNING:datasets.builder:Using custom data configuration n2c2_2006_source-6eec24607a8c4df9
Downloading and preparing dataset n2_c22006_smoking_dataset/n2c2_2006_source to /Users/bo/.cache/huggingface/datasets/n2_c22006_smoking_dataset/n2c2_2006_source-6eec24607a8c4df9/1.0.0/ca753ee83155444d89f3c758a230b0c69dfe11afa0d7a595b8b9eca7f0fdb40e...
Dataset n2_c22006_smoking_dataset downloaded and prepared to /Users/bo/.cache/huggingface/datasets/n2_c22006_smoking_dataset/n2c2_2006_source-6eec24607a8c4df9/1.0.0/ca753ee83155444d89f3c758a230b0c69dfe11afa0d7a595b8b9eca7f0fdb40e. Subsequent calls will reuse this data.
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 783.98it/s]
INFO:__main__:Checking load_dataset with config name n2c2_2006_bigbio_text
WARNING:datasets.builder:Using custom data configuration n2c2_2006_bigbio_text-6eec24607a8c4df9
Downloading and preparing dataset n2_c22006_smoking_dataset/n2c2_2006_bigbio_text to /Users/bo/.cache/huggingface/datasets/n2_c22006_smoking_dataset/n2c2_2006_bigbio_text-6eec24607a8c4df9/1.0.0/ca753ee83155444d89f3c758a230b0c69dfe11afa0d7a595b8b9eca7f0fdb40e...
Dataset n2_c22006_smoking_dataset downloaded and prepared to /Users/bo/.cache/huggingface/datasets/n2_c22006_smoking_dataset/n2c2_2006_bigbio_text-6eec24607a8c4df9/1.0.0/ca753ee83155444d89f3c758a230b0c69dfe11afa0d7a595b8b9eca7f0fdb40e. Subsequent calls will reuse this data.
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 999.00it/s]
INFO:__main__:Checking global ID uniqueness
INFO:__main__:Found 104 unique IDs
INFO:__main__:Gathering schema statistics
INFO:__main__:Gathering schema statistics
train
==========
id: 398
document_id: 398
text: 398
labels: 398

test
==========
id: 104
document_id: 104
text: 104
labels: 104

.
----------------------------------------------------------------------
Ran 1 test in 0.659s

OK
```