### PR TITLE
format,recurse,rename

### DIFF
--- a/bigbio/dataloader.py
+++ b/bigbio/dataloader.py
@@ -7,9 +7,10 @@ import logging
 import os
 import pathlib
 from types import ModuleType
-from typing import Callable, List, Optional
+from typing import Callable, Iterable, List, Optional
 
 from dataclasses import dataclass
+from dataclasses import field
 import datasets
 from datasets import load_dataset
 
@@ -17,44 +18,55 @@ from bigbio.utils.configs import BigBioConfig
 from bigbio.utils.constants import Tasks, SCHEMA_TO_TASKS
 
 
-# TODO: maybe move this to bigbio.utils.constants
-# large datasets take greater than approximately 5 minutes to load
-_LARGE_CONFIG_NAMES = set([
-    "biomrc_large_A_source",
-    "biomrc_large_B_source",
-    "biomrc_large_A_bigbio_qa",
-    "biomrc_large_B_bigbio_qa",
-
-    "medal_source",
-    "medal_bigbio_kb",
-
-    "meddialog_zh_source",
-    "meddialog_zh_bigbio_text",
-
-    "pubtator_central_source",
-    "pubtator_central_bigbio_kb",
-])
+# TODO: update this as fixes come in
+_CURRENTLY_BROKEN_NAMES = set(
+    [
+        "nagel_source",  # download url
+        "nagel_bigbio_kb",  # download url
+        "pcr_source",  # download url
+        "pcr_fixed_source",  # download url
+        "pcr_bigbio_kb",  # download url
+        "seth_corpus_source",  # undefined variable
+        "seth_corpus_bigbio_kb",  # undefined variable
+    ]
+)
 
 
-# TODO: maybe move this to bigbio.utils.constants
-# resource datasets are widely used but not expertly annotated
+# large datasets take greater than ~ 10 minutes to load
+_LARGE_CONFIG_NAMES = set(
+    [
+        "biomrc_large_A_source",
+        "biomrc_large_B_source",
+        "biomrc_large_A_bigbio_qa",
+        "biomrc_large_B_bigbio_qa",
+        "medal_source",
+        "medal_bigbio_kb",
+        "meddialog_zh_source",
+        "meddialog_zh_bigbio_text",
+        "pubtator_central_source",
+        "pubtator_central_bigbio_kb",
+    ]
+)
+
+
+# resource datasets are widely used but not annotated by human experts
 # e.g. PubTator and MIMIC III
-_RESOURCE_CONFIG_NAMES = set([
-    "pubtator_central_sample_source",
-    "pubtator_central_sample_bigbio_kb",
-    "pubtator_central_source",
-    "pubtator_central_bigbio_kb",
-])
+_RESOURCE_CONFIG_NAMES = set(
+    [
+        "pubtator_central_sample_source",
+        "pubtator_central_sample_bigbio_kb",
+        "pubtator_central_source",
+        "pubtator_central_bigbio_kb",
+    ]
+)
 
 
 @dataclass
-class DatasetConfigHelper:
+class BigBioConfigHelper:
     """Metadata for one config of a dataset."""
+
     script: pathlib.Path
     dataset_name: str
-    py_module: ModuleType
-    ds_module: datasets.load.DatasetModule
-    ds_cls: type
     tasks: List[Tasks]
     config: BigBioConfig
     is_local: bool
@@ -62,43 +74,91 @@ class DatasetConfigHelper:
     bigbio_schema_caps: Optional[str]
     is_large: bool
     is_resource: bool
+    is_default: bool
+    is_broken: bool
+    bigbio_version: str
+    source_version: str
+    citation: str
+    description: str
+    homepage: str
+    license: str
+
+    _ds_module: datasets.load.DatasetModule = field(repr=False)
+    _py_module: ModuleType = field(repr=False)
+    _ds_cls: type = field(repr=False)
+
+    def get_load_dataset_kwargs(
+        self,
+        data_dir: Optional[str] = None,
+    ):
+
+        return {
+            "path": self.script,
+            "name": self.config.name,
+            "data_dir": data_dir,
+        }
 
 
-class BigBioDataloader:
+def default_is_keeper(helper: BigBioConfigHelper) -> bool:
+    return not helper.is_large and not helper.is_resource and helper.is_bigbio_schema
+
+
+class BigBioConfigHelpers:
     """
-    Meta dataloader biodatasets
+    Handles creating and filtering BigBioDatasetConfigHelper instances.
     """
 
-    def __init__(self):
+    def __init__(
+        self,
+        helpers: Optional[Iterable[BigBioConfigHelper]] = None,
+        keep_broken: bool = False,
+    ):
 
         path_to_here = pathlib.Path(__file__).parent.absolute()
         self.path_to_biodatasets = (path_to_here / "biodatasets").resolve()
-        self.dataloader_scripts = sorted(self.path_to_biodatasets.glob(os.path.join("*", "*.py")))
-        self.dataloader_scripts = [el for el in self.dataloader_scripts if el.name != '__init__.py']
+        self.dataloader_scripts = sorted(
+            self.path_to_biodatasets.glob(os.path.join("*", "*.py"))
+        )
+        self.dataloader_scripts = [
+            el for el in self.dataloader_scripts if el.name != "__init__.py"
+        ]
 
-        ds_config_helpers = []
+        # if helpers are passed in, just attach and go
+        if helpers is not None:
+            if keep_broken:
+                self._helpers = helpers
+            else:
+                self._helpers = [helper for helper in helpers if not helper.is_broken]
+            return
+
+        # otherwise, create all helpers available in package
+        helpers = []
         for dataloader_script in self.dataloader_scripts:
             dataset_name = dataloader_script.stem
-            py_module = SourceFileLoader(dataset_name, dataloader_script.as_posix()).load_module()
-            ds_module = datasets.load.dataset_module_factory(dataloader_script.as_posix())
+            py_module = SourceFileLoader(
+                dataset_name, dataloader_script.as_posix()
+            ).load_module()
+            ds_module = datasets.load.dataset_module_factory(
+                dataloader_script.as_posix()
+            )
             ds_cls = datasets.load.import_main_class(ds_module.module_path)
 
             for config in ds_cls.BUILDER_CONFIGS:
+
                 is_bigbio_schema = config.schema.startswith("bigbio")
                 if is_bigbio_schema:
                     bigbio_schema_caps = config.schema.split("_")[1].upper()
-                    tasks = SCHEMA_TO_TASKS[bigbio_schema_caps] & set(py_module._SUPPORTED_TASKS)
+                    tasks = SCHEMA_TO_TASKS[bigbio_schema_caps] & set(
+                        py_module._SUPPORTED_TASKS
+                    )
                 else:
                     tasks = py_module._SUPPORTED_TASKS
                     bigbio_schema_caps = None
 
-                ds_config_helpers.append(
-                    DatasetConfigHelper(
+                helpers.append(
+                    BigBioConfigHelper(
                         script=dataloader_script.as_posix(),
                         dataset_name=dataset_name,
-                        py_module=py_module,
-                        ds_module=ds_module,
-                        ds_cls=ds_cls,
                         tasks=tasks,
                         config=config,
                         is_local=py_module._LOCAL,
@@ -106,88 +166,90 @@ class BigBioDataloader:
                         bigbio_schema_caps=bigbio_schema_caps,
                         is_large=config.name in _LARGE_CONFIG_NAMES,
                         is_resource=config.name in _RESOURCE_CONFIG_NAMES,
+                        is_default=config.name == ds_cls.DEFAULT_CONFIG_NAME,
+                        is_broken=config.name in _CURRENTLY_BROKEN_NAMES,
+                        bigbio_version=py_module._BIGBIO_VERSION,
+                        source_version=py_module._SOURCE_VERSION,
+                        citation=py_module._CITATION,
+                        description=py_module._DESCRIPTION,
+                        homepage=py_module._HOMEPAGE,
+                        license=py_module._LICENSE,
+                        _ds_module=ds_module,
+                        _py_module=py_module,
+                        _ds_cls=ds_cls,
                     )
                 )
 
-        self.ds_config_helpers = ds_config_helpers
+        if keep_broken:
+            self._helpers = helpers
+        else:
+            self._helpers = [helper for helper in helpers if not helper.is_broken]
 
+    @property
+    def available_dataset_names(self) -> List[str]:
+        return sorted(list(set([helper.dataset_name for helper in self])))
 
-    def get_filtered_config_helpers(
-        self,
-        is_keeper: Callable[[DatasetConfigHelper], bool]
-    ) -> DatasetConfigHelper:
-        """Return dataset config helpers that match is_keeper."""
-        return [
-            dch for dch in self.ds_config_helpers
-            if is_keeper(dch)
+    def for_dataset(self, dataset_name: str) -> List[BigBioConfigHelper]:
+        helpers = [helper for helper in self if helper.dataset_name == dataset_name]
+        return BigBioConfigHelpers(helpers=helpers)
+
+    def default_for_dataset(self, dataset_name: str) -> BigBioConfigHelper:
+        helpers = [
+            helper
+            for helper in self
+            if helper.is_default and helper.dataset_name == dataset_name
         ]
+        assert len(helpers) == 1
+        return helpers[0]
 
+    def filtered(
+        self, is_keeper: Callable[[BigBioConfigHelper], bool]
+    ) -> "BigBioConfigHelpers":
+        """Return dataset config helpers that match is_keeper."""
+        return BigBioConfigHelpers(
+            helpers=[helper for helper in self if is_keeper(helper)]
+        )
 
-    @staticmethod
-    def get_load_dataset_kwargs_from_config_helper(
-        ds_config_helper,
-        local_data_dir: Optional[str] = None,
-    ):
+    def __iter__(self):
+        for helper in self._helpers:
+            yield helper
 
-        return {
-            'path': ds_config_helper.script,
-            'name': ds_config_helper.config.name,
-            'data_dir': local_data_dir,
-        }
-
+    def __len__(self):
+        return len(self._helpers)
 
 
 if __name__ == "__main__":
 
-    bigbio_dataloader = BigBioDataloader()
+    conhelps = BigBioConfigHelpers()
 
-
-    # first, define is_keeper function and filter config helpers
-    # second, get load_datset kwargs
-    # third, load dataset
-    #====================================================================
-    bb_tmvar_helpers = bigbio_dataloader.get_filtered_config_helpers(
-        lambda x: (
-            "tmvar" in x.dataset_name and
-            x.is_bigbio_schema
+    # filter and load datasets
+    # ====================================================================
+    tmvar_datasets = [
+        load_dataset(**helper.get_load_dataset_kwargs())
+        for helper in conhelps.filtered(
+            lambda x: ("tmvar" in x.dataset_name and x.is_bigbio_schema)
         )
-    )
-    load_ds_kwargs = [
-        bigbio_dataloader.get_load_dataset_kwargs_from_config_helper(helper)
-        for helper in bb_tmvar_helpers
     ]
-    tmvar_datasets = [load_dataset(**kwargs) for kwargs in load_ds_kwargs]
-
 
     # examples of other filters
-    #====================================================================
-
-    # get all config helpers
-    all_helpers = bigbio_dataloader.get_filtered_config_helpers(
-        lambda x: True)
+    # ====================================================================
 
     # get all source schema config helpers
-    source_helpers = bigbio_dataloader.get_filtered_config_helpers(
-        lambda x: x.config.schema == "source")
+    source_helpers = conhelps.filtered(lambda x: x.config.schema == "source")
 
     # get all local bigbio config helpers
-    bb_local_helpers = bigbio_dataloader.get_filtered_config_helpers(
-        lambda x: x.is_bigbio_schema and x.is_local
-    )
+    bb_local_helpers = conhelps.filtered(lambda x: x.is_bigbio_schema and x.is_local)
 
     # bigbio NER public tasks
-    bb_ner_public_helpers = bigbio_dataloader.get_filtered_config_helpers(
+    bb_ner_public_helpers = conhelps.filtered(
         lambda x: (
-            x.is_bigbio_schema and
-            Tasks.NAMED_ENTITY_RECOGNITION in x.tasks and
-            not x.is_local
+            x.is_bigbio_schema
+            and Tasks.NAMED_ENTITY_RECOGNITION in x.tasks
+            and not x.is_local
         )
     )
 
     # n2c2 datasets
-    bb_n2c2_helpers = bigbio_dataloader.get_filtered_config_helpers(
-        lambda x: (
-            "n2c2" in x.dataset_name and
-            x.is_bigbio_schema
-        )
+    bb_n2c2_helpers = conhelps.filtered(
+        lambda x: ("n2c2" in x.dataset_name and x.is_bigbio_schema)
     )


### PR DESCRIPTION
* add a list of broken configs so they wont get loaded 
* rename so we just have two  classes `BigBioConfigHelper` and `BigBioConfigHelpers`
* ^ is the acknowledgement that all we are doing is manipulating and filtering these configs 
* make some of the more opaque attributes underscore attributes and pull out the important pieces in understandable names (e.g. `py_mod` -> `_py_mod` and `py_mod._LICENSE` -> `license`  
* make `BigBioConfigHelpers` iterable instead of always referring to the attached list
* make most methods return another instance of `BigBioConfigHelpers` (hello from your friendly recursion person) 
* ^ allows things like chaining filtered calls (e.g. `filtered_helpers = helpers.filtered(lambda x: filter_1).filtered(lambda x: filter 2)...`