### PR TITLE
Fix dataloader for biosimlex

### DIFF
--- a/biodatasets/bio_simlex/bio_simlex.py
+++ b/biodatasets/bio_simlex/bio_simlex.py
@@ -162,5 +162,5 @@ class BioSimlexDataset(datasets.GeneratorBasedBuilder):
                         "document_id": "NULL",
                         "text_1": word1,
                         "text_2": word2,
-                        "label": str(score),
+                        "label": str(score.strip()),
                     }

--- a/biodatasets/bio_simlex/bio_simlex.py
+++ b/biodatasets/bio_simlex/bio_simlex.py
@@ -159,7 +159,7 @@ class BioSimlexDataset(datasets.GeneratorBasedBuilder):
                 elif self.config.schema == "bigbio_pairs":
                     yield id_, {
                         "id": str(id_),
-                        "document_id": "NULL",
+                        "document_id": str(id_),
                         "text_1": word1,
                         "text_2": word2,
                         "label": str(score.strip()),


### PR DESCRIPTION
Rework of dataloader #154:

- bigbio labels contained newline char in label
- doc_id is now sequential int