### PR TITLE
move metadata script utils to dataloader

### DIFF
--- a/bigbio/dataloader.py
+++ b/bigbio/dataloader.py
@@ -1,13 +1,13 @@
 """
 Utility for filtering and loading BigBio datasets.
 """
-
+from collections import Counter
 from importlib.machinery import SourceFileLoader
 import logging
 import os
 import pathlib
 from types import ModuleType
-from typing import Callable, Iterable, List, Optional
+from typing import Callable, Iterable, List, Optional, Dict
 
 from dataclasses import dataclass
 from dataclasses import field
@@ -74,10 +74,311 @@ _BLURB_CONFIG_NAMES = set(
         "chemprot_bigbio_kb",  # ChemProt
         "ddi_corpus_bigbio_kb",  # DDI
         "hallmarks_of_cancer_bigbio_text",  # HOC
-        "gad_fold0_bigbio_text", #  Gene-Disease Associations (GAD)
+        "gad_fold0_bigbio_text",  #  Gene-Disease Associations (GAD)
         "pubmed_qa_labeled_fold0_bigbio_qa",  # PubMedQA
     ]
 )
+
+
+MAX_COMMON = 50
+
+
+@dataclass
+class BigBioKbMetadata:
+
+    samples_count: int
+
+    passages_count: int
+    passages_char_count: int
+    passages_type_counter: Dict[str, int]
+
+    entities_count: int
+    entities_type_counter: Dict[str, int]
+    entities_db_name_counter: Dict[str, int]
+    entities_unique_db_ids_count: int
+
+    events_count: int
+    events_type_counter: Dict[str, int]
+    events_arguments_count: 0
+    events_arguments_role_counter: Dict[str, int]
+
+    coreferences_count: 0
+
+    relations_count: 0
+    relations_type_counter: Counter()
+    relations_db_name_counter: Counter()
+    relations_unique_db_ids_count: int
+
+    @classmethod
+    def from_dataset(cls, ds, max_common=MAX_COMMON):
+
+        passages_count = 0
+        passages_char_count = 0
+        passages_type_counter = Counter()
+
+        entities_count = 0
+        entities_type_counter = Counter()
+        entities_db_name_counter = Counter()
+        entities_unique_db_ids = set()
+
+        events_count = 0
+        events_type_counter = Counter()
+        events_arguments_count = 0
+        events_arguments_role_counter = Counter()
+
+        coreferences_count = 0
+
+        relations_count = 0
+        relations_type_counter = Counter()
+        relations_db_name_counter = Counter()
+        relations_unique_db_ids = set()
+
+        for sample in ds:
+            for passage in sample["passages"]:
+                passages_count += 1
+                passages_char_count += len(passage["text"][0])
+                passages_type_counter[passage["type"]] += 1
+
+            for entity in sample["entities"]:
+                entities_count += 1
+                entities_type_counter[entity["type"]] += 1
+                for norm in entity["normalized"]:
+                    entities_db_name_counter[norm["db_name"]] += 1
+                    entities_unique_db_ids.add(norm["db_id"])
+
+            for event in sample["events"]:
+                events_count += 1
+                events_type_counter[event["type"]] += 1
+                for argument in event["arguments"]:
+                    events_arguments_count += 1
+                    events_arguments_role_counter[argument["role"]] += 1
+
+            for coreference in sample["coreferences"]:
+                coreferences_count += 1
+
+            for relation in sample["relations"]:
+                relations_count += 1
+                relations_type_counter[relation["type"]] += 1
+                for norm in relation["normalized"]:
+                    relations_db_name_counter[norm["db_name"]] += 1
+                    relations_unique_db_ids.add(norm["db_id"])
+
+        for cc in [
+            passages_type_counter,
+            entities_type_counter,
+            entities_db_name_counter,
+            events_arguments_role_counter,
+            relations_type_counter,
+        ]:
+            if None in cc.keys():
+                raise ValueError()
+
+        return cls(
+            samples_count=ds.num_rows,
+            passages_count=passages_count,
+            passages_type_counter=dict(passages_type_counter.most_common(max_common)),
+            passages_char_count=passages_char_count,
+            entities_count=entities_count,
+            entities_type_counter=dict(entities_type_counter.most_common(max_common)),
+            entities_db_name_counter=dict(
+                entities_db_name_counter.most_common(max_common)
+            ),
+            entities_unique_db_ids_count=len(entities_unique_db_ids),
+            events_count=events_count,
+            events_type_counter=dict(events_type_counter.most_common(max_common)),
+            events_arguments_count=events_arguments_count,
+            events_arguments_role_counter=dict(
+                events_arguments_role_counter.most_common(max_common)
+            ),
+            coreferences_count=coreferences_count,
+            relations_count=relations_count,
+            relations_type_counter=dict(relations_type_counter.most_common(max_common)),
+            relations_db_name_counter=dict(
+                relations_db_name_counter.most_common(max_common)
+            ),
+            relations_unique_db_ids_count=len(relations_unique_db_ids),
+        )
+
+
+@dataclass
+class BigBioTextMetadata:
+
+    samples_count: int
+    text_char_count: int
+    labels_count: int
+    labels_counter: Dict[str, int]
+
+    @classmethod
+    def from_dataset(cls, ds, max_common=MAX_COMMON):
+
+        text_char_count = 0
+        labels_count = 0
+        labels_counter = Counter()
+
+        for sample in ds:
+            text_char_count += len(sample["text"]) if sample["text"] is not None else 0
+            for label in sample["labels"]:
+                labels_count += 1
+                labels_counter[label] += 1
+
+        return cls(
+            samples_count=ds.num_rows,
+            text_char_count=text_char_count,
+            labels_count=labels_count,
+            labels_counter=dict(labels_counter.most_common(max_common)),
+        )
+
+
+@dataclass
+class BigBioPairsMetadata:
+
+    samples_count: int
+    text_1_char_count: int
+    text_2_char_count: int
+    label_counter: Dict[str, int]
+
+    @classmethod
+    def from_dataset(cls, ds, max_common=MAX_COMMON):
+
+        text_1_char_count = 0
+        text_2_char_count = 0
+        label_counter = Counter()
+
+        for sample in ds:
+            text_1_char_count += (
+                len(sample["text_1"]) if sample["text_1"] is not None else 0
+            )
+            text_2_char_count += (
+                len(sample["text_2"]) if sample["text_2"] is not None else 0
+            )
+            label_counter[sample["label"]] += 1
+
+        return cls(
+            samples_count=ds.num_rows,
+            text_1_char_count=text_1_char_count,
+            text_2_char_count=text_2_char_count,
+            label_counter=dict(label_counter.most_common(max_common)),
+        )
+
+
+@dataclass
+class BigBioQaMetadata:
+
+    samples_count: int
+    question_char_count: int
+    context_char_count: int
+    answer_count: int
+    answer_char_count: int
+    type_counter: Dict[str, int]
+    choices_counter: Dict[str, int]
+
+    @classmethod
+    def from_dataset(cls, ds, max_common=MAX_COMMON):
+
+        question_char_count = 0
+        context_char_count = 0
+        answer_count = 0
+        answer_char_count = 0
+        type_counter = Counter()
+        choices_counter = Counter()
+
+        for sample in ds:
+            question_char_count += len(sample["question"])
+            context_char_count += len(sample["context"])
+            type_counter[sample["type"]] += 1
+            for choice in sample["choices"]:
+                choices_counter[choice] += 1
+            for answer in sample["answer"]:
+                answer_count += 1
+                answer_char_count += len(answer)
+
+        return cls(
+            samples_count=ds.num_rows,
+            question_char_count=question_char_count,
+            context_char_count=context_char_count,
+            answer_count=answer_count,
+            answer_char_count=answer_char_count,
+            type_counter=dict(type_counter.most_common(max_common)),
+            choices_counter=dict(choices_counter.most_common(max_common)),
+        )
+
+
+@dataclass
+class BigBioT2tMetadata:
+
+    samples_count: int
+    text_1_char_count: int
+    text_2_char_count: int
+    text_1_name_counter: Dict[str, int]
+    text_2_name_counter: Dict[str, int]
+
+    @classmethod
+    def from_dataset(cls, ds, max_common=MAX_COMMON):
+
+        text_1_char_count = 0
+        text_2_char_count = 0
+        text_1_name_counter = Counter()
+        text_2_name_counter = Counter()
+
+        for sample in ds:
+            text_1_char_count += (
+                len(sample["text_1"]) if sample["text_1"] is not None else 0
+            )
+            text_2_char_count += (
+                len(sample["text_2"]) if sample["text_2"] is not None else 0
+            )
+            text_1_name_counter[sample["text_1_name"]] += 1
+            text_2_name_counter[sample["text_2_name"]] += 1
+
+        return cls(
+            samples_count=ds.num_rows,
+            text_1_char_count=text_1_char_count,
+            text_2_char_count=text_2_char_count,
+            text_1_name_counter=dict(text_1_name_counter.most_common(max_common)),
+            text_2_name_counter=dict(text_2_name_counter.most_common(max_common)),
+        )
+
+
+@dataclass
+class BigBioTeMetadata:
+
+    samples_count: int
+    premise_char_count: int
+    hypothesis_char_count: int
+    label_counter: Dict[str, int]
+
+    @classmethod
+    def from_dataset(cls, ds, max_common=MAX_COMMON):
+
+        premise_char_count = 0
+        hypothesis_char_count = 0
+        label_counter = Counter()
+
+        for sample in ds:
+            premise_char_count += (
+                len(sample["premise"]) if sample["premise"] is not None else 0
+            )
+            hypothesis_char_count += (
+                len(sample["hypothesis"]) if sample["hypothesis"] is not None else 0
+            )
+            label_counter[sample["label"]] += 1
+
+        return cls(
+            samples_count=ds.num_rows,
+            premise_char_count=premise_char_count,
+            hypothesis_char_count=hypothesis_char_count,
+            label_counter=dict(label_counter.most_common(max_common)),
+        )
+
+
+SCHEMA_TO_METADATA_CLS = {
+    "bigbio_kb": BigBioKbMetadata,
+    "bigbio_text": BigBioTextMetadata,
+    "bigbio_pairs": BigBioPairsMetadata,
+    "bigbio_qa": BigBioQaMetadata,
+    "bigbio_t2t": BigBioT2tMetadata,
+    "bigbio_te": BigBioTeMetadata,
+}
 
 
 @dataclass
@@ -126,6 +427,16 @@ class BigBioConfigHelper:
             name=self.config.name,
             **extra_load_dataset_kwargs,
         )
+
+    def get_metadata(self, **extra_load_dataset_kwargs):
+        if not self.is_bigbio_schema:
+            raise ValueError("only supported for bigbio schemas")
+        dsd = self.load_dataset(**extra_load_dataset_kwargs)
+        split_metas = {}
+        for split, ds in dsd.items():
+            meta = SCHEMA_TO_METADATA_CLS[self.config.schema].from_dataset(ds)
+            split_metas[split] = meta
+        return split_metas
 
 
 def default_is_keeper(helper: BigBioConfigHelper) -> bool:
@@ -230,7 +541,9 @@ class BigBioConfigHelpers:
         if len(helpers) == 0:
             raise ValueError(f"no helper with helper.config.name = {config_name}")
         if len(helpers) > 1:
-            raise ValueError(f"multiple helpers with helper.config.name = {config_name}")
+            raise ValueError(
+                f"multiple helpers with helper.config.name = {config_name}"
+            )
         return helpers[0]
 
     def default_for_dataset(self, dataset_name: str) -> BigBioConfigHelper:
@@ -270,9 +583,9 @@ class BigBioConfigHelpers:
                 helpers=[self._helpers[ii] for ii in range(start, stop, step)]
             )
         elif isinstance(key, int):
-            if key < 0: #Handle negative indices
+            if key < 0:  # Handle negative indices
                 key += len(self)
-            if key < 0 or key >= len( self ) :
+            if key < 0 or key >= len(self):
                 raise IndexError(f"The index ({key}) is out of range.")
             return self._helpers[key]
         else:
@@ -286,7 +599,8 @@ if __name__ == "__main__":
     # filter and load datasets
     # ====================================================================
     tmvar_datasets = [
-        helper.load_dataset() for helper in conhelps.filtered(
+        helper.load_dataset()
+        for helper in conhelps.filtered(
             lambda x: ("tmvar" in x.dataset_name and x.is_bigbio_schema)
         )
     ]

--- a/bigbio/dataloader.py
+++ b/bigbio/dataloader.py
@@ -105,8 +105,8 @@ class BigBioKbMetadata:
     coreferences_count: 0
 
     relations_count: 0
-    relations_type_counter: Counter()
-    relations_db_name_counter: Counter()
+    relations_type_counter: Dict[str, int]
+    relations_db_name_counter: Dict[str, int]
     relations_unique_db_ids_count: int
 
     @classmethod

--- a/scripts/gather_dataset_stats.py
+++ b/scripts/gather_dataset_stats.py
@@ -65,7 +65,7 @@ def gather_metadatas_json(conhelps, data_dir_base: Optional[str] = None):
 
         dataset_meta = {
             "dataset_name": dataset_name,
-            "is_local": False,
+            "is_local": helper.is_local,
             "languages": [el.name for el in helper.languages],
             "bigbio_version": helper.bigbio_version,
             "source_version": helper.source_version,

--- a/scripts/gather_dataset_stats.py
+++ b/scripts/gather_dataset_stats.py
@@ -4,6 +4,7 @@ Help make plots
 """
 from collections import Counter
 from collections import defaultdict, OrderedDict
+import dataclasses
 import json
 import os
 from typing import Optional
@@ -17,237 +18,7 @@ from bigbio.dataloader import BigBioConfigHelpers
 MAX_COMMON = 50
 
 
-def get_kb_meta(helper, split, ds):
-
-    passages_count = 0
-    passages_char_count = 0
-    passages_type_counter = Counter()
-
-    entities_count = 0
-    entities_type_counter = Counter()
-    entities_db_name_counter = Counter()
-    entities_unique_db_ids = set()
-
-    events_count = 0
-    events_type_counter = Counter()
-    events_arguments_count = 0
-    events_arguments_role_counter = Counter()
-
-    coreferences_count = 0
-
-    relations_count = 0
-    relations_type_counter = Counter()
-    relations_db_name_counter = Counter()
-    relations_unique_db_ids = set()
-
-    for sample in ds:
-        for passage in sample["passages"]:
-            passages_count += 1
-            passages_char_count += len(passage["text"][0])
-            passages_type_counter[passage["type"]] += 1
-
-        for entity in sample["entities"]:
-            entities_count += 1
-            entities_type_counter[entity["type"]] += 1
-            for norm in entity["normalized"]:
-                entities_db_name_counter[norm["db_name"]] += 1
-                entities_unique_db_ids.add(norm["db_id"])
-
-        for event in sample["events"]:
-            events_count += 1
-            events_type_counter[event["type"]] += 1
-            for argument in event["arguments"]:
-                events_arguments_count += 1
-                events_arguments_role_counter[argument["role"]] += 1
-
-        for coreference in sample["coreferences"]:
-            coreferences_count += 1
-
-        for relation in sample["relations"]:
-            relations_count += 1
-            relations_type_counter[relation["type"]] += 1
-            for norm in relation["normalized"]:
-                relations_db_name_counter[norm["db_name"]] += 1
-                relations_unique_db_ids.add(norm["db_id"])
-
-    for cc in [
-            passages_type_counter,
-            entities_type_counter,
-            entities_db_name_counter,
-            events_arguments_role_counter,
-            relations_type_counter
-    ]:
-        if None in cc.keys():
-            raise ValueError()
-
-
-    meta = {
-        "split": split,
-        "samples_count": ds.num_rows,
-        "passages_count": passages_count,
-        "passages_type_counts": dict(passages_type_counter.most_common(MAX_COMMON)),
-        "passages_char_count": passages_char_count,
-        "entities_count": entities_count,
-        "entities_type_counts": dict(entities_type_counter.most_common(MAX_COMMON)),
-        "entities_db_name_counts": dict(
-            entities_db_name_counter.most_common(MAX_COMMON)
-        ),
-        "entities_unique_db_id_counts": len(entities_unique_db_ids),
-        "events_count": events_count,
-        "events_arguments_count": events_arguments_count,
-        "events_arguments_role_counts": dict(
-            events_arguments_role_counter.most_common(MAX_COMMON)
-        ),
-        "coreferences_count": coreferences_count,
-        "relations_count": relations_count,
-        "relations_type_counts": dict(relations_type_counter.most_common(MAX_COMMON)),
-        "relations_db_name_counts": dict(
-            relations_db_name_counter.most_common(MAX_COMMON)
-        ),
-        "relations_unique_db_id_counts": len(relations_unique_db_ids),
-    }
-
-    return meta
-
-
-def get_text_meta(helper, split, ds):
-
-    text_char_count = 0
-    labels_count = 0
-    labels_counter = Counter()
-
-    for sample in ds:
-        text_char_count += len(sample["text"]) if sample["text"] is not None else 0
-        for label in sample["labels"]:
-            labels_count += 1
-            labels_counter[label] += 1
-
-    meta = {
-        "split": split,
-        "samples_count": ds.num_rows,
-        "text_char_count": text_char_count,
-        "labels_count": labels_count,
-        "labels_counts": dict(labels_counter.most_common(MAX_COMMON)),
-    }
-
-    return meta
-
-
-def get_pairs_meta(helper, split, ds):
-
-    text_1_char_count = 0
-    text_2_char_count = 0
-    label_counter = Counter()
-
-    for sample in ds:
-        text_1_char_count += (
-            len(sample["text_1"]) if sample["text_1"] is not None else 0
-        )
-        text_2_char_count += (
-            len(sample["text_2"]) if sample["text_2"] is not None else 0
-        )
-        label_counter[sample["label"]] += 1
-
-    meta = {
-        "split": split,
-        "samples_count": ds.num_rows,
-        "text_1_char_count": text_1_char_count,
-        "text_2_char_count": text_2_char_count,
-        "label_counts": dict(label_counter.most_common(MAX_COMMON)),
-    }
-
-    return meta
-
-
-def get_qa_meta(helper, split, ds):
-
-    question_char_count = 0
-    context_char_count = 0
-    answer_count = 0
-    answer_char_count = 0
-    type_counter = Counter()
-    choices_counter = Counter()
-
-    for sample in ds:
-        question_char_count += len(sample["question"])
-        context_char_count += len(sample["context"])
-        type_counter[sample["type"]] += 1
-        for choice in sample["choices"]:
-            choices_counter[choice] += 1
-        for answer in sample["answer"]:
-            answer_count += 1
-            answer_char_count += len(answer)
-
-    meta = {
-        "split": split,
-        "samples_count": ds.num_rows,
-        "question_char_count": question_char_count,
-        "context_char_count": context_char_count,
-        "answer_count": answer_count,
-        "answer_char_count": answer_char_count,
-        "type_counts": dict(type_counter.most_common(MAX_COMMON)),
-        "choices_counts": dict(choices_counter.most_common(MAX_COMMON)),
-    }
-
-    return meta
-
-
-def get_t2t_meta(helper, split, ds):
-
-    text_1_char_count = 0
-    text_2_char_count = 0
-    text_1_name_counter = Counter()
-    text_2_name_counter = Counter()
-
-    for sample in ds:
-        text_1_char_count += (
-            len(sample["text_1"]) if sample["text_1"] is not None else 0
-        )
-        text_2_char_count += (
-            len(sample["text_2"]) if sample["text_2"] is not None else 0
-        )
-        text_1_name_counter[sample["text_1_name"]] += 1
-        text_2_name_counter[sample["text_2_name"]] += 1
-
-    meta = {
-        "split": split,
-        "samples_count": ds.num_rows,
-        "text_1_char_count": text_1_char_count,
-        "text_2_char_count": text_2_char_count,
-        "text_1_name_counts": dict(text_1_name_counter.most_common(MAX_COMMON)),
-        "text_2_name_counts": dict(text_2_name_counter.most_common(MAX_COMMON)),
-    }
-
-    return meta
-
-
-def get_te_meta(helper, split, ds):
-
-    premise_char_count = 0
-    hypothesis_char_count = 0
-    label_counter = Counter()
-
-    for sample in ds:
-        premise_char_count += (
-            len(sample["premise"]) if sample["premise"] is not None else 0
-        )
-        hypothesis_char_count += (
-            len(sample["hypothesis"]) if sample["hypothesis"] is not None else 0
-        )
-        label_counter[sample["label"]] += 1
-
-    meta = {
-        "split": split,
-        "samples_count": ds.num_rows,
-        "premise_char_count": premise_char_count,
-        "hypothesis_char_count": hypothesis_char_count,
-        "label_counts": dict(label_counter.most_common(MAX_COMMON)),
-    }
-
-    return meta
-
-
-def gather_metadatas_json(conhelps, data_dir_base: Optional[str]=None):
+def gather_metadatas_json(conhelps, data_dir_base: Optional[str] = None):
 
     # gather configs by dataset
     configs_by_ds = defaultdict(list)
@@ -263,45 +34,25 @@ def gather_metadatas_json(conhelps, data_dir_base: Optional[str]=None):
         for helper in helpers:
             print("config name: ", helper.config.name)
             if helper.config.name in [
-                'bioasq_10b_bigbio_qa',
+                "bioasq_10b_bigbio_qa",
             ]:
                 continue
 
-
             if helper.is_local:
                 if dataset_name == "psytar":
-                    data_dir = os.path.join(data_dir_base, dataset_name, "PsyTAR_dataset.xlsx")
+                    data_dir = os.path.join(
+                        data_dir_base, dataset_name, "PsyTAR_dataset.xlsx"
+                    )
                 else:
                     data_dir = os.path.join(data_dir_base, dataset_name)
             else:
                 data_dir = None
-            dsd = helper.load_dataset(data_dir=data_dir)
 
+            split_metas_dataclasses = helper.get_metadata(data_dir=data_dir)
             split_metas = {}
-            for split, ds in dsd.items():
-
-                if helper.config.schema == "bigbio_kb":
-                    meta = get_kb_meta(helper, split, ds)
-
-                elif helper.config.schema == "bigbio_text":
-                    meta = get_text_meta(helper, split, ds)
-
-                elif helper.config.schema == "bigbio_t2t":
-                    meta = get_t2t_meta(helper, split, ds)
-
-                elif helper.config.schema == "bigbio_pairs":
-                    meta = get_pairs_meta(helper, split, ds)
-
-                elif helper.config.schema == "bigbio_qa":
-                    meta = get_qa_meta(helper, split, ds)
-
-                elif helper.config.schema == "bigbio_te":
-                    meta = get_te_meta(helper, split, ds)
-
-                else:
-                    raise ValueError()
-
-                split_metas[split] = meta
+            for split, meta_dc in split_metas_dataclasses.items():
+                split_metas[split] = dataclasses.asdict(meta_dc)
+                split_metas["split"] = split
 
             config_meta = {
                 "config_name": helper.config.name,
@@ -413,8 +164,8 @@ def flatten_metadatas(dataset_metas):
                         split_meta["relations_unique_db_id_counts"],
                     ]
                     row = dataset_row + config_row + split_row
-                    flat_rows['kb'].append(row)
-                    split_row_names['kb'] = list(split_meta.keys())
+                    flat_rows["kb"].append(row)
+                    split_row_names["kb"] = list(split_meta.keys())
 
                 elif config_meta["bigbio_schema"] == "bigbio_text":
                     split_row = [
@@ -425,8 +176,8 @@ def flatten_metadatas(dataset_metas):
                         json.dumps(split_meta["labels_counts"]),
                     ]
                     row = dataset_row + config_row + split_row
-                    flat_rows['text'].append(row)
-                    split_row_names['text'] = list(split_meta.keys())
+                    flat_rows["text"].append(row)
+                    split_row_names["text"] = list(split_meta.keys())
 
                 elif config_meta["bigbio_schema"] == "bigbio_t2t":
                     split_row = [
@@ -438,8 +189,8 @@ def flatten_metadatas(dataset_metas):
                         json.dumps(split_meta["text_2_name_counts"]),
                     ]
                     row = dataset_row + config_row + split_row
-                    flat_rows['t2t'].append(row)
-                    split_row_names['t2t'] = list(split_meta.keys())
+                    flat_rows["t2t"].append(row)
+                    split_row_names["t2t"] = list(split_meta.keys())
 
                 elif config_meta["bigbio_schema"] == "bigbio_pairs":
                     split_row = [
@@ -450,8 +201,8 @@ def flatten_metadatas(dataset_metas):
                         json.dumps(split_meta["label_counts"]),
                     ]
                     row = dataset_row + config_row + split_row
-                    flat_rows['pairs'].append(row)
-                    split_row_names['pairs'] = list(split_meta.keys())
+                    flat_rows["pairs"].append(row)
+                    split_row_names["pairs"] = list(split_meta.keys())
 
                 elif config_meta["bigbio_schema"] == "bigbio_qa":
                     split_row = [
@@ -465,8 +216,8 @@ def flatten_metadatas(dataset_metas):
                         json.dumps(split_meta["choices_counts"]),
                     ]
                     row = dataset_row + config_row + split_row
-                    flat_rows['qa'].append(row)
-                    split_row_names['qa'] = list(split_meta.keys())
+                    flat_rows["qa"].append(row)
+                    split_row_names["qa"] = list(split_meta.keys())
 
                 elif config_meta["bigbio_schema"] == "bigbio_te":
                     split_row = [
@@ -477,8 +228,8 @@ def flatten_metadatas(dataset_metas):
                         json.dumps(split_meta["label_counts"]),
                     ]
                     row = dataset_row + config_row + split_row
-                    flat_rows['te'].append(row)
-                    split_row_names['te'] = list(split_meta.keys())
+                    flat_rows["te"].append(row)
+                    split_row_names["te"] = list(split_meta.keys())
 
                 else:
                     raise ValueError()
@@ -486,46 +237,50 @@ def flatten_metadatas(dataset_metas):
     dfs = {
         key: pd.DataFrame(
             flat_rows[key],
-            columns = dataset_row_names + config_row_names + split_row_names[key]
-        ) for key in split_row_names.keys()
+            columns=dataset_row_names + config_row_names + split_row_names[key],
+        )
+        for key in split_row_names.keys()
     }
     return dfs
 
 
+if __name__ == "__main__":
 
-# create a BigBioConfigHelpers
-# ==========================================================
-conhelps = BigBioConfigHelpers()
-conhelps = conhelps.filtered(lambda x: x.dataset_name != "pubtator_central")
-conhelps = conhelps.filtered(lambda x: x.is_bigbio_schema)
+    # create a BigBioConfigHelpers
+    # ==========================================================
+    conhelps = BigBioConfigHelpers()
+    conhelps = conhelps.filtered(lambda x: x.dataset_name != "pubtator_central")
+    conhelps = conhelps.filtered(lambda x: x.is_bigbio_schema)
 
-print(
-    "loaded {} configs from {} datasets".format(
-        len(conhelps),
-        len(set([helper.dataset_name for helper in conhelps])),
+    print(
+        "loaded {} configs from {} datasets".format(
+            len(conhelps),
+            len(set([helper.dataset_name for helper in conhelps])),
+        )
     )
-)
 
-do_public = True
-do_private = True
+    do_public = True
+    do_private = True
 
-if do_public:
-    public_conhelps = conhelps.filtered(lambda x: not x.is_local)
-    public_dataset_metas = gather_metadatas_json(public_conhelps)
-    with open("bigbio-public-metadatas.json", "w") as fp:
-        json.dump(public_dataset_metas, fp, indent=4)
-    public_dfs = flatten_metadatas(public_dataset_metas)
-    for key, df in public_dfs.items():
-        df.to_parquet(f"bigbio-public-metadatas-flat-{key}.parquet")
-        df.to_csv(f"bigbio-public-metadatas-flat-{key}.csv", index=False)
+    if do_public:
+        public_conhelps = conhelps.filtered(lambda x: not x.is_local)
+        public_dataset_metas = gather_metadatas_json(public_conhelps)
+        with open("bigbio-public-metadatas.json", "w") as fp:
+            json.dump(public_dataset_metas, fp, indent=4)
+        public_dfs = flatten_metadatas(public_dataset_metas)
+        for key, df in public_dfs.items():
+            df.to_parquet(f"bigbio-public-metadatas-flat-{key}.parquet")
+            df.to_csv(f"bigbio-public-metadatas-flat-{key}.csv", index=False)
 
-if do_private:
-    data_dir_base = "/home/galtay/data/bigbio"
-    private_conhelps = conhelps.filtered(lambda x: x.is_local)
-    private_dataset_metas = gather_metadatas_json(private_conhelps, data_dir_base=data_dir_base)
-    with open("bigbio-private-metadatas.json", "w") as fp:
-        json.dump(private_dataset_metas, fp, indent=4)
-    private_dfs = flatten_metadatas(private_dataset_metas)
-    for key, df in private_dfs.items():
-        df.to_parquet(f"bigbio-private-metadatas-flat-{key}.parquet")
-        df.to_csv(f"bigbio-private-metadatas-flat-{key}.csv", index=False)
+    if do_private:
+        data_dir_base = "/home/galtay/data/bigbio"
+        private_conhelps = conhelps.filtered(lambda x: x.is_local)
+        private_dataset_metas = gather_metadatas_json(
+            private_conhelps, data_dir_base=data_dir_base
+        )
+        with open("bigbio-private-metadatas.json", "w") as fp:
+            json.dump(private_dataset_metas, fp, indent=4)
+        private_dfs = flatten_metadatas(private_dataset_metas)
+        for key, df in private_dfs.items():
+            df.to_parquet(f"bigbio-private-metadatas-flat-{key}.parquet")
+            df.to_csv(f"bigbio-private-metadatas-flat-{key}.csv", index=False)


### PR DESCRIPTION
moves the functions that were used to collect metadata about datasets from the scripts directory into dataclasses in the dataloader.py module. allows, 
```
import dataclasses
from bigbio.dataloader import BigBioConfigHelpers
conhelps = BigBioConfigHelpers()
helper = conhelps.for_config_name("chemprot_bigbio_kb")
metas_as_dcs = helper.get_metadata()
metas_as_dict = dataclasses.asdict(metas_as_dcs)
metas_as_dcs
{'sample': BigBioKbMetadata(samples_count=50, passages_count=50, passages_char_count=83310, passages_type_counter=Counter({'title and abstract': 50}), entities_count=1289, entities_type_counter=Counter({'CHEMICAL': 683, 'GENE-Y': 387, 'GENE-N': 219}), entities_db_name_counter=Counter(), entities_unique_db_ids_count=0, events_count=0, events_type_counter=Counter(), events_arguments_count=0, events_arguments_role_counter=Counter(), coreferences_count=0, relations_count=339, relations_type_counter=Counter({'Downregulator': 89, 'Regulator': 83, 'Upregulator': 78, 'Substrate': 45, 'Not': 15, 'Antagonist': 14, 'Agonist': 13, 'Cofactor': 1, 'Part_of': 1}), relations_db_name_counter=Counter(), relations_unique_db_ids_count=0),
 'train': BigBioKbMetadata(samples_count=1020, passages_count=1020, passages_char_count=1639619, passages_type_counter=Counter({'title and abstract': 1020}), entities_count=25752, entities_type_counter=Counter({'CHEMICAL': 13017, 'GENE-Y': 8348, 'GENE-N': 4387}), entities_db_name_counter=Counter(), entities_unique_db_ids_count=0, events_count=0, events_type_counter=Counter(), events_arguments_count=0, events_arguments_role_counter=Counter(), coreferences_count=0, relations_count=6437, relations_type_counter=Counter({'Downregulator': 2260, 'Regulator': 1652, 'Upregulator': 777, 'Substrate': 727, 'Part_of': 308, 'Not': 241, 'Antagonist': 235, 'Agonist': 173, 'Cofactor': 34, 'Modulator': 29, 'Undefined': 1}), relations_db_name_counter=Counter(), relations_unique_db_ids_count=0),
 'test': BigBioKbMetadata(samples_count=800, passages_count=800, passages_char_count=1301919, passages_type_counter=Counter({'title and abstract': 800}), entities_count=20828, entities_type_counter=Counter({'CHEMICAL': 10810, 'GENE-Y': 6658, 'GENE-N': 3360}), entities_db_name_counter=Counter(), entities_unique_db_ids_count=0, events_count=0, events_type_counter=Counter(), events_arguments_count=0, events_arguments_role_counter=Counter(), coreferences_count=0, relations_count=5744, relations_type_counter=Counter({'Regulator': 1743, 'Downregulator': 1667, 'Upregulator': 667, 'Substrate': 644, 'Antagonist': 293, 'Not': 267, 'Part_of': 215, 'Agonist': 198, 'Modulator': 25, 'Cofactor': 25}), relations_db_name_counter=Counter(), relations_unique_db_ids_count=0),
 'validation': BigBioKbMetadata(samples_count=612, passages_count=612, passages_char_count=989700, passages_type_counter=Counter({'title and abstract': 612}), entities_count=15567, entities_type_counter=Counter({'CHEMICAL': 8004, 'GENE-Y': 5151, 'GENE-N': 2412}), entities_db_name_counter=Counter(), entities_unique_db_ids_count=0, events_count=0, events_type_counter=Counter(), events_arguments_count=0, events_arguments_role_counter=Counter(), coreferences_count=0, relations_count=3558, relations_type_counter=Counter({'Downregulator': 1103, 'Regulator': 780, 'Upregulator': 552, 'Substrate': 457, 'Antagonist': 199, 'Not': 175, 'Part_of': 153, 'Agonist': 116, 'Modulator': 19, 'Cofactor': 2, 'Undefined': 2}), relations_db_name_counter=Counter(), relations_unique_db_ids_count=0)}
```