### PR TITLE
Closes #220

### DIFF
--- a/biodatasets/n2c2_2014/n2c2_2014.py
+++ b/biodatasets/n2c2_2014/n2c2_2014.py
@@ -1,0 +1,396 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A dataset loader for the n2c2 2014  Deidentification & Heart Disease.
+
+https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/
+
+The dataset consists of 6  archive files,
+
+* 2014_training-PHI-Gold-Set1.tar.gz
+* training-PHI-Gold-Set2.tar.gz
+* testing-PHI-Gold-fixed.tar.gz
+* training-RiskFactors-Gold-Set1.tar.gz
+* training-RiskFactors-Gold-Set2.tar.gz
+* testing-RiskFactors-Gold.tar.gz
+
+Each tar.gz contain a set of .xml files. One .xml per clinical report.
+The file names follow a consistent pattern with the first set of digits identifying the
+patient and the last set of digits identifying the sequential record number
+
+ie: XXX-YY.xml
+where XXX is the patient number,  and YY is the record number.
+
+Example: 320-03.xml
+This is the third (03) record for patient 320
+
+Each file has a root level xml node which will contain a
+<TEXT> node that holds the medical annotation text and a <TAGS> node containing
+annotations for the document text.
+
+
+The files comprising this dataset must be on the users local machine
+in a single directory that is passed to `datasets.load_datset` via
+the `data_dir` kwarg. This loader script will read the archive files
+directly (i.e. the user should not uncompress, untar or unzip any of
+the files). For example, if the following directory structure exists
+on the users local machine,
+
+
+n2c2_2014
+├── 2014_training-PHI-Gold-Set1.tar.gz
+├── training-PHI-Gold-Set2.tar.gz
+├── testing-PHI-Gold-fixed.tar.gz
+├── training-RiskFactors-Gold-Set1.tar.gz
+├── training-RiskFactors-Gold-Set2.tar.gz
+├── testing-RiskFactors-Gold.tar.gz
+
+Data Access
+
+from https://www.i2b2.org/NLP/DataSets/Main.php
+
+"As always, you must register AND submit a DUA for access. If you previously
+accessed the data sets here on i2b2.org, you will need to set a new password
+for your account on the Data Portal, but your original DUA will be retained."
+
+Made in collaboration with @JoaoRacedo
+"""
+
+import itertools as it
+import os
+import re
+import tarfile
+import xml.etree.ElementTree as et
+from typing import Dict, List, Tuple
+
+import datasets
+
+from utils import schemas
+from utils.configs import BigBioConfig
+from utils.constants import Tasks
+
+# TODO: Add BibTeX citation
+_CITATION = """\
+@article{
+title = {Automated systems for the de-identification of longitudinal
+clinical narratives: Overview of 2014 i2b2/UTHealth shared task Track 1},
+journal = {Journal of Biomedical Informatics},
+volume = {58},
+pages = {S11-S19},
+year = {2015},
+issn = {1532-0464},
+doi = {https://doi.org/10.1016/j.jbi.2015.06.007},
+url = {https://www.sciencedirect.com/science/article/pii/S1532046415001173},
+author = {Amber Stubbs and Christopher Kotfila and Özlem Uzuner}
+}
+"""
+
+_DATASETNAME = "n2c2_2014"
+
+_GENERAL_DESCRIPTION = """\
+The 2014 i2b2/UTHealth Natural Language Processing (NLP) shared task featured two tracks.
+The first of these was the de-identification track focused on identifying protected health
+information (PHI) in longitudinal clinical narratives. The second track focused on the
+identification of cardiac risk factors
+"""
+
+
+_DESCRIPTION_TRACK_1 = """
+\nTRACK 1: NER PHI\n
+HIPAA requires that patient medical records have all identifying information removed in order to
+protect patient privacy. There are 18 categories of Protected Health Information (PHI) identifiers of the
+patient or of relatives, employers, or household members of the patient that must be removed in order
+for a file to be considered de-identified.
+
+In order to de-identify the records, each file has PHI marked up. All PHI has an
+XML tag indicating its category and type, where applicable. For the purposes of this task,
+the 18 HIPAA categories have been grouped into 6 main categories and 25 sub categories
+"""
+
+_DESCRIPTION_TRACK_2 = """
+\nTRACK 2: CARDIAC RISK FACTORS\n
+This task consist on a set of medical documents that track the progression of heart disease
+in diabetic patients. Multiple records are annotated for each patient, which will allow a general
+timeline from the set. This project uses tags and attributes used to indicate the presence
+and progression of disease (diabetes, heart disease), associated risk factors (hypertension,
+hyperlipidemia, smoking status, obesity status, and family history), and the time they were present in
+the patient's medical history.
+"""
+
+_DESCRIPTIONS = {
+    "track1": _GENERAL_DESCRIPTION + _DESCRIPTION_TRACK_1,
+    "track2": _GENERAL_DESCRIPTION + _DESCRIPTION_TRACK_2,
+    "full_task": _GENERAL_DESCRIPTION + _DESCRIPTION_TRACK_1 + _DESCRIPTION_TRACK_2,
+}
+_HOMEPAGE = "https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/"
+
+_LICENSE = "DUA-C/NC"
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.TEXT_CLASSIFICATION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class n2c2_2014(datasets.GeneratorBasedBuilder):
+    """n2c2 2014"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="n2c2_2014_source",
+            version=SOURCE_VERSION,
+            description="n2c2_2014 source schema",
+            schema="source",
+            subset_id="full_task",
+        ),
+        BigBioConfig(
+            name="n2c2_2014_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="n2c2_2014 BigBio schema",
+            schema="bigbio_kb",
+            subset_id="track1",
+        ),
+        BigBioConfig(
+            name="n2c2_2014_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="n2c2_2014 BigBio schema",
+            schema="bigbio_text",
+            subset_id="track2",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "n2c2_2014_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "cardiac_risk_factors": [
+                        {
+                            "id": datasets.Value("string"),
+                            "risk_factor": datasets.Value("string"),
+                            "indicator": datasets.Value("string"),
+                            "time": datasets.Value("string"),
+                            "status": datasets.Value("string"),
+                            "type1": datasets.Value("string"),
+                            "type2": datasets.Value("string"),
+                            "comment": datasets.Value("string"),
+                        }
+                    ],
+                    "phi": [
+                        {
+                            "id": datasets.Value("string"),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "type": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                            "comment": datasets.Value("string"),
+                        }
+                    ],
+                },
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = schemas.kb_features
+
+        elif self.config.schema == "bigbio_text":
+            features = schemas.text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTIONS[self.config.subset_id],
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        if self.config.data_dir is None:
+            raise ValueError("This is a local dataset. Please pass the data_dir kwarg to load_dataset.")
+        else:
+            data_dir = self.config.data_dir
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "file_names": [
+                        ("2014_training-PHI-Gold-Set1.tar.gz", "track1"),
+                        ("training-PHI-Gold-Set2.tar.gz", "track1"),
+                        ("training-RiskFactors-Gold-Set1.tar.gz", "track2"),
+                        ("training-RiskFactors-Gold-Set2.tar.gz", "track2"),
+                    ],
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "file_names": [
+                        ("testing-PHI-Gold-fixed.tar.gz", "track1"),
+                        ("testing-RiskFactors-Gold.tar.gz", "track2"),
+                    ],
+                },
+            ),
+        ]
+
+    def _generate_examples(self, data_dir, file_names: List[Tuple]) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        if self.config.schema == "source":
+            uid = it.count(0)
+            for fname, task in file_names:
+                full_path = os.path.join(data_dir, fname)
+                for x in self._read_tar_gz(full_path):
+                    xml_flag = x["xml_flag"]
+                    if xml_flag:
+                        if task == "track1":
+                            document = self._read_task1_file(file_object=x["file_object"], file_name=x["file_name"])
+                        elif task == "track2":
+                            pass
+                        document["id"] = next(uid)
+
+        elif self.config.schema == "bigbio_kb":
+            uid = it.count(0)
+            for fname, task in file_names:
+                full_path = os.path.join(data_dir, fname)
+                for x in self._read_tar_gz(full_path):
+                    xml_flag = x["xml_flag"]
+                    if xml_flag:
+                        if task == "track1":
+                            document = self._read_task1_file(file_object=x["file_object"], file_name=x["file_name"])
+                            document["id"] = next(uid)
+                            entity_list = document.pop("phi")
+                            full_text = document.pop("text")
+                            entities_ = []
+                            for entity in entity_list:
+                                entities_.append(
+                                    {
+                                        "id": next(uid),
+                                        "type": entity["type"],
+                                        "text": entity["text"],
+                                        "offsets": entity["offsets"],
+                                        "normalized": entity["normalized"],
+                                    }
+                                )
+                            document["entities"] = entities_
+
+                            document["passages"] = [
+                                {
+                                    "id": next(uid),
+                                    "type": "full_text",
+                                    "text": [full_text],
+                                    "offsets": [[0, len(full_text)]],
+                                },
+                            ]
+
+                            # additional fields required that can be empty
+                            document["relations"] = []
+                            document["events"] = []
+                            document["coreferences"] = []
+                            yield document["document_id"], document
+
+        elif self.config.schema == "bigbio_text":
+            uid = it.count(0)
+            for fname, task in file_names:
+                full_path = os.path.join(data_dir, fname)
+                for x in self._read_tar_gz(full_path):
+                    xml_flag = x["xml_flag"]
+                    if xml_flag:
+                        if task == "track2":
+                            document = self._read_task2_file(file_object=x["file_object"], file_name=x["file_name"])
+                            document["id"] = next(uid)
+
+                            labels = []
+                            risk_factors = document.pop("cardiac_risk_factors")
+                            for label in risk_factors:
+                                label_list = []
+                                for key, value in label.items():
+                                    if value != "" and key not in ["comment", "id"]:
+                                        label_list.append(value)
+                                labels.append("-".join(label_list))
+                            document["labels"] = labels
+
+                            yield document["id"], document
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")
+
+    def _read_tar_gz(self, fpath: str) -> Dict:
+        """
+        Read .tar.gz file
+        """
+        # Open tar file
+        tf = tarfile.open(fpath, "r:gz")
+
+        for tf_member in tf.getmembers():
+            file_object = tf.extractfile(tf_member)
+            name = tf_member.name
+            file_name = os.path.basename(name).split(".")[0]
+            if re.search(r"\.xml", name) is not None:
+                xml_flag = True
+            else:
+                xml_flag = False
+            yield {"file_object": file_object, "file_name": file_name, "xml_flag": xml_flag}
+
+    def _read_task1_file(self, file_object, file_name):
+        xmldoc = et.parse(file_object).getroot()
+        entities = xmldoc.findall("TAGS")[0]
+        text = xmldoc.findall("TEXT")[0].text
+        phi = []
+        for entity in entities:
+            phi.append(
+                {
+                    "id": entity.attrib["id"],
+                    "offsets": [[entity.attrib["start"], entity.attrib["end"]]],
+                    "type": entity.attrib["TYPE"],
+                    "text": [entity.attrib["text"]],
+                    "comment": entity.attrib["comment"],
+                    "normalized": [],
+                }
+            )
+
+        document = {"document_id": file_name, "text": text, "phi": phi}
+        return document
+
+    def _read_task2_file(self, file_object, file_name):
+        # Fix the file
+        bad_tag = b"<?xml version='1.0' encoding='UTF-8'?>"
+        old_xml = file_object.read()
+        new_xml = old_xml.replace(bad_tag, bytes())
+        xmldoc = et.fromstring(new_xml)
+
+        # Find all tags
+        entities = xmldoc.findall("TAGS")[0]
+        text = xmldoc.findall("TEXT")[0].text
+        risk_factors = []
+        for entity in entities:
+            risk_factor = {x: "" for x in ["indicator", "time", "status", "type1", "type2", "comment"]}
+            for key, value in entity.attrib.items():
+                risk_factor[key] = value
+
+            risk_factor["risk_factor"] = entity.tag
+            risk_factors.append(risk_factor)
+
+        document = {"document_id": file_name, "text": text, "cardiac_risk_factors": risk_factors}
+        return document


### PR DESCRIPTION
Please name your PR after the issue it closes. You can use the following line: "Closes #ISSUE-NUMBER" where you replace the ISSUE-NUMBER with the one corresponding to your dataset.

If the following information is NOT present in the issue, please populate:

- **Name:** *name of the dataset*
- **Description:** *short description of the dataset (or link to social media or blog post)*
- **Paper:** *link to the dataset paper if available*
- **Data:** *link to the online home of the dataset*

### Checkbox

- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `biodatasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_BIGBIO_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `BigBioConfig` for the source schema and one for a bigbio schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_bigbio biodatasets/my_dataset/my_dataset.py`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.


```bash
(bigscience-biomedical) root@docker-desktop:/workspaces/biomedical# python -m tests.test_bigbio biodatasets/n2c2_2014/n2c2_2014.py --data_dir /workspaces/biomedical/biodatasets/n2c2_2014/tar_gz
INFO:__main__:args: Namespace(path='biodatasets/n2c2_2014/n2c2_2014.py', schema=None, subset_id=None, data_dir='/workspaces/biomedical/biodatasets/n2c2_2014/tar_gz', use_auth_token=None)
INFO:__main__:self.PATH: biodatasets/n2c2_2014/n2c2_2014.py
INFO:__main__:self.SUBSET_ID: n2c2_2014
INFO:__main__:self.SCHEMA: None
INFO:__main__:self.DATA_DIR: /workspaces/biomedical/biodatasets/n2c2_2014/tar_gz
INFO:__main__:Checking for _SUPPORTED_TASKS ...
INFO:__main__:Found _SUPPORTED_TASKS=[<Tasks.NAMED_ENTITY_RECOGNITION: 'NER'>, <Tasks.TEXT_CLASSIFICATION: 'TXTCLASS'>]
INFO:__main__:_SUPPORTED_TASKS implies _MAPPED_SCHEMAS={'KB', 'TEXT'}
INFO:__main__:schemas_to_check: {'KB', 'TEXT'}
INFO:__main__:Checking load_dataset with config name n2c2_2014_source
WARNING:datasets.builder:Using custom data configuration n2c2_2014_source-57e9df040ed9f011
Downloading and preparing dataset n2c2_2014/n2c2_2014_source to /home/jovyan/.cache/huggingface/datasets/n2c2_2014/n2c2_2014_source-57e9df040ed9f011/1.0.0/1e3e609086987a589ee6db853ac5c55fe73648c31096f144bb0dbbd670cb2f72...
Dataset n2c2_2014 downloaded and prepared to /home/jovyan/.cache/huggingface/datasets/n2c2_2014/n2c2_2014_source-57e9df040ed9f011/1.0.0/1e3e609086987a589ee6db853ac5c55fe73648c31096f144bb0dbbd670cb2f72. Subsequent calls will reuse this data.
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 282.37it/s]
INFO:__main__:Checking load_dataset with config name n2c2_2014_bigbio_kb
WARNING:datasets.builder:Using custom data configuration n2c2_2014_bigbio_kb-57e9df040ed9f011
Downloading and preparing dataset n2c2_2014/n2c2_2014_bigbio_kb to /home/jovyan/.cache/huggingface/datasets/n2c2_2014/n2c2_2014_bigbio_kb-57e9df040ed9f011/1.0.0/1e3e609086987a589ee6db853ac5c55fe73648c31096f144bb0dbbd670cb2f72...
Dataset n2c2_2014 downloaded and prepared to /home/jovyan/.cache/huggingface/datasets/n2c2_2014/n2c2_2014_bigbio_kb-57e9df040ed9f011/1.0.0/1e3e609086987a589ee6db853ac5c55fe73648c31096f144bb0dbbd670cb2f72. Subsequent calls will reuse this data.
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 384.62it/s]
INFO:__main__:Checking load_dataset with config name n2c2_2014_bigbio_text
WARNING:datasets.builder:Using custom data configuration n2c2_2014_bigbio_text-57e9df040ed9f011
Downloading and preparing dataset n2c2_2014/n2c2_2014_bigbio_text to /home/jovyan/.cache/huggingface/datasets/n2c2_2014/n2c2_2014_bigbio_text-57e9df040ed9f011/1.0.0/1e3e609086987a589ee6db853ac5c55fe73648c31096f144bb0dbbd670cb2f72...
Dataset n2c2_2014 downloaded and prepared to /home/jovyan/.cache/huggingface/datasets/n2c2_2014/n2c2_2014_bigbio_text-57e9df040ed9f011/1.0.0/1e3e609086987a589ee6db853ac5c55fe73648c31096f144bb0dbbd670cb2f72. Subsequent calls will reuse this data.
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 514.01it/s]
INFO:__main__:Checking global ID uniqueness
INFO:__main__:Found 12490 unique IDs
INFO:__main__:Gathering schema statistics
INFO:__main__:Gathering schema statistics
train
==========
id: 790
document_id: 790
passages: 790
entities: 17405
normalized: 0
events: 0
coreferences: 0
relations: 0

test
==========
id: 514
document_id: 514
passages: 514
entities: 11462
normalized: 0
events: 0
coreferences: 0
relations: 0

INFO:__main__:Checking if referenced IDs are properly mapped
INFO:__main__:KB ONLY: Checking passage offsets
INFO:__main__:KB ONLY: Checking entity offsets

<SPECIFIC ERRORS ARE HIDDEN> 

There are features with wrong offsets! This is not a hard failure, as it is common for this type of datasets. However, if the error list is long (e.g. >10) you should double check your code. 


INFO:__main__:KB ONLY: Checking event offsets
INFO:__main__:KB ONLY: Checking coref offsets
INFO:__main__:Checking global ID uniqueness
INFO:__main__:Found 514 unique IDs
INFO:__main__:Gathering schema statistics
INFO:__main__:Gathering schema statistics
train
==========
id: 790
document_id: 790
text: 790
labels: 16501

test
==========
id: 514
document_id: 514
text: 514
labels: 10970

.
----------------------------------------------------------------------
Ran 1 test in 11.258s

OK
```