### PR TITLE
Fix dataloader for umnsrs

### DIFF
--- a/biodatasets/umnsrs/umnsrs.py
+++ b/biodatasets/umnsrs/umnsrs.py
@@ -86,7 +86,7 @@ _SOURCE_VERSION = "1.0.0"
 _BIGBIO_VERSION = "1.0.0"
 
 
-class MayosrsDataset(datasets.GeneratorBasedBuilder):
+class UmnsrsDataset(datasets.GeneratorBasedBuilder):
     """UMNSRS, developed by Pakhomov, et al., contains clinical term pairs whose semantic similarity and
     relatedness were scored by experts."""
 

--- a/biodatasets/umnsrs/umnsrs.py
+++ b/biodatasets/umnsrs/umnsrs.py
@@ -172,7 +172,7 @@ class MayosrsDataset(datasets.GeneratorBasedBuilder):
             for id_, row in data.iterrows():
                 yield id_, {
                     "id": id_,
-                    "document_id": "NULL",
+                    "document_id": id_,
                     "text_1": row["text_1"],
                     "text_2": row["text_2"],
                     "label": row["mean_score"],

--- a/biodatasets/umnsrs/umnsrs.py
+++ b/biodatasets/umnsrs/umnsrs.py
@@ -22,10 +22,11 @@ Therefore, as suggested by Pakhomov and colleagues, the subset below consists of
 430 pairs for the relatedness set which each have an ICC equal to 0.73.
 """
 
-import csv
 from typing import Dict, List, Tuple
 
 import datasets
+import pandas as pd
+
 from bigbio.utils import schemas
 from bigbio.utils.configs import BigBioConfig
 from bigbio.utils.constants import Tasks
@@ -48,24 +49,37 @@ _DATASETNAME = "umnsrs"
 _DESCRIPTION = """\
 UMNSRS, developed by Pakhomov, et al., consists of 725 clinical term pairs whose semantic similarity and relatedness.
 The similarity and relatedness of each term pair was annotated based on a continuous scale by having the resident touch
-a bar on a touch sensitive computer screen to indicate the degree of similarity or relatedness. The Intraclass
-Correlation Coefficient (ICC) for the reference standard tagged for similarity was 0.47, and 0.50 for relatedness.
-Therefore, as suggested by Pakhomov and colleagues, the subset below consists of 401 pairs for the similarity set and
-430 pairs for the relatedness set which each have an ICC equal to 0.73.
+a bar on a touch sensitive computer screen to indicate the degree of similarity or relatedness.
+The following subsets are available:
+- similarity: A set of 566 UMLS concept pairs manually rated for semantic similarity (e.g. whale-dolphin) using a
+  continuous response scale.
+- relatedness: A set of 588 UMLS concept pairs manually rated for semantic relatedness (e.g. needle-thread) using a
+  continuous response scale.
+- similarity_mod: Modification of the UMNSRS-Similarity dataset to exclude control samples and those pairs that did not
+  match text in clinical, biomedical and general English corpora. Exact modifications are detailed in the paper (Corpus
+  Domain Effects on Distributional Semantic Modeling of Medical Terms. Serguei V.S. Pakhomov, Greg Finley, Reed McEwan,
+  Yan Wang, and Genevieve B. Melton. Bioinformatics. 2016; 32(23):3635-3644). The resulting dataset contains 449 pairs.
+- relatedness_mod: Modification of the UMNSRS-Relatedness dataset to exclude control samples and those pairs that did
+  not match text in clinical, biomedical and general English corpora. Exact modifications are detailed in the paper
+  (Corpus Domain Effects on Distributional Semantic Modeling of Medical Terms. Serguei V.S. Pakhomov, Greg Finley,
+  Reed McEwan, Yan Wang, and Genevieve B. Melton. Bioinformatics. 2016; 32(23):3635-3644).
+  The resulting dataset contains 458 pairs.
 """
 
-_HOMEPAGE = "https://nlp.cs.vcu.edu/data.html#umnsrs"
+_HOMEPAGE = "https://conservancy.umn.edu/handle/11299/196265/"
 
-_LICENSE = "Unknown"
+_LICENSE = "CC0 1.0 Universal"
+
+_BASE_URL = "https://conservancy.umn.edu/bitstream/handle/11299/196265/"
 
 _URLS = {
-    "source": ["https://nlp.cs.vcu.edu/data/similarity-data/UMNSRS_similarity.csv"],
-    "bigbio_pairs": ["https://nlp.cs.vcu.edu/data/similarity-data/UMNSRS_similarity.csv"],
+    "umnsrs_similarity": _BASE_URL + "UMNSRS_similarity.csv",
+    "umnsrs_relatedness": _BASE_URL + "UMNSRS_relatedness.csv",
+    "umnsrs_similarity_mod": _BASE_URL + "UMNSRS_similarity_mod449_word2vec.csv",
+    "umnsrs_relatedness_mod": _BASE_URL + "UMNSRS_relatedness_mod458_word2vec.csv",
 }
 
-_SUPPORTED_TASKS = [
-    Tasks.SEMANTIC_SIMILARITY
-]  # example: [Tasks.TRANSLATION, Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
+_SUPPORTED_TASKS = [Tasks.SEMANTIC_SIMILARITY]
 
 _SOURCE_VERSION = "1.0.0"
 
@@ -73,30 +87,36 @@ _BIGBIO_VERSION = "1.0.0"
 
 
 class MayosrsDataset(datasets.GeneratorBasedBuilder):
-    """UMNSRS, developed by Pakhomov, et al., consists of 725 clinical term pairs whose semantic similarity and
-    relatedness."""
+    """UMNSRS, developed by Pakhomov, et al., contains clinical term pairs whose semantic similarity and
+    relatedness were scored by experts."""
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
 
-    BUILDER_CONFIGS = [
-        BigBioConfig(
-            name="umnsrs_source",
-            version=SOURCE_VERSION,
-            description="UMNSRS source schema",
-            schema="source",
-            subset_id="umnsrs",
-        ),
-        BigBioConfig(
-            name="umnsrs_bigbio_pairs",
-            version=BIGBIO_VERSION,
-            description="UMNSRS BigBio schema",
-            schema="bigbio_pairs",
-            subset_id="umnsrs",
-        ),
-    ]
+    BUILDER_CONFIGS = []
 
-    DEFAULT_CONFIG_NAME = "umnsrs_source"
+    for subset in ["similarity", "relatedness"]:
+        for mod in ["_mod", ""]:
+            BUILDER_CONFIGS.append(
+                BigBioConfig(
+                    name=f"umnsrs_{subset}{mod}_source",
+                    version=SOURCE_VERSION,
+                    description=f"UMNSRS {subset}{mod} source schema",
+                    schema="source",
+                    subset_id=f"umnsrs_{subset}{mod}",
+                )
+            )
+            BUILDER_CONFIGS.append(
+                BigBioConfig(
+                    name=f"umnsrs_{subset}{mod}_bigbio_pairs",
+                    version=BIGBIO_VERSION,
+                    description=f"UMNSRS {subset}{mod} BigBio schema",
+                    schema="bigbio_pairs",
+                    subset_id=f"umnsrs_{subset}{mod}",
+                )
+            )
+
+    DEFAULT_CONFIG_NAME = "umnsrs_similarity_source"
 
     def _info(self) -> datasets.DatasetInfo:
 
@@ -126,61 +146,34 @@ class MayosrsDataset(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
 
-        urls = _URLS[self.config.schema]
-        data_dir = dl_manager.download_and_extract(urls)
+        urls = _URLS[self.config.subset_id]
+        filepath = dl_manager.download_and_extract(urls)
 
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
                 gen_kwargs={
-                    "filepath": data_dir,
-                    "split": "train",
+                    "filepath": filepath,
                 },
             )
         ]
 
-    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+    def _generate_examples(self, filepath) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
+        print(filepath)
+        data = pd.read_csv(
+            filepath, sep=",", header=0, names=["mean_score", "std_score", "text_1", "text_2", "code_1", "code_2"]
+        )
 
-        if split == "train":
-            combined_file = filepath[0]
-
-            data = []
-            with open(combined_file, encoding="utf-8") as csv_file:
-                csv_reader = csv.reader(
-                    csv_file, quotechar='"', delimiter=",", quoting=csv.QUOTE_ALL, skipinitialspace=True
-                )
-                next(csv_reader)
-                for id_, row in enumerate(csv_reader):
-                    mean_score, std_score, text_1, text_2, code_1, code_2 = row
-                    data.append([mean_score, std_score, text_1, text_2, code_1, code_2])
-
-            if self.config.schema == "source":
-                for id_, row in enumerate(data):
-                    mean_score, std_score, text_1, text_2, code_1, code_2 = row
-
-                    yield id_, {
-                        "mean_score": float(mean_score),
-                        "std_score": float(std_score),
-                        "text_1": text_1,
-                        "text_2": text_2,
-                        "code_1": code_1,
-                        "code_2": code_2,
-                    }
-
-            elif self.config.schema == "bigbio_pairs":
-                uid = 0
-                for id_, row in enumerate(data):
-                    uid += 1
-                    label, _, text_1, text_2, _, _ = row
-                    yield id_, {
-                        "id": uid,  # uid is an unique identifier for every record that starts from 1
-                        "document_id": "NULL",
-                        "text_1": text_1,
-                        "text_2": text_2,
-                        "label": str(label),
-                    }
-
-        else:
-            print("There's no test/val split available for the given dataset")
-            return
+        if self.config.schema == "source":
+            for id_, row in data.iterrows():
+                yield id_, row.to_dict()
+        elif self.config.schema == "bigbio_pairs":
+            for id_, row in data.iterrows():
+                yield id_, {
+                    "id": id_,
+                    "document_id": "NULL",
+                    "text_1": row["text_1"],
+                    "text_2": row["text_2"],
+                    "label": row["mean_score"],
+                }


### PR DESCRIPTION
Rework of dataloader #155:

- Changed source to https://conservancy.umn.edu/handle/11299/196265
  Why: Unit tests failed - The original source could not be programatically downloaded with `download_and_extract` since the it the url automatically redirected to a website for accepting cookies
- Added subset "relatedness"
  Original dataloader implemented the similarity dataset (e.g., whale-dolphin) but not the relatedness dataset (e.g. needle-thread)
- Added subsets "mod"
  There is a modified set for "similarity" and "relatedness" which 'exclude control samples and those pairs that did not match text in clinical, biomedical and general English corpora.', see ref paper in https://conservancy.umn.edu/handle/11299/196265
- Added license
- Doc_id is now sequential int rather than "NULL"