### PR TITLE
bionlp_st_2013_cg: standardize roles

### DIFF
--- a/biodatasets/bionlp_st_2013_cg/bionlp_st_2013_cg.py
+++ b/biodatasets/bionlp_st_2013_cg/bionlp_st_2013_cg.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 import datasets
 
@@ -94,6 +94,20 @@ class bionlp_st_2013_cg(datasets.GeneratorBasedBuilder):
     ]
 
     DEFAULT_CONFIG_NAME = "bionlp_st_2013_cg_source"
+
+    _ROLE_MAPPING = {
+        "Theme2": "Theme",
+        "Theme3": "Theme",
+        "Theme4": "Theme",
+        "Theme5": "Theme",
+        "Theme6": "Theme",
+        "Instrument2": "Instrument",
+        "Instrument3": "Instrument",
+        "Participant2": "Participant",
+        "Participant3": "Participant",
+        "Participant4": "Participant",
+        "Cause2": "Cause",
+    }
 
     def _info(self):
         """
@@ -221,6 +235,15 @@ class bionlp_st_2013_cg(datasets.GeneratorBasedBuilder):
             ),
         ]
 
+    def _standardize_arguments_roles(self, kb_example: Dict) -> Dict:
+
+        for event in kb_example["events"]:
+            for argument in event["arguments"]:
+                role = argument["role"]
+                argument["role"] = self._ROLE_MAPPING.get(role, role)
+
+        return kb_example
+
     def _generate_examples(self, data_files: Path):
         if self.config.schema == "source":
             txt_files = list(data_files.glob("*txt"))
@@ -234,6 +257,7 @@ class bionlp_st_2013_cg(datasets.GeneratorBasedBuilder):
                 example = parsing.brat_parse_to_bigbio_kb(
                     parsing.parse_brat_file(txt_file)
                 )
+                example = self._standardize_arguments_roles(example)
                 example["id"] = str(guid)
                 yield guid, example
         else:


### PR DESCRIPTION
Same as #570

```python
from collections import Counter
from datasets import load_dataset
ds = load_dataset("biodatasets/bionlp_st_2013_cg/bionlp_st_2013_cg.py","bionlp_st_2013_cg_bigbio_kb")
roles = []
for split in ds:
    for example in ds[split]:
        for event in example["events"]:
            for argument in event["arguments"]:
                roles.append(argument["role"])
Counter(roles)
```

BEFORE:

```python
Counter({'Cause': 3393,
         'Theme': 10098,
         'ToLoc': 194,
         'Participant': 187,
         'AtLoc': 390,
         'Instrument': 628,
         'Theme2': 142,
         'Theme3': 10,
         'FromLoc': 34,
         'Theme4': 2,
         'Theme5': 2,
         'Site': 114,
         'Instrument2': 29,
         'Participant2': 46,
         'Participant3': 14,
         'CSite': 24,
         'Theme6': 1,
         'Instrument3': 3,
         'Participant4': 7,
         'Cause2': 2})
```

AFTER:

```python
Counter({'Cause': 3395,
         'Theme': 10255,
         'ToLoc': 194,
         'Participant': 254,
         'AtLoc': 390,
         'Instrument': 660,
         'FromLoc': 34,
         'Site': 114,
         'CSite': 24})
```
