### PR TITLE
Fix bionlp_st_2013_ge

### DIFF
--- a/biodatasets/bionlp_st_2013_ge/bionlp_st_2013_ge.py
+++ b/biodatasets/bionlp_st_2013_ge/bionlp_st_2013_ge.py
@@ -94,7 +94,28 @@ class bionlp_st_2013_ge(datasets.GeneratorBasedBuilder):
 
     DEFAULT_CONFIG_NAME = "bionlp_st_2013_ge_source"
 
-    _ENTITY_TYPES = {"Protein", "Entity"}
+    # _ENTITY_TYPES = {
+    #     "Protein",
+    #     "Entity",
+    # }
+    _ENTITY_TYPES = [
+        "Phosphorylation",
+        "Acetylation",
+        "Localization",
+        "Ubiquitination",
+        "Anaphora",
+        "Transcription",
+        "Protein_catabolism",
+        "Gene_expression",
+        "Negative_regulation",
+        "Regulation",
+        "Protein_modification",
+        "Protein",
+        "Entity",
+        "Positive_regulation",
+        "Binding",
+        "Deacetylation",
+    ]
 
     def _info(self):
         """
@@ -119,7 +140,9 @@ class bionlp_st_2013_ge(datasets.GeneratorBasedBuilder):
                     ],
                     "events": [  # E line in brat
                         {
-                            "trigger": datasets.Value("string"),  # refers to the text_bound_annotation of the trigger,
+                            "trigger": datasets.Value(
+                                "string"
+                            ),  # refers to the text_bound_annotation of the trigger,
                             "id": datasets.Value("string"),
                             "type": datasets.Value("string"),
                             "arguments": datasets.Sequence(
@@ -163,8 +186,12 @@ class bionlp_st_2013_ge(datasets.GeneratorBasedBuilder):
                             "id": datasets.Value("string"),
                             "type": datasets.Value("string"),
                             "ref_id": datasets.Value("string"),
-                            "resource_name": datasets.Value("string"),  # Name of the resource, e.g. "Wikipedia"
-                            "cuid": datasets.Value("string"),  # ID in the resource, e.g. 534366
+                            "resource_name": datasets.Value(
+                                "string"
+                            ),  # Name of the resource, e.g. "Wikipedia"
+                            "cuid": datasets.Value(
+                                "string"
+                            ),  # ID in the resource, e.g. 534366
                             "text": datasets.Value(
                                 "string"
                             ),  # Human readable description/name of the entity, e.g. "Barack Obama"
@@ -183,7 +210,9 @@ class bionlp_st_2013_ge(datasets.GeneratorBasedBuilder):
             citation=_CITATION,
         )
 
-    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
 
         my_urls = _URLs[self.config.schema]
         data_dir = Path(dl_manager.download_and_extract(my_urls))


### PR DESCRIPTION
It seems that the pattern for the failed check on referenced ids is because of missing types in `_ENTITY_TYPE` for the brat parser.
However, this time if I try to add all the entity type associated to a `T` line I get this error:
```python
Traceback (most recent call last):
  File "/home/ele/Desktop/projects/tm/bigbio/tests/test_bigbio.py", line 133, in runTest
    self.dataset = datasets.load_dataset(
  File "/home/ele/.venv/bigbio/lib/python3.9/site-packages/datasets/load.py", line 1691, in load_dataset
    builder_instance.download_and_prepare(
  File "/home/ele/.venv/bigbio/lib/python3.9/site-packages/datasets/builder.py", line 605, in download_and_prepare
    self._download_and_prepare(
  File "/home/ele/.venv/bigbio/lib/python3.9/site-packages/datasets/builder.py", line 1104, in _download_and_prepare
    super()._download_and_prepare(dl_manager, verify_infos, check_duplicate_keys=verify_infos)
  File "/home/ele/.venv/bigbio/lib/python3.9/site-packages/datasets/builder.py", line 694, in _download_and_prepare
    self._prepare_split(split_generator, **prepare_split_kwargs)
  File "/home/ele/.venv/bigbio/lib/python3.9/site-packages/datasets/builder.py", line 1087, in _prepare_split
    for key, record in logging.tqdm(
  File "/home/ele/.venv/bigbio/lib/python3.9/site-packages/tqdm/std.py", line 1180, in __iter__
    for obj in iterable:
  File "/home/ele/.cache/huggingface/modules/datasets_modules/datasets/bionlp_st_2013_ge/49256844b3138a792d795859ff96d8ff12db17f1ca68c748dcfa8bccdda7cdb9/bionlp_st_2013_ge.py", line 250, in _generate_examples
    example = parsing.brat_parse_to_bigbio_kb(
  File "/home/ele/Desktop/projects/tm/bigbio/bigbio/utils/parsing.py", line 347, in brat_parse_to_bigbio_kb
    trigger = id_to_event_trigger[event["trigger"]]
KeyError: 'T5'

```