### PR TITLE
remove redundant/conflicting docstrings

### DIFF
--- a/biodatasets/tmvar_v1/tmvar_v1.py
+++ b/biodatasets/tmvar_v1/tmvar_v1.py
@@ -14,11 +14,6 @@
 # limitations under the License.
 
 
-"""\
-This dataset contains 500 PubMed articles manually annotated with mutation mentions of various kinds. It can be used for NER tasks
-"""
-
-
 import os
 from pydoc import doc
 from typing import List, Tuple, Dict, Iterator

--- a/biodatasets/tmvar_v2/tmvar_v2.py
+++ b/biodatasets/tmvar_v2/tmvar_v2.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 
-"""\
-This dataset contains 500 PubMed articles manually annotated with mutation mentions of various kinds. It can be used for NER tasks
-"""
-
 import os
 from pydoc import doc
 from typing import List, Tuple, Dict, Iterator


### PR DESCRIPTION
tmvar_v1 and tmvar_v2 had identical docstrings but the descriptions are different. this removes the docstrings and leaves the correct descriptions. 