### PR TITLE
BioASQ Task B Fixes for 2014-2016 (BioASQ2-BioASQ4)

### DIFF
--- a/biodatasets/bioasq_task_b/bioasq_task_b.py
+++ b/biodatasets/bioasq_task_b/bioasq_task_b.py
@@ -575,6 +575,8 @@ class BioasqTaskBDataset(datasets.GeneratorBasedBuilder):
                     }
 
         elif self.config.schema == "bigbio_qa":
+            # NOTE: Years 2014-2016 (BioASQ2-BioASQ4) have duplicate records 
+            cache = set()
             with open(filepath, encoding="utf-8") as file:
                 uid = 0
                 data = json.load(file)
@@ -583,14 +585,18 @@ class BioasqTaskBDataset(datasets.GeneratorBasedBuilder):
                     if "snippets" not in record:
                         continue
                     for i, snippet in enumerate(record["snippets"]):
-                        yield uid, {
-                            "id": f'{record["id"]}_{i}',
-                            "document_id": snippet["document"],
-                            "question_id": record["id"],
-                            "question": record["body"],
-                            "type": record["type"],
-                            "choices": [],
-                            "context": snippet["text"],
-                            "answer": self._get_exact_answer(record),
-                        }
-                        uid += 1
+                        key = f'{record["id"]}_{i}'
+                        # ignore duplicate records
+                        if key not in cache:
+                            cache.add(key)
+                            yield uid, {
+                                "id": key,
+                                "document_id": snippet["document"],
+                                "question_id": record["id"],
+                                "question": record["body"],
+                                "type": record["type"],
+                                "choices": [],
+                                "context": snippet["text"],
+                                "answer": self._get_exact_answer(record),
+                            }
+                            uid += 1

--- a/examples/bioasq_task_b.py
+++ b/examples/bioasq_task_b.py
@@ -575,6 +575,8 @@ class BioasqTaskBDataset(datasets.GeneratorBasedBuilder):
                     }
 
         elif self.config.schema == "bigbio_qa":
+            # NOTE: Years 2014-2016 (BioASQ2-BioASQ4) have duplicate records 
+            cache = set()
             with open(filepath, encoding="utf-8") as file:
                 uid = 0
                 data = json.load(file)
@@ -583,14 +585,18 @@ class BioasqTaskBDataset(datasets.GeneratorBasedBuilder):
                     if "snippets" not in record:
                         continue
                     for i, snippet in enumerate(record["snippets"]):
-                        yield uid, {
-                            "id": f'{record["id"]}_{i}',
-                            "document_id": snippet["document"],
-                            "question_id": record["id"],
-                            "question": record["body"],
-                            "type": record["type"],
-                            "choices": [],
-                            "context": snippet["text"],
-                            "answer": self._get_exact_answer(record),
-                        }
-                        uid += 1
+                        key = f'{record["id"]}_{i}'
+                        # ignore duplicate records
+                        if key not in cache:
+                            cache.add(key)
+                            yield uid, {
+                                "id": key,
+                                "document_id": snippet["document"],
+                                "question_id": record["id"],
+                                "question": record["body"],
+                                "type": record["type"],
+                                "choices": [],
+                                "context": snippet["text"],
+                                "answer": self._get_exact_answer(record),
+                            }
+                            uid += 1


### PR DESCRIPTION
… duplicate records. This fix ensures each record emitted for the  schema is unique.  schema is left unchanges to preserve original dataset.

Please name your PR after the issue it closes. You can use the following line: "Closes #ISSUE-NUMBER" where you replace the ISSUE-NUMBER with the one corresponding to your dataset.

If the following information is NOT present in the issue, please populate:

- **Name:** *name of the dataset*
- **Description:** *short description of the dataset (or link to social media or blog post)*
- **Paper:** *link to the dataset paper if available*
- **Data:** *link to the online home of the dataset*

### Checkbox

- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `biodatasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_BIGBIO_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `BigBioConfig` for the source schema and one for a bigbio schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_bigbio biodatasets/my_dataset/my_dataset.py`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
