### PR TITLE
Fix bionlp_st_2011_rel

### DIFF
--- a/biodatasets/bionlp_st_2011_rel/bionlp_st_2011_rel.py
+++ b/biodatasets/bionlp_st_2011_rel/bionlp_st_2011_rel.py
@@ -67,8 +67,11 @@ _URLs = {
     "bigbio_kb": "https://github.com/openbiocorpora/bionlp-st-2011-rel/archive/refs/heads/master.zip",
 }
 
-_SUPPORTED_TASKS = [Tasks.RELATION_EXTRACTION,
-                    Tasks.NAMED_ENTITY_RECOGNITION,]
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.RELATION_EXTRACTION,
+    Tasks.COREFERENCE_RESOLUTION,
+]
 _SOURCE_VERSION = "1.0.0"
 _BIGBIO_VERSION = "1.0.0"
 
@@ -98,9 +101,7 @@ class bionlp_st_2011_rel(datasets.GeneratorBasedBuilder):
 
     DEFAULT_CONFIG_NAME = "bionlp_st_2011_rel_source"
 
-    _ENTITY_TYPES = {
-        "Entity",
-    }
+    _ENTITY_TYPES = {"Entity", "Protein"}
 
     _FILE_SUFFIX = [".a1", ".rel", ".ann"]
 
@@ -127,7 +128,9 @@ class bionlp_st_2011_rel(datasets.GeneratorBasedBuilder):
                     ],
                     "events": [  # E line in brat
                         {
-                            "trigger": datasets.Value("string"),  # refers to the text_bound_annotation of the trigger,
+                            "trigger": datasets.Value(
+                                "string"
+                            ),  # refers to the text_bound_annotation of the trigger,
                             "id": datasets.Value("string"),
                             "type": datasets.Value("string"),
                             "arguments": datasets.Sequence(
@@ -171,8 +174,12 @@ class bionlp_st_2011_rel(datasets.GeneratorBasedBuilder):
                             "id": datasets.Value("string"),
                             "type": datasets.Value("string"),
                             "ref_id": datasets.Value("string"),
-                            "resource_name": datasets.Value("string"),  # Name of the resource, e.g. "Wikipedia"
-                            "cuid": datasets.Value("string"),  # ID in the resource, e.g. 534366
+                            "resource_name": datasets.Value(
+                                "string"
+                            ),  # Name of the resource, e.g. "Wikipedia"
+                            "cuid": datasets.Value(
+                                "string"
+                            ),  # ID in the resource, e.g. 534366
                             "text": datasets.Value(
                                 "string"
                             ),  # Human readable description/name of the entity, e.g. "Barack Obama"
@@ -191,12 +198,17 @@ class bionlp_st_2011_rel(datasets.GeneratorBasedBuilder):
             citation=_CITATION,
         )
 
-    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
 
         my_urls = _URLs[self.config.schema]
         data_dir = Path(dl_manager.download_and_extract(my_urls))
         data_files = {
-            "train": data_dir / f"bionlp-st-2011-rel-master" / "original-data" / "train",
+            "train": data_dir
+            / f"bionlp-st-2011-rel-master"
+            / "original-data"
+            / "train",
             "dev": data_dir / f"bionlp-st-2011-rel-master" / "original-data" / "devel",
             "test": data_dir / f"bionlp-st-2011-rel-master" / "original-data" / "test",
         }
@@ -227,7 +239,8 @@ class bionlp_st_2011_rel(datasets.GeneratorBasedBuilder):
             txt_files = list(data_files.glob("*txt"))
             for guid, txt_file in enumerate(txt_files):
                 example = parsing.brat_parse_to_bigbio_kb(
-                    parsing.parse_brat_file(txt_file, self._FILE_SUFFIX), entity_types=self._ENTITY_TYPES
+                    parsing.parse_brat_file(txt_file, self._FILE_SUFFIX),
+                    entity_types=self._ENTITY_TYPES,
                 )
                 example["id"] = str(guid)
                 yield guid, example


### PR DESCRIPTION
- failing reference id check was failing because "Protein" was missing from `_ENTIY_TYPE` required from `parse_brat`.
- added COREFERENCE_RESOLUTION task