### PR TITLE
fixing typo in top comment encoding line

### DIFF
--- a/bigbio/biodatasets/meddialog/meddialog.py
+++ b/bigbio/biodatasets/meddialog/meddialog.py
@@ -1,4 +1,4 @@
-# coding=utf-8medd
+# coding=utf-8
 # Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
fixing typo in top comment encoding line