### PR TITLE
Add swedish_medical_ner dataset loader

### DIFF
--- a/biodatasets/swedish_medical_ner/swedish_medical_ner.py
+++ b/biodatasets/swedish_medical_ner/swedish_medical_ner.py
@@ -1,0 +1,290 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+swedish_medical_ner is Named Entity Recognition dataset on medical text in Swedish. 
+
+It consists three subsets which are in turn derived from three different sources respectively: 
+
+* the Swedish Wikipedia (a.k.a. wiki): Wiki_annotated_60.txt
+* Läkartidningen (a.k.a. lt): LT_annotated_60.txt
+* 1177 Vårdguiden (a.k.a. 1177): 1177_annotated_sentences.txt
+
+Texts from both Swedish Wikipedia and Läkartidningen were automatically annotated using a 
+list of medical seed terms. Sentences from 1177 Vårdguiden were manuually annotated.
+
+It can be found in Hugging Face Datasets: https://huggingface.co/datasets/swedish_medical_ner.
+
+"""
+
+import os
+from typing import Dict, List, Tuple
+
+import datasets
+import regex as re
+
+from utils import schemas
+from utils.configs import BigBioConfig
+from utils.constants import Tasks
+
+_DATASETNAME = "swedish_medical_ner"
+
+_CITATION = """\
+@inproceedings{almgren-etal-2016-named,
+    author = {
+        Almgren, Simon and
+        Pavlov, Sean and
+        Mogren, Olof
+    },
+    title     = {Named Entity Recognition in Swedish Medical Journals with Deep Bidirectional Character-Based LSTMs},
+    booktitle = {Proceedings of the Fifth Workshop on Building and Evaluating Resources for Biomedical Text Mining (BioTxtM 2016)},
+    publisher = {The COLING 2016 Organizing Committee},
+    pages     = {30-39},
+    year      = {2016},
+    month     = {12},
+    url       = {https://aclanthology.org/W16-5104},
+    eprint    = {https://aclanthology.org/W16-5104.pdf}
+}
+"""
+
+_DESCRIPTION = """\
+swedish_medical_ner is Named Entity Recognition dataset on medical text in Swedish. 
+It consists three subsets which are in turn derived from three different sources 
+respectively: the Swedish Wikipedia (a.k.a. wiki), Läkartidningen (a.k.a. lt), 
+and 1177 Vårdguiden (a.k.a. 1177). While the Swedish Wikipedia and Läkartidningen 
+subsets in total contains over 790000 sequences with 60 characters each, 
+the 1177 Vårdguiden subset is manually annotated and contains 927 sentences, 
+2740 annotations, out of which 1574 are disorder and findings, 546 are 
+pharmaceutical drug, and 620 are body structure.
+
+Texts from both Swedish Wikipedia and Läkartidningen were automatically annotated 
+using a list of medical seed terms. Sentences from 1177 Vårdguiden were manuually 
+annotated.
+"""
+
+_HOMEPAGE = "https://github.com/olofmogren/biomedical-ner-data-swedish/"
+
+_LICENSE = "Creative Commons Attribution-ShareAlike 4.0 International Public License (CC BY-SA 4.0)"
+
+_URLS = {
+    _DATASETNAME: [
+        "https://raw.githubusercontent.com/olofmogren/biomedical-ner-data-swedish/master/Wiki_annotated_60.txt",
+        "https://raw.githubusercontent.com/olofmogren/biomedical-ner-data-swedish/master/LT_annotated_60.txt",
+        "https://raw.githubusercontent.com/olofmogren/biomedical-ner-data-swedish/master/1177_annotated_sentences.txt",
+    ],
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+def _read_data(datapaths):
+    def find_type(s, e):
+        if (s == "(") and (e == ")"):
+            return "Disorder and Finding"
+        elif (s == "[") and (e == "]"):
+            return "Pharmaceutical Drug"
+        elif (s == "{") and (e == "}"):
+            return "Body Structure"
+        else:
+            return ""
+
+    pattern = r"{[^{}]+}|\[[^\[\]]+\]|\([^\(\)]+\)"
+    pattern2 = r"(?<=[\[{(])\s+|\s+(?=[\]})])"
+    documents = []
+    s_id = 0
+    for filepath in datapaths:
+        db_id = 1
+        if db_id == 1:
+            db_name = "wiki"
+        elif db_id == 2:
+            db_name = "LT"
+        else:
+            db_name = "1177"
+
+        with open(filepath, encoding="utf-8") as f:
+            for _, row in enumerate(f):
+                sentence = row.replace("\n", "")
+                sentence = re.sub(pattern2, "", sentence)
+                matches = re.findall(pattern, sentence, overlapped=True)
+                words = [re.sub(r"[{}\[\]\(\)]", "", m) for m in matches]
+                types = [find_type(match[0], match[-1]) for match in matches]
+                clean_sent = re.sub(r"(\w|\)|\]|})([\(\[{])", "\\1 \\2", sentence)
+                clean_sent = re.sub(r"([\)\]}])(\w|\(|\[|{)", "\\1 \\2", clean_sent)
+                clean_sent = re.sub(r"[{}\[\]\(\)]", "", clean_sent)
+
+                try:
+                    targets = [
+                        {
+                            "start": m.start(2),
+                            "end": m.end(2),
+                            "text": clean_sent[m.start(2) : m.end(2)],
+                        }
+                        for m in map(lambda word: re.search(f"(^|[^\w]+)({word})($|[^\w]+)", clean_sent), words)
+                    ]
+                except:
+                    continue  # skip wrongly formatted sentences, e.g. (Barretts ){e)s)o)f)a)g)u)s),}
+
+                if targets:
+                    documents.append(
+                        {
+                            "sid": "s" + str(s_id),
+                            "row": row.replace("\n", ""),
+                            "sentence": clean_sent,
+                            "entities": [
+                                {
+                                    "start": targets[i]["start"],
+                                    "end": targets[i]["end"],
+                                    "text": targets[i]["text"],
+                                    "type": types[i],
+                                }
+                                for i in range(len(targets))
+                            ],
+                            "normalized": {"db_name": db_name, "db_id": "d" + str(db_id)},
+                        }
+                    )
+                s_id += 1
+        db_id += 1
+
+    return documents
+
+
+class SwedishMedicalNerDataset(datasets.GeneratorBasedBuilder):
+    """Swedish medical named entity recognition"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="swedish_medical_ner_source",
+            version=SOURCE_VERSION,
+            description="swedish_medical_ner source schema",
+            schema="source",
+            subset_id="swedish_medical_ner",
+        ),
+        BigBioConfig(
+            name="swedish_medical_ner_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="swedish_medical_ner BigBio schema",
+            schema="bigbio_kb",
+            subset_id="swedish_medical_ner",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "swedish_medical_ner_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "sid": datasets.Value("string"),
+                    "row": datasets.Value("string"),
+                    "sentence": datasets.Value("string"),
+                    "entities": [
+                        {
+                            "start": datasets.Value("int32"),
+                            "end": datasets.Value("int32"),
+                            "text": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = schemas.kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "split": "train",
+                },
+            ),
+        ]
+
+    @staticmethod
+    def _get_source_sample(sample):
+        return {
+            "sid": sample["sid"],
+            "row": sample["row"],
+            "sentence": sample["sentence"],
+            "entities": sample["entities"],
+        }
+
+    @staticmethod
+    def _get_bigbio_sample(sample_id, sample):
+        return {
+            "id": str(sample_id),
+            "document_id": sample["sid"],
+            "passages": [
+                {
+                    "id": sample["sid"] + "-passage-0",
+                    "type": "sentence",
+                    "text": [sample["sentence"]],
+                    "offsets": [[0, len(sample["sentence"])]],
+                }
+            ],
+            "entities": [
+                {
+                    "id": sample["sid"] + "-entity-" + str(i),
+                    "text": [ent["text"]],
+                    "offsets": [[ent["start"], ent["end"]]],
+                    "type": ent["type"],
+                    "normalized": [sample["normalized"]],
+                }
+                for i, ent in enumerate(sample["entities"])
+            ],
+            "events": [],
+            "coreferences": [],
+            "relations": [],
+        }
+
+    def _generate_examples(self, data_dir, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        _id = 0
+        samples = _read_data(data_dir)
+        for sample in samples:
+            if self.config.schema == "source":
+                yield _id, self._get_source_sample(sample)
+
+            elif self.config.schema == "bigbio_kb":
+                yield _id, self._get_bigbio_sample(_id, sample)
+            _id += 1
+
+
+if __name__ == "__main__":
+    datasets.load_dataset(__file__)


### PR DESCRIPTION
Please name your PR after the issue it closes. You can use the following line: "Closes #ISSUE-NUMBER" where you replace the ISSUE-NUMBER with the one corresponding to your dataset.

If the following information is NOT present in the issue, please populate:

- **Name:** swedish_medical_ner
- **Description:** Named entity recognition in Swedish medical journals
- **Paper:** [*link to the dataset paper*](http://aclanthology.lst.uni-saarland.de/W16-5104.pdf)
- **Data:** [*link to the online home of the dataset*](https://github.com/olofmogren/biomedical-ner-data-swedish)

### Checkbox

- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `biodatasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_BIGBIO_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `BigBioConfig` for the source schema and one for a bigbio schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_bigbio biodatasets/my_dataset/my_dataset.py`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.


**unit-test output**
```
(bigscience-biomedical) bo@Bos-MacBook-Pro biomedical % python -m tests.test_bigbio biodatasets/swedish_medical_ner/swedish_medical_ner.py
INFO:__main__:args: Namespace(path='biodatasets/swedish_medical_ner/swedish_medical_ner.py', schema=None, subset_id=None, data_dir=None, use_auth_token=None)
INFO:__main__:self.PATH: biodatasets/swedish_medical_ner/swedish_medical_ner.py
INFO:__main__:self.SUBSET_ID: swedish_medical_ner
INFO:__main__:self.SCHEMA: None
INFO:__main__:self.DATA_DIR: None
INFO:__main__:Checking for _SUPPORTED_TASKS ...
INFO:__main__:Found _SUPPORTED_TASKS=[<Tasks.NAMED_ENTITY_RECOGNITION: 'NER'>]
INFO:__main__:_SUPPORTED_TASKS implies _MAPPED_SCHEMAS={'KB'}
INFO:__main__:schemas_to_check: {'KB'}
INFO:__main__:Checking load_dataset with config name swedish_medical_ner_source
Downloading and preparing dataset swedish_medical_ner_dataset/swedish_medical_ner_source to /Users/bo/.cache/huggingface/datasets/swedish_medical_ner_dataset/swedish_medical_ner_source/1.0.0/edd3c2bb994079bebf5c6350639ad35d09b03802b02ee8047cd55e700f1499f4...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 2499.59it/s]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 945.73it/s]
Dataset swedish_medical_ner_dataset downloaded and prepared to /Users/bo/.cache/huggingface/datasets/swedish_medical_ner_dataset/swedish_medical_ner_source/1.0.0/edd3c2bb994079bebf5c6350639ad35d09b03802b02ee8047cd55e700f1499f4. Subsequent calls will reuse this data.
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 99.17it/s]
INFO:__main__:Checking load_dataset with config name swedish_medical_ner_bigbio_kb
Downloading and preparing dataset swedish_medical_ner_dataset/swedish_medical_ner_bigbio_kb to /Users/bo/.cache/huggingface/datasets/swedish_medical_ner_dataset/swedish_medical_ner_bigbio_kb/1.0.0/edd3c2bb994079bebf5c6350639ad35d09b03802b02ee8047cd55e700f1499f4...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 5701.36it/s]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 1169.20it/s]
Dataset swedish_medical_ner_dataset downloaded and prepared to /Users/bo/.cache/huggingface/datasets/swedish_medical_ner_dataset/swedish_medical_ner_bigbio_kb/1.0.0/edd3c2bb994079bebf5c6350639ad35d09b03802b02ee8047cd55e700f1499f4. Subsequent calls will reuse this data.
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 39.97it/s]
INFO:__main__:Checking global ID uniqueness
INFO:__main__:Found 2469542 unique IDs
INFO:__main__:Gathering schema statistics
WARNING:__main__:Found instances of 'normalized' but there seems to be no task in 'SUPPORTED_TASKS' for them. Is 'SUPPORTED_TASKS' correct?
INFO:__main__:Gathering schema statistics
train
==========
id: 745084
document_id: 745084
passages: 745084
entities: 979374
normalized: 979374
events: 0
coreferences: 0
relations: 0

INFO:__main__:Checking if referenced IDs are properly mapped
INFO:__main__:KB ONLY: Checking passage offsets
INFO:__main__:KB ONLY: Checking entity offsets
INFO:__main__:KB ONLY: Checking event offsets
INFO:__main__:KB ONLY: Checking coref offsets
.
----------------------------------------------------------------------
Ran 1 test in 1669.193s

OK
```
