### PR TITLE
try another version of null constant

### DIFF
--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,5 +1,8 @@
 from enum import Enum
+from types import SimpleNamespace
 
+
+BigBioValues = SimpleNamespace(NULL="<BB_NULL_STR>")
 
 class Tasks(Enum):
     NAMED_ENTITY_RECOGNITION = "NER"


### PR DESCRIPTION
try another version of null constant
(is being used https://github.com/bigscience-workshop/biomedical/blob/master/biodatasets/pubmed_qa/pubmed_qa.py#L241)
the problem before was that an enum value wasn't serializable .. a simple string should be fine.