### PR TITLE
bionlp_st_2013_pc: standardize roles

### DIFF
--- a/biodatasets/bionlp_st_2013_pc/bionlp_st_2013_pc.py
+++ b/biodatasets/bionlp_st_2013_pc/bionlp_st_2013_pc.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 import datasets
 
@@ -99,6 +99,19 @@ class bionlp_st_2013_pc(datasets.GeneratorBasedBuilder):
     ]
 
     DEFAULT_CONFIG_NAME = "bionlp_st_2013_pc_source"
+
+    _ROLE_MAPPING = {
+        "Theme2": "Theme",
+        "Theme3": "Theme",
+        "Theme4": "Theme",
+        "Participant2": "Participant",
+        "Participant3": "Participant",
+        "Participant4": "Participant",
+        "Participant5": "Participant",
+        "Product2": "Product",
+        "Product3": "Product",
+        "Product4": "Product",
+    }
 
     def _info(self):
         """
@@ -227,6 +240,15 @@ class bionlp_st_2013_pc(datasets.GeneratorBasedBuilder):
             ),
         ]
 
+    def _standardize_arguments_roles(self, kb_example: Dict) -> Dict:
+
+        for event in kb_example["events"]:
+            for argument in event["arguments"]:
+                role = argument["role"]
+                argument["role"] = self._ROLE_MAPPING.get(role, role)
+
+        return kb_example
+
     def _generate_examples(self, data_files: Path):
         if self.config.schema == "source":
             txt_files = list(data_files.glob("*txt"))
@@ -240,6 +262,7 @@ class bionlp_st_2013_pc(datasets.GeneratorBasedBuilder):
                 example = parsing.brat_parse_to_bigbio_kb(
                     parsing.parse_brat_file(txt_file)
                 )
+                example = self._standardize_arguments_roles(example)
                 example["id"] = str(guid)
                 yield guid, example
         else:


### PR DESCRIPTION
PSame as #570

```python
from collections import Counter
from datasets import load_dataset
ds = load_dataset("biodatasets/bionlp_st_2013_pc/bionlp_st_2013_pc.py","bionlp_st_2013_pc_bigbio_kb")
roles = []
for split in ds:
    for example in ds[split]:
        for event in example["events"]:
            for argument in event["arguments"]:
                roles.append(argument["role"])
Counter(roles)
```

BEFORE:

```python
Counter({'Theme': 7527,
         'Cause': 3306,
         'Site': 228,
         'Product': 172,
         'Theme2': 504,
         'Participant': 314,
         'Participant2': 89,
         'ToLoc': 106,
         'FromLoc': 49,
         'Product2': 12,
         'AtLoc': 62,
         'Participant3': 23,
         'Participant4': 11,
         'Theme3': 32,
         'Theme4': 3,
         'Participant5': 2,
         'Product3': 3,
         'Product4': 2})
```

AFTER:

```python
Counter({'Theme': 8066,
         'Cause': 3306,
         'Site': 228,
         'Product': 189,
         'Participant': 439,
         'ToLoc': 106,
         'FromLoc': 49,
         'AtLoc': 62})
```