### PR TITLE
replace external dua with dua

### DIFF
--- a/bigbio/biodatasets/n2c2_2009/n2c2_2009.py
+++ b/bigbio/biodatasets/n2c2_2009/n2c2_2009.py
@@ -131,7 +131,7 @@ i.e. `anticoagulation` != `anticoagulation.` from doc_id: 818404
 
 _HOMEPAGE = "https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/"
 
-_LICENSE = Licenses.EXTERNAL_DUA
+_LICENSE = Licenses.DUA
 
 _SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
 

--- a/bigbio/biodatasets/n2c2_2010/n2c2_2010.py
+++ b/bigbio/biodatasets/n2c2_2010/n2c2_2010.py
@@ -102,7 +102,7 @@ Using this reference standard, 22 systems were developed for concept extraction,
 
 _HOMEPAGE = "https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/"
 
-_LICENSE = Licenses.EXTERNAL_DUA
+_LICENSE = Licenses.DUA
 
 _SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
 

--- a/bigbio/biodatasets/n2c2_2018_track1/n2c2_2018_track1.py
+++ b/bigbio/biodatasets/n2c2_2018_track1/n2c2_2018_track1.py
@@ -118,17 +118,17 @@ For the purposes of this annotation, we define “advanced” as having 2 or mor
 The training consists of 202 patient records with document-level annotations, 10 records
 with textual spans indicating annotator’s evidence for their annotations while test set contains 86.
 
-Note: 
+Note:
 * The inter-annotator average agreement is 84.9%
-* Whereabouts of 10 records with textual spans indicating annotator’s evidence are unknown. 
-However, author did a simple script based validation to check if any of the tags contained any text 
+* Whereabouts of 10 records with textual spans indicating annotator’s evidence are unknown.
+However, author did a simple script based validation to check if any of the tags contained any text
 in any of the training set and they do not, which confirms that atleast train and test do not
  have any evidence tagged alongside corresponding tags.
 """
 
 _HOMEPAGE = "https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/"
 
-_LICENSE = Licenses.EXTERNAL_DUA
+_LICENSE = Licenses.DUA
 
 _SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
 

--- a/bigbio/biodatasets/n2c2_2018_track2/n2c2_2018_track2.py
+++ b/bigbio/biodatasets/n2c2_2018_track2/n2c2_2018_track2.py
@@ -118,7 +118,7 @@ of the art in a particular task, learn from it, and build on it.
 
 _HOMEPAGE = "https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/"
 
-_LICENSE = Licenses.EXTERNAL_DUA
+_LICENSE = Licenses.DUA
 
 _SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
 

--- a/bigbio/utils/license.py
+++ b/bigbio/utils/license.py
@@ -177,7 +177,7 @@ GENERAL TERMS AND CONDITIONS
     Users of the data agree to:
         acknowledge NLM as the source of the data by including the phrase "Courtesy of the U.S. National Library of Medicine" in a clear and conspicuous manner,
         properly use registration and/or trademark symbols when referring to NLM products, and
-        not indicate or imply that NLM has endorsed its products/services/applications. 
+        not indicate or imply that NLM has endorsed its products/services/applications.
 
     Users who republish or redistribute the data (services, products or raw data) agree to:
         maintain the most current version of all distributed data, or
@@ -216,7 +216,7 @@ It is hereby agreed between the data requestor, hereinafter referred to as the "
     The LICENSEE will use the data for the sole purpose of lawful use in scientific research and no other.
     The LICENSEE will be responsible for ensuring that he or she maintains up to date certification in human research subject protection and HIPAA regulations.
     The LICENSEE agrees to contribute code associated with publications arising from this data to a repository that is open to the research community.
-    This agreement may be terminated by either party at any time, but the LICENSEE's obligations with respect to PhysioNet data shall continue after termination.  
+    This agreement may be terminated by either party at any time, but the LICENSEE's obligations with respect to PhysioNet data shall continue after termination.
 
 THE DATA ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE DATA OR THE USE OR OTHER DEALINGS IN THE DATA.
 """
@@ -306,7 +306,7 @@ def load_licenses() -> Dict[str, License]:
     json_licenses = load_json_licenses()
 
     json_licenses.update(
-        {"DUA": "Data User Agreement", "EXTERNAL_DUA": "External Data User Agreement"}
+        {"DUA": "Data User Agreement"}
     )
 
     licenses_kwargs = {k: {"name": v} for k, v in json_licenses.items()}


### PR DESCRIPTION
some n2c2 datasets were using "External DUA" and others where using "DUA" for licensing. I don't think we have an actual distinction between the two so I made all DUAs.  