### PR TITLE
Only include notes in the source parse when `parse_notes == True`

### DIFF
--- a/utils/parsing.py
+++ b/utils/parsing.py
@@ -157,7 +157,10 @@ def parse_brat_file(txt_file: Path, annotation_file_suffixes: List[str] = None,
     example["equivalences"] = []
     example["attributes"] = []
     example["normalizations"] = []
-    example["notes"] = []
+
+    if parse_notes:
+        example["notes"] = []
+
     for line in ann_lines:
         line = line.strip()
         if not line:


### PR DESCRIPTION
Only include `notes` in the source parse schema when `parse_notes == True`. This was included regardless of the status of `parse_notes` which leads to failures for all datasets using `parse_brat` which do not need annotator notes.