### PR TITLE
mlee: standardize roles

### DIFF
--- a/biodatasets/mlee/mlee.py
+++ b/biodatasets/mlee/mlee.py
@@ -19,7 +19,7 @@ on angiogenesis. It contains annotations for entities, relations, events and cor
 The annotations span molecular, cellular, tissue, and organ-level processes.
 """
 from pathlib import Path
-from typing import Dict, List
+from typing import List
 
 import datasets
 
@@ -95,14 +95,6 @@ class MLEE(datasets.GeneratorBasedBuilder):
     ]
 
     DEFAULT_CONFIG_NAME = "mlee_source"
-
-    _ROLE_MAPPING = {
-        "Theme2": "Theme",
-        "Instrument2": "Instrument",
-        "Participant2": "Participant",
-        "Participant3": "Participant",
-        "Participant4": "Participant",
-    }
 
     def _info(self):
         """
@@ -244,15 +236,6 @@ class MLEE(datasets.GeneratorBasedBuilder):
             ),
         ]
 
-    def _standardize_arguments_roles(self, kb_example: Dict) -> Dict:
-
-        for event in kb_example["events"]:
-            for argument in event["arguments"]:
-                role = argument["role"]
-                argument["role"] = self._ROLE_MAPPING.get(role, role)
-
-        return kb_example
-
     def _generate_examples(self, data_files: Path):
         """
         Yield one `(guid, example)` pair per abstract in MLEE.
@@ -270,7 +253,6 @@ class MLEE(datasets.GeneratorBasedBuilder):
                 example = parsing.brat_parse_to_bigbio_kb(
                     parsing.parse_brat_file(txt_file)
                 )
-                example = self._standardize_arguments_roles(example)
                 example["id"] = str(guid)
                 yield guid, example
         else:

--- a/examples/mlee.py
+++ b/examples/mlee.py
@@ -19,7 +19,7 @@ on angiogenesis. It contains annotations for entities, relations, events and cor
 The annotations span molecular, cellular, tissue, and organ-level processes.
 """
 from pathlib import Path
-from typing import Dict, List
+from typing import List
 
 import datasets
 
@@ -95,14 +95,6 @@ class MLEE(datasets.GeneratorBasedBuilder):
     ]
 
     DEFAULT_CONFIG_NAME = "mlee_source"
-
-    _ROLE_MAPPING = {
-        "Theme2": "Theme",
-        "Instrument2": "Instrument",
-        "Participant2": "Participant",
-        "Participant3": "Participant",
-        "Participant4": "Participant",
-    }
 
     def _info(self):
         """
@@ -244,15 +236,6 @@ class MLEE(datasets.GeneratorBasedBuilder):
             ),
         ]
 
-    def _standardize_arguments_roles(self, kb_example: Dict) -> Dict:
-
-        for event in kb_example["events"]:
-            for argument in event["arguments"]:
-                role = argument["role"]
-                argument["role"] = self._ROLE_MAPPING.get(role, role)
-
-        return kb_example
-
     def _generate_examples(self, data_files: Path):
         """
         Yield one `(guid, example)` pair per abstract in MLEE.
@@ -270,7 +253,6 @@ class MLEE(datasets.GeneratorBasedBuilder):
                 example = parsing.brat_parse_to_bigbio_kb(
                     parsing.parse_brat_file(txt_file)
                 )
-                example = self._standardize_arguments_roles(example)
                 example["id"] = str(guid)
                 yield guid, example
         else:


### PR DESCRIPTION
Same as #570

```python
from collections import Counter
from datasets import load_dataset
ds = load_dataset("biodatasets/mlee/mlee.py","mlee_bigbio_kb")
roles = []
for split in ds:
    for example in ds[split]:
        for event in example["events"]:
            for argument in event["arguments"]:
                roles.append(argument["role"])
Counter(roles)
```

BEFORE:

```python
Counter({'Theme': 5679,
         'Cause': 2000,
         'AtLoc': 212,
         'Instrument': 454,
         'Theme2': 12,
         'Site': 40,
         'Participant': 92,
         'FromLoc': 14,
         'ToLoc': 45,
         'Participant2': 25,
         'Instrument2': 3,
         'CSite': 13,
         'Participant3': 7,
         'Participant4': 3})
```

AFTER:

```python
Counter({'Theme': 5691,
         'Cause': 2000,
         'AtLoc': 212,
         'Instrument': 457,
         'Site': 40,
         'Participant': 127,
         'FromLoc': 14,
         'ToLoc': 45,
         'CSite': 13})
```