### PR TITLE
Fix license type

### DIFF
--- a/bigbio/utils/constants.py
+++ b/bigbio/utils/constants.py
@@ -5,10 +5,15 @@ from enum import Enum
 from types import SimpleNamespace
 
 from bigbio.utils import resources
-from bigbio.utils.license import Licenses
-from bigbio.utils.schemas import (entailment_features, kb_features,
-                                  pairs_features, qa_features,
-                                  text2text_features, text_features)
+from bigbio.utils.license import License
+from bigbio.utils.schemas import (
+    entailment_features,
+    kb_features,
+    pairs_features,
+    qa_features,
+    text2text_features,
+    text_features,
+)
 
 BigBioValues = SimpleNamespace(NULL="<BB_NULL_STR>")
 
@@ -23,7 +28,7 @@ METADATA: dict = {
     "_LOCAL": bool,
     "_LANGUAGES": Lang,
     "_PUBMED": bool,
-    "_LICENSE": Licenses,
+    "_LICENSE": License,
 }
 
 

--- a/bigbio/utils/license.py
+++ b/bigbio/utils/license.py
@@ -7,7 +7,7 @@ License objects.
 import importlib.resources as pkg_resources
 import json
 from dataclasses import dataclass
-from enum import Enum
+from types import SimpleNamespace
 from typing import Dict, Optional
 
 from bigbio.utils import resources
@@ -305,9 +305,7 @@ def load_licenses() -> Dict[str, License]:
 
     json_licenses = load_json_licenses()
 
-    json_licenses.update(
-        {"DUA": "Data User Agreement"}
-    )
+    json_licenses.update({"DUA": "Data User Agreement"})
 
     licenses_kwargs = {k: {"name": v} for k, v in json_licenses.items()}
 
@@ -328,4 +326,4 @@ def load_licenses() -> Dict[str, License]:
 
 
 _LICENSES = load_licenses()
-Licenses = Enum("Licenses", _LICENSES)
+Licenses = SimpleNamespace(**_LICENSES)

--- a/tests/test_bigbio.py
+++ b/tests/test_bigbio.py
@@ -17,12 +17,22 @@ from typing import Dict, Iterable, Iterator, List, Optional, Union
 import datasets
 from datasets import DatasetDict, Features
 
-from bigbio.utils.constants import (METADATA, SCHEMA_TO_FEATURES,
-                                    TASK_TO_SCHEMA, VALID_SCHEMAS, VALID_TASKS,
-                                    Tasks)
-from bigbio.utils.schemas import (entailment_features, kb_features,
-                                  pairs_features, qa_features,
-                                  text2text_features, text_features)
+from bigbio.utils.constants import (
+    METADATA,
+    SCHEMA_TO_FEATURES,
+    TASK_TO_SCHEMA,
+    VALID_SCHEMAS,
+    VALID_TASKS,
+    Tasks,
+)
+from bigbio.utils.schemas import (
+    entailment_features,
+    kb_features,
+    pairs_features,
+    qa_features,
+    text2text_features,
+    text_features,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -153,10 +163,21 @@ class TestDataLoader(unittest.TestCase):
             metadata_attr = getattr(module, metadata_name)
 
             if metadata_name == "_LANGUAGES":
-                for lang in metadata_attr:
-                    if not isinstance(lang, metadata_type):
+
+                if not isinstance(metadata_attr, list):
+                    raise AssertionError(
+                        f"Dataloader attribute '{metadata_name}' must be a list of `{metadata_type}`! Found `{type(metadata_attr)}`!"
+                    )
+
+                if len(metadata_attr) == 0:
+                    raise AssertionError(
+                        f"Dataloader attribute '{metadata_name}' must be a list of `{metadata_type}`! Found an empty list!"
+                    )
+
+                for elem in metadata_attr:
+                    if not isinstance(elem, metadata_type):
                         raise AssertionError(
-                            f"Dataloader attribute '{metadata_name}' must be a list of `{metadata_type}`! Found `{type(lang)}`!"
+                            f"Dataloader attribute '{metadata_name}' must be a list of `{metadata_type}`! Found `{type(elem)}`!"
                         )
             else:
                 if not isinstance(metadata_attr, metadata_type):


### PR DESCRIPTION
This addresses the issue #689.

Container type for `Licenses` is changed to `SimpleNameSpace`.

```python
[ins] In [6]: from bigbio.utils.license import Licenses, License, CustomLicense

[ins] In [7]: custom = CustomLicense(text="abc")

[ins] In [8]: licens = Licenses.GPL_1p0

[ins] In [9]: type(custom), isinstance(custom, License)
Out[9]: (bigbio.utils.license.CustomLicense, True)

[ins] In [10]: type(licens), isinstance(licens, License)
Out[10]: (bigbio.utils.license.License, True)
```