### PR TITLE
Fixes download of three STS datasets

### DIFF
--- a/biodatasets/mayosrs/mayosrs.py
+++ b/biodatasets/mayosrs/mayosrs.py
@@ -19,6 +19,7 @@ nine medical coders and three physicians from the Mayo Clinic.
 """
 
 import csv
+import requests
 from typing import Dict, List, Tuple
 
 import datasets
@@ -51,14 +52,10 @@ _HOMEPAGE = "https://nlp.cs.vcu.edu/data.html#mayosrs"
 _LICENSE = "Unknown"
 
 _URLS = {
-    "source": [
+    "mayosrs": [
         "https://nlp.cs.vcu.edu/data/similarity-data/MayoSRS.gold",
         "https://nlp.cs.vcu.edu/data/similarity-data/MayoSRS.terms",
-    ],
-    "bigbio_pairs": [
-        "https://nlp.cs.vcu.edu/data/similarity-data/MayoSRS.gold",
-        "https://nlp.cs.vcu.edu/data/similarity-data/MayoSRS.terms",
-    ],
+    ]
 }
 
 _SUPPORTED_TASKS = [
@@ -123,8 +120,13 @@ class MayosrsDataset(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
 
-        urls = _URLS[self.config.schema]
-        data_dir = dl_manager.download_and_extract(urls)
+        urls = _URLS[_DATASETNAME]
+        def custom_download(src_url: str, dst_path: str):
+            cookies = {'NotificationDone': "true"}
+            response = requests.get(src_url, cookies=cookies)
+            with open(dst_path, "w") as handle:
+                handle.write(response.text)
+        data_dir = dl_manager.download_custom(urls, custom_download)
 
         return [
             datasets.SplitGenerator(

--- a/biodatasets/mayosrs/mayosrs.py
+++ b/biodatasets/mayosrs/mayosrs.py
@@ -19,10 +19,11 @@ nine medical coders and three physicians from the Mayo Clinic.
 """
 
 import csv
-import requests
 from typing import Dict, List, Tuple
 
 import datasets
+import requests
+
 from bigbio.utils import schemas
 from bigbio.utils.configs import BigBioConfig
 from bigbio.utils.constants import Tasks
@@ -121,11 +122,13 @@ class MayosrsDataset(datasets.GeneratorBasedBuilder):
         """Returns SplitGenerators."""
 
         urls = _URLS[_DATASETNAME]
+
         def custom_download(src_url: str, dst_path: str):
-            cookies = {'NotificationDone': "true"}
+            cookies = {"NotificationDone": "true"}
             response = requests.get(src_url, cookies=cookies)
             with open(dst_path, "w") as handle:
                 handle.write(response.text)
+
         data_dir = dl_manager.download_custom(urls, custom_download)
 
         return [

--- a/biodatasets/mayosrs/mayosrs.py
+++ b/biodatasets/mayosrs/mayosrs.py
@@ -52,7 +52,7 @@ _HOMEPAGE = "https://nlp.cs.vcu.edu/data.html#mayosrs"
 _LICENSE = "Unknown"
 
 _URLS = {
-    "mayosrs": [
+    _DATASETNAME: [
         "https://nlp.cs.vcu.edu/data/similarity-data/MayoSRS.gold",
         "https://nlp.cs.vcu.edu/data/similarity-data/MayoSRS.terms",
     ]

--- a/biodatasets/minimayosrs/minimayosrs.py
+++ b/biodatasets/minimayosrs/minimayosrs.py
@@ -19,6 +19,7 @@ nine medical coders and three physicians from the Mayo Clinic.
 """
 
 import csv
+import requests
 from typing import Dict, List, Tuple
 
 import datasets
@@ -51,12 +52,7 @@ _HOMEPAGE = "https://nlp.cs.vcu.edu/data.html#minimayosrs"
 _LICENSE = "Unknown"
 
 _URLS = {
-    "source": [
-        "https://nlp.cs.vcu.edu/data/similarity-data/MiniMayoSRS.terms",
-        "https://nlp.cs.vcu.edu/data/similarity-data/MiniMayoSRS.physicians",
-        "https://nlp.cs.vcu.edu/data/similarity-data/MiniMayoSRS.coders",
-    ],
-    "bigbio_pairs": [
+    "minimayosrs": [
         "https://nlp.cs.vcu.edu/data/similarity-data/MiniMayoSRS.terms",
         "https://nlp.cs.vcu.edu/data/similarity-data/MiniMayoSRS.physicians",
         "https://nlp.cs.vcu.edu/data/similarity-data/MiniMayoSRS.coders",
@@ -130,8 +126,13 @@ class MinimayosrsDataset(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
 
-        urls = _URLS[self.config.schema]
-        data_dir = dl_manager.download_and_extract(urls)
+        urls = _URLS[_DATASETNAME]
+        def custom_download(src_url: str, dst_path: str):
+            cookies = {'NotificationDone': "true"}
+            response = requests.get(src_url, cookies=cookies)
+            with open(dst_path, "w") as handle:
+                handle.write(response.text)
+        data_dir = dl_manager.download_custom(urls, custom_download)
 
         return [
             datasets.SplitGenerator(

--- a/biodatasets/minimayosrs/minimayosrs.py
+++ b/biodatasets/minimayosrs/minimayosrs.py
@@ -52,7 +52,7 @@ _HOMEPAGE = "https://nlp.cs.vcu.edu/data.html#minimayosrs"
 _LICENSE = "Unknown"
 
 _URLS = {
-    "minimayosrs": [
+    _DATASETNAME: [
         "https://nlp.cs.vcu.edu/data/similarity-data/MiniMayoSRS.terms",
         "https://nlp.cs.vcu.edu/data/similarity-data/MiniMayoSRS.physicians",
         "https://nlp.cs.vcu.edu/data/similarity-data/MiniMayoSRS.coders",

--- a/biodatasets/minimayosrs/minimayosrs.py
+++ b/biodatasets/minimayosrs/minimayosrs.py
@@ -19,10 +19,11 @@ nine medical coders and three physicians from the Mayo Clinic.
 """
 
 import csv
-import requests
 from typing import Dict, List, Tuple
 
 import datasets
+import requests
+
 from bigbio.utils import schemas
 from bigbio.utils.configs import BigBioConfig
 from bigbio.utils.constants import Tasks
@@ -127,11 +128,13 @@ class MinimayosrsDataset(datasets.GeneratorBasedBuilder):
         """Returns SplitGenerators."""
 
         urls = _URLS[_DATASETNAME]
+
         def custom_download(src_url: str, dst_path: str):
-            cookies = {'NotificationDone': "true"}
+            cookies = {"NotificationDone": "true"}
             response = requests.get(src_url, cookies=cookies)
             with open(dst_path, "w") as handle:
                 handle.write(response.text)
+
         data_dir = dl_manager.download_custom(urls, custom_download)
 
         return [

--- a/biodatasets/umnsrs/umnsrs.py
+++ b/biodatasets/umnsrs/umnsrs.py
@@ -23,10 +23,11 @@ Therefore, as suggested by Pakhomov and colleagues, the subset below consists of
 """
 
 import csv
-import requests
 from typing import Dict, List, Tuple
 
 import datasets
+import requests
+
 from bigbio.utils import schemas
 from bigbio.utils.configs import BigBioConfig
 from bigbio.utils.constants import Tasks
@@ -127,11 +128,13 @@ class MayosrsDataset(datasets.GeneratorBasedBuilder):
         """Returns SplitGenerators."""
 
         urls = _URLS[_DATASETNAME]
+
         def custom_download(src_url: str, dst_path: str):
-            cookies = {'NotificationDone': "true"}
+            cookies = {"NotificationDone": "true"}
             response = requests.get(src_url, cookies=cookies)
             with open(dst_path, "w") as handle:
                 handle.write(response.text)
+
         data_dir = dl_manager.download_custom(urls, custom_download)
 
         return [

--- a/biodatasets/umnsrs/umnsrs.py
+++ b/biodatasets/umnsrs/umnsrs.py
@@ -23,6 +23,7 @@ Therefore, as suggested by Pakhomov and colleagues, the subset below consists of
 """
 
 import csv
+import requests
 from typing import Dict, List, Tuple
 
 import datasets
@@ -59,8 +60,7 @@ _HOMEPAGE = "https://nlp.cs.vcu.edu/data.html#umnsrs"
 _LICENSE = "Unknown"
 
 _URLS = {
-    "source": ["https://nlp.cs.vcu.edu/data/similarity-data/UMNSRS_similarity.csv"],
-    "bigbio_pairs": ["https://nlp.cs.vcu.edu/data/similarity-data/UMNSRS_similarity.csv"],
+    _DATASETNAME: "https://nlp.cs.vcu.edu/data/similarity-data/UMNSRS_similarity.csv",
 }
 
 _SUPPORTED_TASKS = [
@@ -126,8 +126,13 @@ class MayosrsDataset(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
 
-        urls = _URLS[self.config.schema]
-        data_dir = dl_manager.download_and_extract(urls)
+        urls = _URLS[_DATASETNAME]
+        def custom_download(src_url: str, dst_path: str):
+            cookies = {'NotificationDone': "true"}
+            response = requests.get(src_url, cookies=cookies)
+            with open(dst_path, "w") as handle:
+                handle.write(response.text)
+        data_dir = dl_manager.download_custom(urls, custom_download)
 
         return [
             datasets.SplitGenerator(
@@ -143,10 +148,9 @@ class MayosrsDataset(datasets.GeneratorBasedBuilder):
         """Yields examples as (key, example) tuples."""
 
         if split == "train":
-            combined_file = filepath[0]
-
+            print(filepath)
             data = []
-            with open(combined_file, encoding="utf-8") as csv_file:
+            with open(filepath, encoding="utf-8") as csv_file:
                 csv_reader = csv.reader(
                     csv_file, quotechar='"', delimiter=",", quoting=csv.QUOTE_ALL, skipinitialspace=True
                 )


### PR DESCRIPTION
Currently for the datasets mayosrs, its subset minimayosrs and umnsrs, dataloader scripts currently fail to download the correct files and downloads a HTML instead. This is due to the cookie consent not set (nlp.cs.vcu.edu sets this as a cookie if the user gave his consent for cookies) and nlp.cs.vcu.edu is redirecting to a website to query the consent. 

These changes use a custom download function to set the cookie "NotificationDone" to true.

Mayosrs #161
Minimayosrs #162
Umnsrs #155

Current test output mayosrs
```batch
File "...\mayosrs.py", line 152, in _generate_examples
    label, code1, code2 = row[0].split("<>")
ValueError: not enough values to unpack (expected 3, got 1)
```

Current test output minimayosrs
```batch
  File "...minimayosrs.py", line 161, in 
_generate_examples
    text_1, text_2 = row[0].split("<>")
ValueError: not enough values to unpack (expected 2, got 1)
```

Current test output of umnsrs:
```batch
  File "...minimayosrs.py", line 161, in 
_generate_examples
     mean_score, std_score, text_1, text_2, code_1, code_2 = row
ValueError: not enough values to unpack (expected 6, got 1)
```
