### PR TITLE
pico_extraction norms as empty list instead of None

### DIFF
--- a/bigbio/biodatasets/pico_extraction/pico_extraction.py
+++ b/bigbio/biodatasets/pico_extraction/pico_extraction.py
@@ -276,7 +276,7 @@ class PicoExtractionDataset(datasets.GeneratorBasedBuilder):
                         "type": ent["annotation_type"],
                         "text": [ent["annotation_text"]],
                         "offsets": [[ent["char_start"], ent["char_end"]]],
-                        "normalized": [{"db_name": None, "db_id": None}],
+                        "normalized": [],
                     }
                     data["entities"].append(entity)
                     uid += 1


### PR DESCRIPTION
pico_extraction norms as empty list instead of None

