### PR TITLE
Added displayname variable to all dataloaders.

### DIFF
--- a/bigbio/biodatasets/an_em/an_em.py
+++ b/bigbio/biodatasets/an_em/an_em.py
@@ -51,6 +51,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "an_em"
+_DISPLAYNAME = "AnEM"
 
 _DESCRIPTION = """\
 AnEM corpus is a domain- and species-independent resource manually annotated for anatomical

--- a/bigbio/biodatasets/anat_em/anat_em.py
+++ b/bigbio/biodatasets/anat_em/anat_em.py
@@ -47,12 +47,15 @@ _CITATION = """\
 """
 
 _DATASETNAME = "anat_em"
+_DISPLAYNAME = "AnatEM"
+
 
 _DESCRIPTION = """\
-The extended Anatomical Entity Mention corpus (AnatEM) consists of 1212 documents (approx. 250,000 words)
-manually annotated to identify over 13,000 mentions of anatomical entities. Each annotation is assigned one
-of 12 granularity-based types such as Cellular component, Tissue and Organ, defined with reference to the
-Common Anatomy Reference Ontology.
+The extended Anatomical Entity Mention corpus (AnatEM) consists of 1212 \
+documents (approx. 250,000 words) manually annotated to identify over 13,000 \
+mentions of anatomical entities. Each annotation is assigned one of 12 \
+granularity-based types such as Cellular component, Tissue and Organ, defined \
+with reference to the Common Anatomy Reference Ontology.
 """
 
 _HOMEPAGE = "http://nactem.ac.uk/anatomytagger/#AnatEM"

--- a/bigbio/biodatasets/ask_a_patient/ask_a_patient.py
+++ b/bigbio/biodatasets/ask_a_patient/ask_a_patient.py
@@ -25,6 +25,7 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "ask_a_patient"
+_DISPLAYNAME = "AskAPatient"
 
 _LANGUAGES = [Lang.EN]
 _PUBMED = True

--- a/bigbio/biodatasets/bc5cdr/bc5cdr.py
+++ b/bigbio/biodatasets/bc5cdr/bc5cdr.py
@@ -64,10 +64,12 @@ _CITATION = """\
 """
 
 _DATASETNAME = "bc5cdr"
+_DISPLAYNAME = "BC5CDR"
 
 _DESCRIPTION = """\
-The BioCreative V Chemical Disease Relation (CDR) dataset is a large annotated text corpus of
-human annotations of all chemicals, diseases and their interactions in 1,500 PubMed articles.
+The BioCreative V Chemical Disease Relation (CDR) dataset is a large annotated \
+text corpus of human annotations of all chemicals, diseases and their \
+interactions in 1,500 PubMed articles.
 """
 
 _HOMEPAGE = "http://www.biocreative.org/tasks/biocreative-v/track-3-cdr/"

--- a/bigbio/biodatasets/bc7_litcovid/bc7_litcovid.py
+++ b/bigbio/biodatasets/bc7_litcovid/bc7_litcovid.py
@@ -27,19 +27,28 @@ _LANGUAGES = [Lang.EN]
 _PUBMED = True
 _LOCAL = False
 _CITATION = """\
-@inproceedings{chen2021overview, 
-    title={Overview of the BioCreative VII LitCovid Track: multi-label topic classification for COVID-19 literature annotation}, 
-    author={Chen, Qingyu and Allot, Alexis and Leaman, Robert and Do{\\u{g}}an, Rezarta Islamaj and Lu, Zhiyong}, 
-    booktitle={Proceedings of the seventh BioCreative challenge evaluation workshop}, year={2021} 
+@inproceedings{chen2021overview,
+  title        = {
+    Overview of the BioCreative VII LitCovid Track: multi-label topic
+    classification for COVID-19 literature annotation
+  },
+  author       = {
+    Chen, Qingyu and Allot, Alexis and Leaman, Robert and Do{\\u{g}}an, Rezarta
+    Islamaj and Lu, Zhiyong
+  },
+  year         = 2021,
+  booktitle    = {Proceedings of the seventh BioCreative challenge evaluation workshop}
 }
+
 """
 
 _DATASETNAME = "bc7_litcovid"
+_DISPLAYNAME = "BC7-LitCovid"
 
 _DESCRIPTION = """\
-The training and development datasets contain the publicly-available
-text of over 30 thousand COVID-19-related articles and their metadata
-(e.g., title, abstract, journal). Articles in both datasets have been
+The training and development datasets contain the publicly-available \
+text of over 30 thousand COVID-19-related articles and their metadata \
+(e.g., title, abstract, journal). Articles in both datasets have been \
 manually reviewed and articles annotated by in-house models.
 """
 
@@ -74,7 +83,10 @@ _CLASS_NAMES = [
 
 
 class BC7LitCovidDataset(datasets.GeneratorBasedBuilder):
-    """Track 5 - LitCovid track Multi-label topic classification for COVID-19 literature annotation"""
+    """
+    Track 5 - LitCovid track Multi-label topic classification for
+    COVID-19 literature annotation
+    """
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)

--- a/bigbio/biodatasets/bio_sim_verb/bio_sim_verb.py
+++ b/bigbio/biodatasets/bio_sim_verb/bio_sim_verb.py
@@ -12,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 """
 This repository contains the evaluation datasets for the paper Bio-SimVerb and
 Bio-SimLex: Wide-coverage Evaluation Sets of Word Similarity in Biomedicine by
@@ -35,48 +33,41 @@ _LANGUAGES = [Lang.EN]
 _PUBMED = True
 _LOCAL = False
 _CITATION = """\
-@article{chiu2018bio,
-  title={Bio-SimVerb and Bio-SimLex: wide-coverage evaluation sets of word similarity in biomedicine},
-  author={Chiu, Billy and Pyysalo, Sampo and Vuli{\'c}, Ivan and Korhonen, Anna},
-  journal={BMC bioinformatics},
-  volume={19},
-  number={1},
-  pages={1--13},
-  year={2018},
-  publisher={BioMed Central}
+@article{article,
+  title        = {
+    Bio-SimVerb and Bio-SimLex: Wide-coverage evaluation sets of word
+    similarity in biomedicine
+  },
+  author       = {Chiu, Billy and Pyysalo, Sampo and Vulić, Ivan and Korhonen, Anna},
+  year         = 2018,
+  month        = {02},
+  journal      = {BMC Bioinformatics},
+  volume       = 19,
+  pages        = {},
+  doi          = {10.1186/s12859-018-2039-z}
 }
 """
 
 _DATASETNAME = "bio_sim_verb"
-
+_DISPLAYNAME = "Bio-SimVerb"
 
 _DESCRIPTION = """
-This repository contains the evaluation datasets for the paper
-Bio-SimVerb and Bio-SimLex: Wide-coverage Evaluation Sets of Word
-Similarity in Biomedicine by Billy Chiu, Sampo Pyysalo and Anna Korhonen.
+This repository contains the evaluation datasets for the paper Bio-SimVerb and \
+Bio-SimLex: Wide-coverage Evaluation Sets of Word Similarity in Biomedicine by \
+Billy Chiu, Sampo Pyysalo and Anna Korhonen.
 """
 
 _HOMEPAGE = "https://github.com/cambridgeltl/bio-simverb"
 
 _LICENSE = Licenses.UNKNOWN
 
-# TODO: Add links to the urls needed to download your dataset files.
-#  For local datasets, this variable can be an empty dictionary.
-
-# For publicly available datasets you will most likely end up passing these URLs to dl_manager in _split_generators.
-# In most cases the URLs will be the same for the source and bigbio config.
-# However, if you need to access different files for each config you can have multiple entries in this dict.
-# This can be an arbitrarily nested dict/list of URLs (see below in `_split_generators` method)
 _URLS = {
     _DATASETNAME: "https://raw.githubusercontent.com/cambridgeltl/bio-simverb/master/wvlib/word-similarities/bio-simverb/Bio-SimVerb.txt",
 }
 
-_SUPPORTED_TASKS = [
-    Tasks.SEMANTIC_SIMILARITY
-]  # example: [Tasks.TRANSLATION, Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
+_SUPPORTED_TASKS = [Tasks.SEMANTIC_SIMILARITY]
 
 _SOURCE_VERSION = "1.0.0"
-
 _BIGBIO_VERSION = "1.0.0"
 
 

--- a/bigbio/biodatasets/bio_simlex/bio_simlex.py
+++ b/bigbio/biodatasets/bio_simlex/bio_simlex.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 """
-Bio-SimLex enables intrinsic evaluation of word representations. This evaluation can serve as a predictor of
-performance on various downstream tasks in the biomedical domain. The results on Bio-SimLex using standard word
-representation models highlight the importance of developing dedicated evaluation resources for NLP in biomedicine
-for particular word classes (e.g. verbs).
-[bigbio_schema_name] = pairs
+Bio-SimLex enables intrinsic evaluation of word representations. This evaluation
+can serve as a predictor of performance on various downstream tasks in the
+biomedical domain. The results on Bio-SimLex using standard word representation
+models highlight the importance of developing dedicated evaluation resources for
+NLP in biomedicine for particular word classes (e.g. verbs).
 """
 
 from typing import Dict, List, Tuple
@@ -30,37 +30,39 @@ from bigbio.utils.configs import BigBioConfig
 from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
-# TODO: Add BibTeX citation
 _LANGUAGES = [Lang.EN]
 _PUBMED = True
 _LOCAL = False
 _CITATION = """\
 @article{article,
-author = {Chiu, Billy and Pyysalo, Sampo and Vulić, Ivan and Korhonen, Anna},
-year = {2018},
-month = {02},
-pages = {},
-title = {Bio-SimVerb and Bio-SimLex: Wide-coverage evaluation sets of word similarity in biomedicine},
-volume = {19},
-journal = {BMC Bioinformatics},
-doi = {10.1186/s12859-018-2039-z}
-}{}
+  title        = {
+    Bio-SimVerb and Bio-SimLex: Wide-coverage evaluation sets of word
+    similarity in biomedicine
+  },
+  author       = {Chiu, Billy and Pyysalo, Sampo and Vulić, Ivan and Korhonen, Anna},
+  year         = 2018,
+  month        = {02},
+  journal      = {BMC Bioinformatics},
+  volume       = 19,
+  pages        = {},
+  doi          = {10.1186/s12859-018-2039-z}
 }
 """
 
 _DATASETNAME = "bio_simlex"
+_DISPLAYNAME = "Bio-SimLex"
 
 _DESCRIPTION = """\
-Bio-SimLex enables intrinsic evaluation of word representations. This evaluation can serve as a predictor of
-performance on various downstream tasks in the biomedical domain. The results on Bio-SimLex using standard
-word representation models highlight the importance of developing dedicated evaluation resources for NLP in biomedicine
-for particular word classes (e.g. verbs).
+Bio-SimLex enables intrinsic evaluation of word representations. This evaluation \
+can serve as a predictor of performance on various downstream tasks in the \
+biomedical domain. The results on Bio-SimLex using standard word representation \
+models highlight the importance of developing dedicated evaluation resources for \
+NLP in biomedicine for particular word classes (e.g. verbs).
 """
 
 _HOMEPAGE = "https://github.com/cambridgeltl/bio-simverb"
 
 _LICENSE = Licenses.UNKNOWN
-
 
 _URLS = {
     _DATASETNAME: "https://github.com/cambridgeltl/bio-simverb/blob/master/wvlib/word-similarities/\
@@ -70,13 +72,15 @@ bio-simlex/Bio-SimLex.txt?raw=true"
 _SUPPORTED_TASKS = [Tasks.SEMANTIC_SIMILARITY]
 
 _SOURCE_VERSION = "1.0.0"
-
 _BIGBIO_VERSION = "1.0.0"
 
 
 class BioSimlexDataset(datasets.GeneratorBasedBuilder):
-    """Bio-SimLex enables intrinsic evaluation of word representations. Config schema as source gives score between
-    0-10 for pairs of words. The source schema casts labels as `float`, but the bigbio schema casts them as `str`."""
+    """
+    Bio-SimLex enables intrinsic evaluation of word representations. Config schema
+    as source gives score between 0-10 for pairs of words. The source schema casts
+    labels as `float`, but the bigbio schema casts them as `str`.
+    """
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
@@ -131,7 +135,6 @@ class BioSimlexDataset(datasets.GeneratorBasedBuilder):
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
-                # Whatever you put in gen_kwargs will be passed to _generate_examples
                 gen_kwargs={
                     "filepath": data_dir,
                     "split": "train",

--- a/bigbio/biodatasets/bioasq_2021_mesinesp/bioasq_2021_mesinesp.py
+++ b/bigbio/biodatasets/bioasq_2021_mesinesp/bioasq_2021_mesinesp.py
@@ -12,35 +12,35 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 The main aim of MESINESP2 is to promote the development of practically relevant
-semantic indexing tools for biomedical content in non-English language.
-We have generated a manually annotated corpus, where domain experts have
-labeled a set of scientific literature, clinical trials, and patent abstracts.
-All the documents were labeled with DeCS descriptors, which is a structured controlled
-vocabulary created by BIREME to index scientific publications on BvSalud, the largest
-database of scientific documents in Spanish, which hosts records from the databases
-LILACS, MEDLINE, IBECS, among others.
+semantic indexing tools for biomedical content in non-English language. We have
+generated a manually annotated corpus, where domain experts have labeled a set
+of scientific literature, clinical trials, and patent abstracts. All the
+documents were labeled with DeCS descriptors, which is a structured controlled
+vocabulary created by BIREME to index scientific publications on BvSalud, the
+largest database of scientific documents in Spanish, which hosts records from
+the databases LILACS, MEDLINE, IBECS, among others.
 
-MESINESP track at BioASQ9 explores the efficiency of systems for assigning
-DeCS to different types of biomedical documents. To that purpose, we have
-divided the task into three subtracks depending on the document type. Then, for
-each one we generated an annotated corpus which was provided to participating teams:
+MESINESP track at BioASQ9 explores the efficiency of systems for assigning DeCS
+to different types of biomedical documents. To that purpose, we have divided the
+task into three subtracks depending on the document type. Then, for each one we
+generated an annotated corpus which was provided to participating teams:
 
-[Subtrack 1 corpus] MESINESP-L – Scientific Literature: It contains all
-Spanish records from LILACS and IBECS databases at the Virtual Health Library
-(VHL) with non-empty abstract written in Spanish.
-[Subtrack 2 corpus] MESINESP-T- Clinical Trials contains records from Registro
-Español de Estudios Clínicos (REEC). REEC doesn't provide documents with the
-structure title/abstract needed in BioASQ, for that reason we have built
-artificial abstracts based on the content available in the data crawled using the REEC API.
-[Subtrack 3 corpus] MESINESP-P – Patents: This corpus includes patents in
-Spanish extracted from Google Patents which have the IPC code “A61P” and “A61K31”.
-In addition, we also provide a set of complementary data such as: the DeCS
-terminology file, a silver standard with the participants' predictions to the task
-background set and the entities of medications, diseases, symptoms and medical
-procedures extracted from the BSC NERs documents.
+- [Subtrack 1 corpus] MESINESP-L – Scientific Literature: It contains all
+  Spanish records from LILACS and IBECS databases at the Virtual Health Library
+  (VHL) with non-empty abstract written in Spanish.
+- [Subtrack 2 corpus] MESINESP-T- Clinical Trials contains records from Registro
+  Español de Estudios Clínicos (REEC). REEC doesn't provide documents with the
+  structure title/abstract needed in BioASQ, for that reason we have built
+  artificial abstracts based on the content available in the data crawled using
+  the REEC API.
+- [Subtrack 3 corpus] MESINESP-P – Patents: This corpus includes patents in
+  Spanish extracted from Google Patents which have the IPC code “A61P” and
+  “A61K31”. In addition, we also provide a set of complementary data such as:
+  the DeCS terminology file, a silver standard with the participants' predictions
+  to the task background set and the entities of medications, diseases, symptoms
+  and medical procedures extracted from the BSC NERs documents.
 """
 
 import json
@@ -75,40 +75,40 @@ _CITATION = """\
 """
 
 _DATASETNAME = "bioasq_2021_mesinesp"
+_DISPLAYNAME = "MESINESP 2021"
 
+_DESCRIPTION = """\
+The main aim of MESINESP2 is to promote the development of practically relevant \
+semantic indexing tools for biomedical content in non-English language. We have \
+generated a manually annotated corpus, where domain experts have labeled a set \
+of scientific literature, clinical trials, and patent abstracts. All the \
+documents were labeled with DeCS descriptors, which is a structured controlled \
+vocabulary created by BIREME to index scientific publications on BvSalud, the \
+largest database of scientific documents in Spanish, which hosts records from \
+the databases LILACS, MEDLINE, IBECS, among others.
 
-_DESCRIPTION = """
-The main aim of MESINESP2 is to promote the development of practically relevant
-semantic indexing tools for biomedical content in non-English language.
-We have generated a manually annotated corpus, where domain experts have
-labeled a set of scientific literature, clinical trials, and patent abstracts.
-All the documents were labeled with DeCS descriptors, which is a structured controlled
-vocabulary created by BIREME to index scientific publications on BvSalud, the largest
-database of scientific documents in Spanish, which hosts records from the databases
-LILACS, MEDLINE, IBECS, among others.
+MESINESP track at BioASQ9 explores the efficiency of systems for assigning DeCS \
+to different types of biomedical documents. To that purpose, we have divided the \
+task into three subtracks depending on the document type. Then, for each one we \
+generated an annotated corpus which was provided to participating teams:
 
-MESINESP track at BioASQ9 explores the efficiency of systems for assigning
-DeCS to different types of biomedical documents. To that purpose, we have
-divided the task into three subtracks depending on the document type. Then, for
-each one we generated an annotated corpus which was provided to participating teams:
-
-[Subtrack 1 corpus] MESINESP-L – Scientific Literature: It contains all
-Spanish records from LILACS and IBECS databases at the Virtual Health Library
-(VHL) with non-empty abstract written in Spanish.
-[Subtrack 2 corpus] MESINESP-T- Clinical Trials contains records from Registro
-Español de Estudios Clínicos (REEC). REEC doesn't provide documents with the
-structure title/abstract needed in BioASQ, for that reason we have built
-artificial abstracts based on the content available in the data crawled using the REEC API.
-[Subtrack 3 corpus] MESINESP-P – Patents: This corpus includes patents in
-Spanish extracted from Google Patents which have the IPC code “A61P” and “A61K31”.
-In addition, we also provide a set of complementary data such as: the DeCS
-terminology file, a silver standard with the participants' predictions to the task
-background set and the entities of medications, diseases, symptoms and medical
-procedures extracted from the BSC NERs documents.
+- [Subtrack 1 corpus] MESINESP-L – Scientific Literature: It contains all \
+  Spanish records from LILACS and IBECS databases at the Virtual Health Library \
+  (VHL) with non-empty abstract written in Spanish.
+- [Subtrack 2 corpus] MESINESP-T- Clinical Trials contains records from Registro \
+  Español de Estudios Clínicos (REEC). REEC doesn't provide documents with the \
+  structure title/abstract needed in BioASQ, for that reason we have built \
+  artificial abstracts based on the content available in the data crawled using \
+  the REEC API.
+- [Subtrack 3 corpus] MESINESP-P – Patents: This corpus includes patents in \
+  Spanish extracted from Google Patents which have the IPC code “A61P” and \
+  “A61K31”. In addition, we also provide a set of complementary data such as: \
+  the DeCS terminology file, a silver standard with the participants' predictions \
+  to the task background set and the entities of medications, diseases, symptoms \
+  and medical procedures extracted from the BSC NERs documents.
 """
 
 _HOMEPAGE = "https://zenodo.org/record/5602914#.YhSXJ5PMKWt"
-
 
 _LICENSE = Licenses.CC_BY_4p0
 
@@ -120,17 +120,17 @@ _URLS = {
     },
 }
 
-
 _SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
 
 _SOURCE_VERSION = "1.0.6"
-
 _BIGBIO_VERSION = "1.0.0"
 
 
 class Bioasq2021MesinespDataset(datasets.GeneratorBasedBuilder):
-    """A dataset to promote the development of practically relevant
-    semantic indexing tools for biomedical content in non-English language."""
+    """\
+    A dataset to promote the development of practically relevant
+    semantic indexing tools for biomedical content in non-English language.
+    """
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)

--- a/bigbio/biodatasets/bioasq_task_b/bioasq_task_b.py
+++ b/bigbio/biodatasets/bioasq_task_b/bioasq_task_b.py
@@ -59,7 +59,8 @@ _CITATION = """\
 }
 """
 
-_DATASETNAME = "bioasq"
+_DATASETNAME = "bioasq_task_b"
+_DISPLAYNAME = "BioASQ Task B"
 
 _BIOASQ_10B_DESCRIPTION = """\
 The data are intended to be used as training and development data for BioASQ

--- a/bigbio/biodatasets/bioasq_task_c_2017/bioasq_task_c_2017.py
+++ b/bigbio/biodatasets/bioasq_task_c_2017/bioasq_task_c_2017.py
@@ -31,25 +31,30 @@ _PUBMED = True
 _LOCAL = True
 _CITATION = """\
 @article{nentidis-etal-2017-results,
-  author    = {Nentidis, Anastasios  and Bougiatiotis, Konstantinos  and Krithara, Anastasia  and
-               Paliouras, Georgios  and Kakadiaris, Ioannis},
-  title     = {Results of the fifth edition of the {B}io{ASQ} Challenge},
-  journal   = {},
-  volume    = {BioNLP 2017},
-  year      = {2007},
-  url       = {https://aclanthology.org/W17-2306},
-  doi       = {10.18653/v1/W17-2306},
-  biburl    = {},
-  bibsource = {https://aclanthology.org/W17-2306}
+  title        = {Results of the fifth edition of the {B}io{ASQ} Challenge},
+  author       = {
+    Nentidis, Anastasios  and Bougiatiotis, Konstantinos  and Krithara,
+    Anastasia  and Paliouras, Georgios  and Kakadiaris, Ioannis
+  },
+  year         = 2007,
+  journal      = {},
+  volume       = {BioNLP 2017},
+  doi          = {10.18653/v1/W17-2306},
+  url          = {https://aclanthology.org/W17-2306},
+  biburl       = {},
+  bibsource    = {https://aclanthology.org/W17-2306}
 }
+
 """
 
 _DATASETNAME = "bioasq_task_c_2017"
+_DISPLAYNAME = "BioASQ Task C 2017"
 
 _DESCRIPTION = """\
-The training data set for this task contains annotated biomedical articles published in PubMed
-and corresponding full text from PMC. By annotated is meant that GrantIDs and corresponding
-Grant Agencies have been identified in the full text of articles.
+The training data set for this task contains annotated biomedical articles
+published in PubMed and corresponding full text from PMC. By annotated is meant
+that GrantIDs and corresponding Grant Agencies have been identified in the full
+text of articles
 """
 
 _HOMEPAGE = "http://participants-area.bioasq.org/general_information/Task5c/"
@@ -61,8 +66,6 @@ _URLS = {_DATASETNAME: "http://participants-area.bioasq.org/datasets/"}
 
 _SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
 
-# this version doesn't have to be consistent with semantic versioning. Anything that is
-# provided by the original dataset as a version goes.
 _SOURCE_VERSION = "1.0.0"
 _BIGBIO_VERSION = "1.0.0"
 
@@ -163,7 +166,7 @@ class BioASQTaskC2017(datasets.GeneratorBasedBuilder):
             ),
         ]
 
-    def _generate_examples(self, filepath, filespath, split) -> (int, dict):
+    def _generate_examples(self, filepath, filespath, split):
 
         with open(filepath) as f:
             task_data = json.load(f)

--- a/bigbio/biodatasets/bioinfer/bioinfer.py
+++ b/bigbio/biodatasets/bioinfer/bioinfer.py
@@ -14,7 +14,13 @@
 # limitations under the License.
 
 """
-The authors present BioInfer (Bio Information Extraction Resource), a new public resource providing an annotated corpus of biomedical English. We describe an annotation scheme capturing named entities and their relationships along with a dependency analysis of sentence syntax. We further present ontologies defining the types of entities and relationships annotated in the corpus. Currently, the corpus contains 1100 sentences from abstracts of biomedical research articles annotated for relationships, named entities, as well as syntactic dependencies.
+The authors present BioInfer (Bio Information Extraction Resource), a new public
+resource providing an annotated corpus of biomedical English. We describe an
+annotation scheme capturing named entities and their relationships along with a
+dependency analysis of sentence syntax. We further present ontologies defining
+the types of entities and relationships annotated in the corpus. Currently, the
+corpus contains 1100 sentences from abstracts of biomedical research articles
+annotated for relationships, named entities, as well as syntactic dependencies.
 """
 
 import os
@@ -33,24 +39,29 @@ _PUBMED = True
 _LOCAL = False
 _CITATION = """\
 @article{pyysalo2007bioinfer,
-  title={BioInfer: a corpus for information extraction in the biomedical domain},
-  author={Pyysalo, Sampo and Ginter, Filip and Heimonen, Juho and Bj{\"o}rne, Jari and Boberg, Jorma and J{\"a}rvinen, Jouni and Salakoski, Tapio},
-  journal={BMC bioinformatics},
-  volume={8},
-  number={1},
-  pages={1--24},
-  year={2007},
-  publisher={BioMed Central}
+  title        = {BioInfer: a corpus for information extraction in the biomedical domain},
+  author       = {
+    Pyysalo, Sampo and Ginter, Filip and Heimonen, Juho and Bj{\"o}rne, Jari
+    and Boberg, Jorma and J{\"a}rvinen, Jouni and Salakoski, Tapio
+  },
+  year         = 2007,
+  journal      = {BMC bioinformatics},
+  publisher    = {BioMed Central},
+  volume       = 8,
+  number       = 1,
+  pages        = {1--24}
 }
 """
 
 _DATASETNAME = "bioinfer"
+_DISPLAYNAME = "BioInfer"
 
 _DESCRIPTION = """\
-A corpus targeted at protein, gene, and RNA relationships which serves as a resource for the development of 
-information extraction systems and their components such as parsers and domain analyzers. Currently, the corpus 
-contains 1100 sentences from abstracts of biomedical research articles annotated for relationships, named entities, 
-as well as syntactic dependencies.
+A corpus targeted at protein, gene, and RNA relationships which serves as a
+resource for the development of information extraction systems and their
+components such as parsers and domain analyzers. Currently, the corpus contains
+1100 sentences from abstracts of biomedical research articles annotated for
+relationships, named entities, as well as syntactic dependencies.
 """
 
 _HOMEPAGE = "https://github.com/metalrt/ppi-dataset"
@@ -68,7 +79,10 @@ _BIGBIO_VERSION = "1.0.0"
 
 
 class BioinferDataset(datasets.GeneratorBasedBuilder):
-    """1100 sentences from abstracts of biomedical research articles annotated for relationships, named entities, as well as syntactic dependencies."""
+    """
+    1100 sentences from abstracts of biomedical research articles annotated
+    for relationships, named entities, as well as syntactic dependencies.
+    """
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)

--- a/bigbio/biodatasets/biology_how_why_corpus/biology_how_why_corpus.py
+++ b/bigbio/biodatasets/biology_how_why_corpus/biology_how_why_corpus.py
@@ -46,6 +46,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "biology_how_why_corpus"
+_DISPLAYNAME = "BiologyHowWhyCorpus"
 
 _DESCRIPTION = """\
 This dataset consists of 185 "how" and 193 "why" biology questions authored by a domain expert, with one or more gold 

--- a/bigbio/biodatasets/biomrc/biomrc.py
+++ b/bigbio/biodatasets/biomrc/biomrc.py
@@ -55,6 +55,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "biomrc"
+_DISPLAYNAME = "BIOMRC"
 
 _DESCRIPTION = """\
 We introduce BIOMRC, a large-scale cloze-style biomedical MRC dataset. Care was taken to reduce noise, compared to the

--- a/bigbio/biodatasets/bionlp_shared_task_2009/bionlp_shared_task_2009.py
+++ b/bigbio/biodatasets/bionlp_shared_task_2009/bionlp_shared_task_2009.py
@@ -47,6 +47,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "bionlp_shared_task_2009"
+_DISPLAYNAME = "BioNLP 2009"
 
 _DESCRIPTION = """\
 The BioNLP Shared Task 2009 was organized by GENIA Project and its corpora were curated based

--- a/bigbio/biodatasets/bionlp_st_2011_epi/bionlp_st_2011_epi.py
+++ b/bigbio/biodatasets/bionlp_st_2011_epi/bionlp_st_2011_epi.py
@@ -25,6 +25,8 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "bionlp_st_2011_epi"
+_DISPLAYNAME = "BioNLP 2011 EPI"
+
 _SOURCE_VIEW_NAME = "source"
 _UNIFIED_VIEW_NAME = "bigbio"
 

--- a/bigbio/biodatasets/bionlp_st_2011_ge/bionlp_st_2011_ge.py
+++ b/bigbio/biodatasets/bionlp_st_2011_ge/bionlp_st_2011_ge.py
@@ -24,6 +24,8 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "bionlp_st_2011_ge"
+_DISPLAYNAME = "BioNLP 2011 GE"
+
 _SOURCE_VIEW_NAME = "source"
 _UNIFIED_VIEW_NAME = "bigbio"
 

--- a/bigbio/biodatasets/bionlp_st_2011_id/bionlp_st_2011_id.py
+++ b/bigbio/biodatasets/bionlp_st_2011_id/bionlp_st_2011_id.py
@@ -24,6 +24,8 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "bionlp_st_2011_id"
+_DISPLAYNAME = "BioNLP 2011 ID"
+
 _SOURCE_VIEW_NAME = "source"
 _UNIFIED_VIEW_NAME = "bigbio"
 

--- a/bigbio/biodatasets/bionlp_st_2011_rel/bionlp_st_2011_rel.py
+++ b/bigbio/biodatasets/bionlp_st_2011_rel/bionlp_st_2011_rel.py
@@ -24,6 +24,8 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "bionlp_st_2011_rel"
+_DISPLAYNAME = "BioNLP 2011 REL"
+
 _SOURCE_VIEW_NAME = "source"
 _UNIFIED_VIEW_NAME = "bigbio"
 

--- a/bigbio/biodatasets/bionlp_st_2013_cg/bionlp_st_2013_cg.py
+++ b/bigbio/biodatasets/bionlp_st_2013_cg/bionlp_st_2013_cg.py
@@ -24,6 +24,8 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "bionlp_st_2013_cg"
+_DISPLAYNAME = "BioNLP 2013 CG"
+
 _UNIFIED_VIEW_NAME = "bigbio"
 
 _LANGUAGES = [Lang.EN]

--- a/bigbio/biodatasets/bionlp_st_2013_ge/bionlp_st_2013_ge.py
+++ b/bigbio/biodatasets/bionlp_st_2013_ge/bionlp_st_2013_ge.py
@@ -24,6 +24,8 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "bionlp_st_2013_ge"
+_DISPLAYNAME = "BioNLP 2013 GE"
+
 _SOURCE_VIEW_NAME = "source"
 _UNIFIED_VIEW_NAME = "bigbio"
 

--- a/bigbio/biodatasets/bionlp_st_2013_gro/bionlp_st_2013_gro.py
+++ b/bigbio/biodatasets/bionlp_st_2013_gro/bionlp_st_2013_gro.py
@@ -25,6 +25,8 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "bionlp_st_2013_gro"
+_DISPLAYNAME = "BioNLP 2013 GRO"
+
 _SOURCE_VIEW_NAME = "source"
 _UNIFIED_VIEW_NAME = "bigbio"
 

--- a/bigbio/biodatasets/bionlp_st_2013_pc/bionlp_st_2013_pc.py
+++ b/bigbio/biodatasets/bionlp_st_2013_pc/bionlp_st_2013_pc.py
@@ -24,6 +24,8 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "bionlp_st_2013_pc"
+_DISPLAYNAME = "BioNLP 2013 PC"
+
 _UNIFIED_VIEW_NAME = "bigbio"
 
 _LANGUAGES = [Lang.EN]

--- a/bigbio/biodatasets/bionlp_st_2019_bb/bionlp_st_2019_bb.py
+++ b/bigbio/biodatasets/bionlp_st_2019_bb/bionlp_st_2019_bb.py
@@ -24,6 +24,8 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "bionlp_st_2019_bb"
+_DISPLAYNAME = "BioNLP 2019 BB"
+
 _SOURCE_VIEW_NAME = "source"
 _UNIFIED_VIEW_NAME = "bigbio"
 

--- a/bigbio/biodatasets/biored/biored.py
+++ b/bigbio/biodatasets/biored/biored.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 
 """
-Relation Extraction corpus with multiple entity types (e.g., gene/protein, disease, chemical) and relation pairs (e.g., gene-disease; chemical-chemical), on a set of 600 PubMed articles
+Relation Extraction corpus with multiple entity types (e.g., gene/protein,
+disease, chemical) and relation pairs (e.g., gene-disease; chemical-chemical),
+on a set of 600 PubMed articles
 """
 
 import itertools
@@ -29,34 +31,37 @@ from bigbio.utils.configs import BigBioConfig
 from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
-# TODO: Add BibTeX citation
 _LANGUAGES = [Lang.EN]
 _PUBMED = True
 _LOCAL = False
 _CITATION = """\
-  @misc{https://doi.org/10.48550/arxiv.2204.04263,
-  doi = {10.48550/ARXIV.2204.04263},
-
-  url = {https://arxiv.org/abs/2204.04263},
-
-  author = {Luo, Ling and Lai, Po-Ting and Wei, Chih-Hsuan and Arighi, Cecilia N and Lu, Zhiyong},
-
-  keywords = {Computation and Language (cs.CL), FOS: Computer and information sciences, FOS: Computer and information sciences},
-
-  title = {BioRED: A Comprehensive Biomedical Relation Extraction Dataset},
-
-  publisher = {arXiv},
-
-  year = {2022},
-
-  copyright = {Creative Commons Attribution 4.0 International}
+@article{DBLP:journals/corr/abs-2204-04263,
+  author    = {Ling Luo and
+               Po{-}Ting Lai and
+               Chih{-}Hsuan Wei and
+               Cecilia N. Arighi and
+               Zhiyong Lu},
+  title     = {BioRED: {A} Comprehensive Biomedical Relation Extraction Dataset},
+  journal   = {CoRR},
+  volume    = {abs/2204.04263},
+  year      = {2022},
+  url       = {https://doi.org/10.48550/arXiv.2204.04263},
+  doi       = {10.48550/arXiv.2204.04263},
+  eprinttype = {arXiv},
+  eprint    = {2204.04263},
+  timestamp = {Wed, 11 May 2022 15:24:37 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-2204-04263.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
 }
-
 """
 
 _DATASETNAME = "biored"
+_DISPLAYNAME = "BioRED"
 
-_DESCRIPTION = """Relation Extraction corpus with multiple entity types (e.g., gene/protein, disease, chemical) and relation pairs (e.g., gene-disease; chemical-chemical), on a set of 600 PubMed articles
+_DESCRIPTION = """\
+Relation Extraction corpus with multiple entity types (e.g., gene/protein,
+disease, chemical) and relation pairs (e.g., gene-disease; chemical-chemical),
+on a set of 600 PubMed articles
 """
 
 _HOMEPAGE = "https://ftp.ncbi.nlm.nih.gov/pub/lu/BioRED/"

--- a/bigbio/biodatasets/biorelex/biorelex.py
+++ b/bigbio/biodatasets/biorelex/biorelex.py
@@ -14,16 +14,20 @@
 # limitations under the License.
 
 """
-BioRelEx is a biological relation extraction dataset. Version 1.0 contains 2010 annotated sentences that describe
-binding interactions between various biological entities (proteins, chemicals, etc.). 1405 sentences are for training,
-another 201 sentences are for validation. They are publicly available at https://github.com/YerevaNN/BioRelEx/releases.
-Another 404 sentences are for testing which are kept private for at this Codalab competition https:
-//competitions.codalab.org/competitions/20468. All sentences contain words "bind", "bound" or "binding". For every
-sentence we provide: 1) Complete annotations of all biological entities that appear in the sentence 2) Entity types (32
-types) and grounding information for most of the proteins and families (links to uniprot, interpro and other databases)
-3) Coreference between entities in the same sentence (e.g. abbreviations and synonyms) 4) Binding interactions between
-the annotated entities 5) Binding interaction types: positive, negative (A does not bind B) and neutral (A may bind to
-B)
+BioRelEx is a biological relation extraction dataset. Version 1.0 contains 2010
+annotated sentences that describe binding interactions between various
+biological entities (proteins, chemicals, etc.). 1405 sentences are for
+training, another 201 sentences are for validation. They are publicly available
+at https://github.com/YerevaNN/BioRelEx/releases. Another 404 sentences are for
+testing which are kept private for at this Codalab competition
+https://competitions.codalab.org/competitions/20468. All sentences contain words
+"bind", "bound" or "binding". For every sentence we provide: 1) Complete
+annotations of all biological entities that appear in the sentence 2) Entity
+types (32 types) and grounding information for most of the proteins and families
+(links to uniprot, interpro and other databases) 3) Coreference between entities
+in the same sentence (e.g. abbreviations and synonyms) 4) Binding interactions
+between the annotated entities 5) Binding interaction types: positive, negative
+(A does not bind B) and neutral (A may bind to B)
 """
 
 import itertools as it
@@ -65,19 +69,23 @@ _CITATION = """\
 """
 
 _DATASETNAME = "biorelex"
+_DISPLAYNAME = "BioRelEx"
 
 _DESCRIPTION = """\
-BioRelEx is a biological relation extraction dataset. Version 1.0 contains 2010 annotated sentences that describe
-binding interactions between various biological entities (proteins, chemicals, etc.). 1405 sentences are for training,
-another 201 sentences are for validation. They are publicly available at https://github.com/YerevaNN/BioRelEx/releases.
-Another 404 sentences are for testing which are kept private for at this Codalab competition https:
-//competitions.codalab.org/competitions/20468. All sentences contain words "bind", "bound" or "binding". For every
-sentence we provide: 1) Complete annotations of all biological entities that appear in the sentence 2) Entity types (32
-types) and grounding information for most of the proteins and families (links to uniprot, interpro and other databases)
-3) Coreference between entities in the same sentence (e.g. abbreviations and synonyms) 4) Binding interactions between
-the annotated entities 5) Binding interaction types: positive, negative (A does not bind B) and neutral (A may bind to
-B)
-"""
+BioRelEx is a biological relation extraction dataset. Version 1.0 contains 2010
+annotated sentences that describe binding interactions between various
+biological entities (proteins, chemicals, etc.). 1405 sentences are for
+training, another 201 sentences are for validation. They are publicly available
+at https://github.com/YerevaNN/BioRelEx/releases. Another 404 sentences are for
+testing which are kept private for at this Codalab competition
+https://competitions.codalab.org/competitions/20468. All sentences contain words
+"bind", "bound" or "binding". For every sentence we provide: 1) Complete
+annotations of all biological entities that appear in the sentence 2) Entity
+types (32 types) and grounding information for most of the proteins and families
+(links to uniprot, interpro and other databases) 3) Coreference between entities
+in the same sentence (e.g. abbreviations and synonyms) 4) Binding interactions
+between the annotated entities 5) Binding interaction types: positive, negative
+(A does not bind B) and neutral (A may bind to B)"""
 
 _HOMEPAGE = "https://github.com/YerevaNN/BioRelEx"
 

--- a/bigbio/biodatasets/bioscope/bioscope.py
+++ b/bigbio/biodatasets/bioscope/bioscope.py
@@ -16,13 +16,15 @@
 """
 BioScope
 ---
-The corpus consists of three parts, namely medical free texts, biological full papers and biological scientific
-abstracts. The dataset contains annotations at the token level for negative and speculative keywords and at the
-sentence level for their linguistic scope. The annotation process was carried out by two independent linguist
-annotators and a chief linguist – also responsible for setting up the annotation guidelines – who resolved cases
-where the annotators disagreed. The resulting corpus consists of more than 20.000 sentences that were considered
-for annotation and over 10% of them actually contain one (or more) linguistic annotation suggesting negation or
-uncertainty.
+The corpus consists of three parts, namely medical free texts, biological full
+papers and biological scientific abstracts. The dataset contains annotations at
+the token level for negative and speculative keywords and at the sentence level
+for their linguistic scope. The annotation process was carried out by two
+independent linguist annotators and a chief linguist - also responsible for
+setting up the annotation guidelines - who resolved cases where the annotators
+disagreed. The resulting corpus consists of more than 20.000 sentences that were
+considered for annotation and over 10% of them actually contain one (or more)
+linguistic annotation suggesting negation or uncertainty.
 """
 
 import os
@@ -55,12 +57,16 @@ _CITATION = """\
 """
 
 _DATASETNAME = "bioscope"
+_DISPLAYNAME = "BioScope"
+
 
 _DESCRIPTION = """\
-The BioScope corpus consists of medical and biological texts annotated for negation, speculation and their linguistic 
-scope. This was done to allow a comparison between the development of systems for negation/hedge detection and scope 
-resolution. The BioScope corpus was annotated by two independent linguists following the guidelines written by our 
-linguist expert before the annotation of the corpus was initiated.
+The BioScope corpus consists of medical and biological texts annotated for
+negation, speculation and their linguistic scope. This was done to allow a
+comparison between the development of systems for negation/hedge detection and
+scope resolution. The BioScope corpus was annotated by two independent linguists
+following the guidelines written by our linguist expert before the annotation of
+the corpus was initiated.
 """
 
 _HOMEPAGE = "https://rgai.inf.u-szeged.hu/node/105"

--- a/bigbio/biodatasets/biosses/biosses.py
+++ b/bigbio/biodatasets/biosses/biosses.py
@@ -32,6 +32,7 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "biosses"
+_DISPLAYNAME = "BIOSSES"
 
 _LANGUAGES = [Lang.EN]
 _PUBMED = False

--- a/bigbio/biodatasets/cadec/cadec.py
+++ b/bigbio/biodatasets/cadec/cadec.py
@@ -54,6 +54,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "cadec"
+_DISPLAYNAME = "CADEC"
 
 _DESCRIPTION = """\
 The CADEC corpus (CSIRO Adverse Drug Event Corpus) is is a new rich annotated corpus of medical forum posts on patient-

--- a/bigbio/biodatasets/cantemist/cantemist.py
+++ b/bigbio/biodatasets/cantemist/cantemist.py
@@ -49,6 +49,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "cantemist"
+_DISPLAYNAME = "CANTEMIST"
 
 _DESCRIPTION = """\
 Collection of 1301 oncological clinical case reports written in Spanish, with tumor morphology mentions \

--- a/bigbio/biodatasets/cas/cas.py
+++ b/bigbio/biodatasets/cas/cas.py
@@ -1,3 +1,17 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import os
 
 import datasets
@@ -14,25 +28,54 @@ _PUBMED = False
 _LOCAL = True
 _CITATION = """\
 @inproceedings{grabar-etal-2018-cas,
-    title = "{CAS}: {F}rench Corpus with Clinical Cases",
-    author = "Grabar, Natalia  and
-      Claveau, Vincent  and
-      Dalloux, Cl{\'e}ment",
-    booktitle = "Proceedings of the Ninth International Workshop on Health Text Mining and Information Analysis",
-    month = oct,
-    year = "2018",
-    address = "Brussels, Belgium",
-    publisher = "Association for Computational Linguistics",
-    url = "https://aclanthology.org/W18-5614",
-    doi = "10.18653/v1/W18-5614",
-    pages = "122--128",
-    abstract = "Textual corpora are extremely important for various NLP applications as they provide information necessary for creating, setting and testing these applications and the corresponding tools. They are also crucial for designing reliable methods and reproducible results. Yet, in some areas, such as the medical area, due to confidentiality or to ethical reasons, it is complicated and even impossible to access textual data representative of those produced in these areas. We propose the CAS corpus built with clinical cases, such as they are reported in the published scientific literature in French. We describe this corpus, currently containing over 397,000 word occurrences, and the existing linguistic and semantic annotations.",
+  title        = {{CAS}: {F}rench Corpus with Clinical Cases},
+  author       = {Grabar, Natalia  and Claveau, Vincent  and Dalloux, Cl{\'e}ment},
+  year         = 2018,
+  month        = oct,
+  booktitle    = {
+    Proceedings of the Ninth International Workshop on Health Text Mining and
+    Information Analysis
+  },
+  publisher    = {Association for Computational Linguistics},
+  address      = {Brussels, Belgium},
+  pages        = {122--128},
+  doi          = {10.18653/v1/W18-5614},
+  url          = {https://aclanthology.org/W18-5614},
+  abstract     = {
+    Textual corpora are extremely important for various NLP applications as
+    they provide information necessary for creating, setting and testing these
+    applications and the corresponding tools. They are also crucial for
+    designing reliable methods and reproducible results. Yet, in some areas,
+    such as the medical area, due to confidentiality or to ethical reasons, it
+    is complicated and even impossible to access textual data representative of
+    those produced in these areas. We propose the CAS corpus built with
+    clinical cases, such as they are reported in the published scientific
+    literature in French. We describe this corpus, currently containing over
+    397,000 word occurrences, and the existing linguistic and semantic
+    annotations.
+  }
 }"""
 
-_DatasetName = "cas"
+_DATASETNAME = "cas"
+_DISPLAYNAME = "CAS"
 
 _DESCRIPTION = """\
-We manually annotated two corpora from the biomedical field. The ESSAI corpus contains clinical trial protocols in French. They were mainly obtained from the National Cancer Institute The typical protocol consists of two parts: the summary of the trial, which indicates the purpose of the trial and the methods applied; and a detailed description of the trial with the inclusion and exclusion criteria. The CAS corpus contains clinical cases published in scientific literature and training material. They are published in different journals from French-speaking countries (France, Belgium, Switzerland, Canada, African countries, tropical countries) and are related to various medical specialties (cardiology, urology, oncology, obstetrics, pulmonology, gastro-enterology). The purpose of clinical cases is to describe clinical situations of patients. Hence, their content is close to the content of clinical narratives (description of diagnoses, treatments or procedures, evolution, family history, expected audience, etc.). In clinical cases, the negation is frequently used for describing the patient signs, symptoms, and diagnosis. Speculation is present as well but less frequently.
+We manually annotated two corpora from the biomedical field. The ESSAI corpus \
+contains clinical trial protocols in French. They were mainly obtained from the \
+National Cancer Institute The typical protocol consists of two parts: the \
+summary of the trial, which indicates the purpose of the trial and the methods \
+applied; and a detailed description of the trial with the inclusion and \
+exclusion criteria. The CAS corpus contains clinical cases published in \
+scientific literature and training material. They are published in different \
+journals from French-speaking countries (France, Belgium, Switzerland, Canada, \
+African countries, tropical countries) and are related to various medical \
+specialties (cardiology, urology, oncology, obstetrics, pulmonology, \
+gastro-enterology). The purpose of clinical cases is to describe clinical \
+situations of patients. Hence, their content is close to the content of clinical \
+narratives (description of diagnoses, treatments or procedures, evolution, \
+family history, expected audience, etc.). In clinical cases, the negation is \
+frequently used for describing the patient signs, symptoms, and diagnosis. \
+Speculation is present as well but less frequently.
 
 This version only contain the annotated CAS corpus
 """

--- a/bigbio/biodatasets/cellfinder/cellfinder.py
+++ b/bigbio/biodatasets/cellfinder/cellfinder.py
@@ -13,12 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-The CellFinder project aims to create a stem cell data repository by linking information from existing public databases
- and by performing text mining on the research literature. The first version of the corpus is composed
- of 10 full text documents containing more than 2,100 sentences, 65,000 tokens and 5,200 annotations for entities.
- The corpus has been annotated with six types of entities (anatomical parts, cell components, cell lines, cell types,
- genes/protein and species) with an overall inter-annotator agreement around 80%.
-(see https://www.informatik.hu-berlin.de/de/forschung/gebiete/wbi/resources/cellfinder/).
+The CellFinder project aims to create a stem cell data repository by linking
+information from existing public databases and by performing text mining on the
+research literature. The first version of the corpus is composed of 10 full text
+documents containing more than 2,100 sentences, 65,000 tokens and 5,200
+annotations for entities. The corpus has been annotated with six types of
+entities (anatomical parts, cell components, cell lines, cell types,
+genes/protein and species) with an overall inter-annotator agreement around 80%.
+
+See: https://www.informatik.hu-berlin.de/de/forschung/gebiete/wbi/resources/cellfinder/
 """
 from pathlib import Path
 from typing import Dict, Iterator, Tuple
@@ -36,25 +39,32 @@ _PUBMED = True
 _LOCAL = False
 _CITATION = """\
 @inproceedings{neves2012annotating,
-  title={Annotating and evaluating text for stem cell research},
-  author={Neves, Mariana and Damaschun, Alexander and Kurtz, Andreas and Leser, Ulf},
-  booktitle={Proceedings of the Third Workshop on Building and Evaluation Resources for Biomedical Text Mining\
-   (BioTxtM 2012) at Language Resources and Evaluation (LREC). Istanbul, Turkey},
-  pages={16--23},
-  year={2012},
-  organization={Citeseer}
+  title        = {Annotating and evaluating text for stem cell research},
+  author       = {Neves, Mariana and Damaschun, Alexander and Kurtz, Andreas and Leser, Ulf},
+  year         = 2012,
+  booktitle    = {
+    Proceedings of the Third Workshop on Building and Evaluation Resources for
+    Biomedical Text Mining\ (BioTxtM 2012) at Language Resources and Evaluation
+    (LREC). Istanbul, Turkey
+  },
+  pages        = {16--23},
+  organization = {Citeseer}
 }
 """
 
 _DATASETNAME = "cellfinder"
+_DISPLAYNAME = "CellFinder"
 
 _DESCRIPTION = """\
-The CellFinder project aims to create a stem cell data repository by linking information from existing public databases
- and by performing text mining on the research literature. The first version of the corpus is composed
- of 10 full text documents containing more than 2,100 sentences, 65,000 tokens and 5,200 annotations for entities.
- The corpus has been annotated with six types of entities (anatomical parts, cell components, cell lines, cell types,
- genes/protein and species) with an overall inter-annotator agreement around 80%.
-(see https://www.informatik.hu-berlin.de/de/forschung/gebiete/wbi/resources/cellfinder/).
+The CellFinder project aims to create a stem cell data repository by linking \
+information from existing public databases and by performing text mining on the \
+research literature. The first version of the corpus is composed of 10 full text \
+documents containing more than 2,100 sentences, 65,000 tokens and 5,200 \
+annotations for entities. The corpus has been annotated with six types of \
+entities (anatomical parts, cell components, cell lines, cell types, \
+genes/protein and species) with an overall inter-annotator agreement around 80%.
+
+See: https://www.informatik.hu-berlin.de/de/forschung/gebiete/wbi/resources/cellfinder/
 """
 
 _HOMEPAGE = (
@@ -70,9 +80,7 @@ _URLS = {
     _DATASETNAME + "_splits": _SOURCE_URL + "cellfinder1_brat_sections.tar.gz",
 }
 
-_SUPPORTED_TASKS = [
-    Tasks.NAMED_ENTITY_RECOGNITION
-]  # example: [Tasks.TRANSLATION, Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
 
 _SOURCE_VERSION = "1.0.0"
 _BIGBIO_VERSION = "1.0.0"

--- a/bigbio/biodatasets/chebi_nactem/chebi_nactem.py
+++ b/bigbio/biodatasets/chebi_nactem/chebi_nactem.py
@@ -29,26 +29,39 @@ _LANGUAGES = [Lang.EN]
 _PUBMED = True
 _LOCAL = False
 _CITATION = """\
-@InProceedings{Shardlow2018,
-author = {Shardlow, M J and Nguyen, N and Owen, G and O'Donovan, C and Leach, A and McNaught, J and Turner,
-S and Ananiadou, S},
-booktitle = {Proceedings of the Eleventh International Conference on Language Resources and Evaluation ({LREC} 2018)},
-title = {A New Corpus to Support Text Mining for the Curation of Metabolites in the {ChEBI} Database},
-year = {2018},
-month = may,
-pages = {280--285},
-conference = {Eleventh International Conference on Language Resources and Evaluation (LREC 2018)},
-language = {en},
-location = {Miyazaki, Japan},
+@inproceedings{Shardlow2018,
+  title        = {
+    A New Corpus to Support Text Mining for the Curation of Metabolites in the
+    {ChEBI} Database
+  },
+  author       = {
+    Shardlow, M J and Nguyen, N and Owen, G and O'Donovan, C and Leach, A and
+    McNaught, J and Turner, S and Ananiadou, S
+  },
+  year         = 2018,
+  month        = may,
+  booktitle    = {
+    Proceedings of the Eleventh International Conference on Language Resources
+    and Evaluation ({LREC} 2018)
+  },
+  location     = {Miyazaki, Japan},
+  pages        = {280--285},
+  conference   = {
+    Eleventh International Conference on Language Resources and Evaluation
+    (LREC 2018)
+  },
+  language     = {en}
 }
 """
 
 _DATASETNAME = "chebi_nactem"
+_DISPLAYNAME = "CHEBI Corpus"
 
 _DESCRIPTION = """\
 The ChEBI corpus contains 199 annotated abstracts and 100 annotated full papers.
-All documents in the corpus have been annotated for named entities and relations between these.
-In total, our corpus provides over 15000 named entity annotations and over 6,000 relations between entities.
+All documents in the corpus have been annotated for named entities and relations
+between these. In total, our corpus provides over 15000 named entity annotations
+and over 6,000 relations between entities.
 """
 
 _HOMEPAGE = "http://www.nactem.ac.uk/chebi"

--- a/bigbio/biodatasets/chemdner/chemdner.py
+++ b/bigbio/biodatasets/chemdner/chemdner.py
@@ -30,105 +30,80 @@ _LANGUAGES = [Lang.EN]
 _PUBMED = True
 _LOCAL = False
 _CITATION = """\
-@Article{Krallinger2015,
-author={Krallinger,
-Martin and Rabal,
-Obdulia and Leitner,
-Florian and Vazquez,
-Miguel and Salgado,
-David and Lu,
-Zhiyong and Leaman,
-Robert and Lu,
-Yanan and Ji,
-Donghong and Lowe,
-Daniel M. and Sayle,
-Roger A. and Batista-Navarro,
-Riza Theresa and Rak,
-Rafal and Huber,
-Torsten and Rockt{\"a}schel,
-Tim and Matos,
-S{\'e}rgio and Campos,
-David and Tang,
-Buzhou and Xu,
-Hua and Munkhdalai,
-Tsendsuren and Ryu,
-Keun Ho and Ramanan,
-S. V. and Nathan,
-Senthil and {\v{Z}}itnik,
-Slavko and Bajec,
-Marko and Weber,
-Lutz and Irmer,
-Matthias and Akhondi,
-Saber A. and Kors,
-Jan A. and Xu,
-Shuo and An,
-Xin and Sikdar,
-Utpal Kumar and Ekbal,
-Asif and Yoshioka,
-Masaharu and Dieb,
-Thaer M. and Choi,
-Miji and Verspoor,
-Karin and Khabsa,
-Madian and Giles,
-C. Lee and Liu,
-Hongfang and Ravikumar,
-Komandur Elayavilli and Lamurias,
-Andre and Couto,
-Francisco M. and Dai,
-Hong-Jie and Tsai,
-Richard Tzong-Han and Ata,
-Caglar and Can,
-Tolga and Usi{\'e},
-Anabel and Alves,
-Rui and Segura-Bedmar,
-Isabel and Mart{\'i}nez,
-Paloma and Oyarzabal,
-Julen and Valencia,
-Alfonso},
-title={The CHEMDNER corpus of chemicals and drugs and its annotation principles},
-journal={Journal of Cheminformatics},
-year={2015},
-month={Jan},
-day={19},
-volume={7},
-number={1},
-pages={S2},
-abstract={
-    The automatic extraction of chemical information from text requires the recognition of chemical entity mentions
-    as one of its key steps. When developing supervised named entity recognition (NER) systems, the availability of
-    a large, manually annotated text corpus is desirable. Furthermore, large corpora permit the robust evaluation
-    and comparison of different approaches that detect chemicals in documents. We present the CHEMDNER corpus,
-    a collection of 10,000 PubMed abstracts that contain a total of 84,355 chemical entity mentions labeled manually
-    by expert chemistry literature curators, following annotation guidelines specifically defined for this task.
-    The abstracts of the CHEMDNER corpus were selected to be representative for all major chemical disciplines.
-    Each of the chemical entity mentions was manually labeled according to its structure-associated chemical entity
-    mention (SACEM) class: abbreviation, family, formula, identifier, multiple, systematic and trivial.
-    The difficulty and consistency of tagging chemicals in text was measured using an agreement study between
-    annotators, obtaining a percentage agreement of 91. For a subset of the CHEMDNER corpus
-    (the test set of 3,000 abstracts) we provide not only the Gold Standard manual annotations, but also
-    mentions automatically detected by the 26 teams that participated in the BioCreative IV CHEMDNER
-    chemical mention recognition task. In addition, we release the CHEMDNER silver standard corpus of automatically
-    extracted mentions from 17,000 randomly selected PubMed abstracts. A version of the CHEMDNER corpus in
-    the BioC format has been generated as well. We propose a standard for required minimum information about
-    entity annotations for the construction of domain specific corpora on chemical and drug entities.
-    The CHEMDNER corpus and annotation guidelines are available at:
+@article{Krallinger2015,
+  title        = {The CHEMDNER corpus of chemicals and drugs and its annotation principles},
+  author       = {
+    Krallinger, Martin and Rabal, Obdulia and Leitner, Florian and Vazquez,
+    Miguel and Salgado, David and Lu, Zhiyong and Leaman, Robert and Lu, Yanan
+    and Ji, Donghong and Lowe, Daniel M. and Sayle, Roger A. and
+    Batista-Navarro, Riza Theresa and Rak, Rafal and Huber, Torsten and
+    Rockt{\"a}schel, Tim and Matos, S{\'e}rgio and Campos, David and Tang,
+    Buzhou and Xu, Hua and Munkhdalai, Tsendsuren and Ryu, Keun Ho and Ramanan,
+    S. V. and Nathan, Senthil and {\v{Z}}itnik, Slavko and Bajec, Marko and
+    Weber, Lutz and Irmer, Matthias and Akhondi, Saber A. and Kors, Jan A. and
+    Xu, Shuo and An, Xin and Sikdar, Utpal Kumar and Ekbal, Asif and Yoshioka,
+    Masaharu and Dieb, Thaer M. and Choi, Miji and Verspoor, Karin and Khabsa,
+    Madian and Giles, C. Lee and Liu, Hongfang and Ravikumar, Komandur
+    Elayavilli and Lamurias, Andre and Couto, Francisco M. and Dai, Hong-Jie
+    and Tsai, Richard Tzong-Han and Ata, Caglar and Can, Tolga and Usi{\'e},
+    Anabel and Alves, Rui and Segura-Bedmar, Isabel and Mart{\'i}nez, Paloma
+    and Oyarzabal, Julen and Valencia, Alfonso
+  },
+  year         = 2015,
+  month        = {Jan},
+  day          = 19,
+  journal      = {Journal of Cheminformatics},
+  volume       = 7,
+  number       = 1,
+  pages        = {S2},
+  doi          = {10.1186/1758-2946-7-S1-S2},
+  issn         = {1758-2946},
+  url          = {https://doi.org/10.1186/1758-2946-7-S1-S2},
+  abstract     = {
+    The automatic extraction of chemical information from text requires the
+    recognition of chemical entity mentions as one of its key steps. When
+    developing supervised named entity recognition (NER) systems, the
+    availability of a large, manually annotated text corpus is desirable.
+    Furthermore, large corpora permit the robust evaluation and comparison of
+    different approaches that detect chemicals in documents. We present the
+    CHEMDNER corpus, a collection of 10,000 PubMed abstracts that contain a
+    total of 84,355 chemical entity mentions labeled manually by expert
+    chemistry literature curators, following annotation guidelines specifically
+    defined for this task. The abstracts of the CHEMDNER corpus were selected
+    to be representative for all major chemical disciplines. Each of the
+    chemical entity mentions was manually labeled according to its
+    structure-associated chemical entity mention (SACEM) class: abbreviation,
+    family, formula, identifier, multiple, systematic and trivial. The
+    difficulty and consistency of tagging chemicals in text was measured using
+    an agreement study between annotators, obtaining a percentage agreement of
+    91. For a subset of the CHEMDNER corpus (the test set of 3,000 abstracts)
+    we provide not only the Gold Standard manual annotations, but also mentions
+    automatically detected by the 26 teams that participated in the BioCreative
+    IV CHEMDNER chemical mention recognition task. In addition, we release the
+    CHEMDNER silver standard corpus of automatically extracted mentions from
+    17,000 randomly selected PubMed abstracts. A version of the CHEMDNER corpus
+    in the BioC format has been generated as well. We propose a standard for
+    required minimum information about entity annotations for the construction
+    of domain specific corpora on chemical and drug entities. The CHEMDNER
+    corpus and annotation guidelines are available at:
     ttp://www.biocreative.org/resources/biocreative-iv/chemdner-corpus/
-},
-issn={1758-2946},
-doi={10.1186/1758-2946-7-S1-S2},
-url={https://doi.org/10.1186/1758-2946-7-S1-S2}
+  }
 }
 """
 
 _DESCRIPTION = """\
-We present the CHEMDNER corpus, a collection of 10,000 PubMed abstracts that contain a total of 84,355 chemical entity
-mentions labeled manually by expert chemistry literature curators, following annotation guidelines specifically
-defined for this task. The abstracts of the CHEMDNER corpus were selected to be representative for all major chemical
-disciplines. Each of the chemical entity mentions was manually labeled according to its structure-associated chemical
-entity mention (SACEM) class: abbreviation, family, formula, identifier, multiple, systematic and trivial.
+We present the CHEMDNER corpus, a collection of 10,000 PubMed abstracts that
+contain a total of 84,355 chemical entity mentions labeled manually by expert
+chemistry literature curators, following annotation guidelines specifically
+defined for this task. The abstracts of the CHEMDNER corpus were selected to be
+representative for all major chemical disciplines. Each of the chemical entity
+mentions was manually labeled according to its structure-associated chemical
+entity mention (SACEM) class: abbreviation, family, formula, identifier,
+multiple, systematic and trivial.
 """
 
-_DATASETNAME = "CHEMDNER"
+_DATASETNAME = "chemdner"
+_DISPLAYNAME = "CHEMDNER"
 
 _HOMEPAGE = "https://biocreative.bioinformatics.udel.edu/resources/biocreative-iv/chemdner-corpus/"
 
@@ -178,7 +153,7 @@ class CHEMDNERDataset(datasets.GeneratorBasedBuilder):
         ),
     ]
 
-    DEFAULT_CONFIG_NAME = "chemdner_source"  # It's not mandatory to have a default configuration. Just use one if it make sense.
+    DEFAULT_CONFIG_NAME = "chemdner_source"
 
     def _info(self):
 

--- a/bigbio/biodatasets/chemprot/chemprot.py
+++ b/bigbio/biodatasets/chemprot/chemprot.py
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-The BioCreative VI Chemical-Protein interaction dataset identifies entities of chemicals and proteins and their likely
-relation to one other. Compounds are generally agonists (activators) or antagonists (inhibitors) of proteins.
-The script loads dataset in bigbio schema (using knowledgebase schema: schemas/kb) AND/OR source (default) schema
-
+The BioCreative VI Chemical-Protein interaction dataset identifies entities of
+chemicals and proteins and their likely relation to one other. Compounds are
+generally agonists (activators) or antagonists (inhibitors) of proteins. The
+script loads dataset in bigbio schema (using knowledgebase schema: schemas/kb)
+AND/OR source (default) schema
 """
 import os
 from typing import Dict, Tuple
@@ -34,9 +35,9 @@ _LOCAL = False
 _CITATION = """\
 @article{DBLP:journals/biodb/LiSJSWLDMWL16,
   author    = {Krallinger, M., Rabal, O., Lourenço, A.},
-  title     = {Overview of the BioCreative VI chemical–protein interaction Track},
+  title     = {Overview of the BioCreative VI chemical-protein interaction Track},
   journal   = {Proceedings of the BioCreative VI Workshop,},
-  volume    = {141–146},
+  volume    = {141-146},
   year      = {2017},
   url       = {https://biocreative.bioinformatics.udel.edu/tasks/biocreative-vi/track-5/},
   doi       = {},
@@ -45,8 +46,13 @@ _CITATION = """\
 }
 """
 _DESCRIPTION = """\
-The BioCreative VI Chemical-Protein interaction dataset identifies entities of chemicals and proteins and their likely relation to one other. Compounds are generally agonists (activators) or antagonists (inhibitors) of proteins.
+The BioCreative VI Chemical-Protein interaction dataset identifies entities of
+chemicals and proteins and their likely relation to one other. Compounds are
+generally agonists (activators) or antagonists (inhibitors) of proteins.
 """
+
+_DATASETNAME = "chemprot"
+_DISPLAYNAME = "ChemProt"
 
 _HOMEPAGE = "https://biocreative.bioinformatics.udel.edu/tasks/biocreative-vi/track-5/"
 

--- a/bigbio/biodatasets/chia/chia.py
+++ b/bigbio/biodatasets/chia/chia.py
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-A large annotated corpus of patient eligibility criteria extracted from 1,000 interventional, Phase IV clinical
-trials registered in ClinicalTrials.gov. This dataset includes 12,409 annotated eligibility criteria, represented
-by 41,487 distinctive entities of 15 entity types and 25,017 relationships of 12 relationship types.
-"""
+A large annotated corpus of patient eligibility criteria extracted from 1,000
+interventional, Phase IV clinical trials registered in ClinicalTrials.gov. This
+dataset includes 12,409 annotated eligibility criteria, represented by 41,487
+distinctive entities of 15 entity types and 25,017 relationships of 12
+relationship types."""
 from pathlib import Path
 from typing import Dict, Iterator, List, Tuple
 
@@ -33,24 +34,30 @@ _PUBMED = False
 _LOCAL = False
 _CITATION = """\
 @article{kury2020chia,
-  title={Chia, a large annotated corpus of clinical trial eligibility criteria},
-  author={Kury, Fabr{\'\\i}cio and Butler, Alex and Yuan, Chi and Fu, Li-heng and Sun, Yingcheng and Liu,
-          Hao and Sim, Ida and Carini, Simona and Weng, Chunhua},
-  journal={Scientific data},
-  volume={7},
-  number={1},
-  pages={1--11},
-  year={2020},
-  publisher={Nature Publishing Group}
+  title        = {Chia, a large annotated corpus of clinical trial eligibility criteria},
+  author       = {
+    Kury, Fabr{\'\\i}cio and Butler, Alex and Yuan, Chi and Fu, Li-heng and
+    Sun, Yingcheng and Liu, Hao and Sim, Ida and Carini, Simona and Weng,
+    Chunhua
+  },
+  year         = 2020,
+  journal      = {Scientific data},
+  publisher    = {Nature Publishing Group},
+  volume       = 7,
+  number       = 1,
+  pages        = {1--11}
 }
 """
 
 _DATASETNAME = "chia"
+_DISPLAYNAME = "CHIA"
 
 _DESCRIPTION = """\
-A large annotated corpus of patient eligibility criteria extracted from 1,000 interventional, Phase IV clinical
-trials registered in ClinicalTrials.gov. This dataset includes 12,409 annotated eligibility criteria, represented
-by 41,487 distinctive entities of 15 entity types and 25,017 relationships of 12 relationship types.
+A large annotated corpus of patient eligibility criteria extracted from 1,000
+interventional, Phase IV clinical trials registered in ClinicalTrials.gov. This
+dataset includes 12,409 annotated eligibility criteria, represented by 41,487
+distinctive entities of 15 entity types and 25,017 relationships of 12
+relationship types.
 """
 
 _HOMEPAGE = "https://github.com/WengLab-InformaticsResearch/CHIA"

--- a/bigbio/biodatasets/citation_gia_test_collection/citation_gia_test_collection.py
+++ b/bigbio/biodatasets/citation_gia_test_collection/citation_gia_test_collection.py
@@ -32,25 +32,28 @@ _PUBMED = True
 _LOCAL = False
 _CITATION = """\
 @article{Wei2015,
-  doi = {10.1155/2015/918710},
-  url = {https://doi.org/10.1155/2015/918710},
-  year = {2015},
-  publisher = {Hindawi Limited},
-  volume = {2015},
-  pages = {1--7},
-  author = {Chih-Hsuan Wei and Hung-Yu Kao and Zhiyong Lu},
-  title = {{GNormPlus}: An Integrative Approach for Tagging Genes,  Gene Families,  and Protein Domains},
-  journal = {{BioMed} Research International}
+  title        = {
+    {GNormPlus}: An Integrative Approach for Tagging Genes,  Gene Families,
+    and Protein Domains
+  },
+  author       = {Chih-Hsuan Wei and Hung-Yu Kao and Zhiyong Lu},
+  year         = 2015,
+  journal      = {{BioMed} Research International},
+  publisher    = {Hindawi Limited},
+  volume       = 2015,
+  pages        = {1--7},
+  doi          = {10.1155/2015/918710},
+  url          = {https://doi.org/10.1155/2015/918710}
 }
 """
 
 _DATASETNAME = "citation_gia_test_collection"
+_DISPLAYNAME = "Citation GIA Test Collection"
 
 _DESCRIPTION = """\
-The Citation GIA Test Collection was recently created for gene 
-indexing at the NLM and includes 151 PubMed abstracts with both 
-mention-level and document-level annotations. 
-They are selected because both have a focus on human genes.
+The Citation GIA Test Collection was recently created for gene indexing at the
+NLM and includes 151 PubMed abstracts with both mention-level and document-level
+annotations. They are selected because both have a focus on human genes.
 """
 
 _HOMEPAGE = "https://www.ncbi.nlm.nih.gov/research/bionlp/Tools/gnormplus/"
@@ -59,22 +62,21 @@ _LICENSE = Licenses.UNKNOWN
 
 _URLS = {
     _DATASETNAME: [
-        "https://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/tmTools/download/GNormPlus/GNormPlusCorpus.zip"]
+        "https://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/tmTools/download/GNormPlus/GNormPlusCorpus.zip"
+    ]
 }
 
-_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION,
-                    Tasks.NAMED_ENTITY_DISAMBIGUATION]
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION]
 
 _SOURCE_VERSION = "1.0.0"
-
 _BIGBIO_VERSION = "1.0.0"
 
 
 class CitationGIATestCollection(datasets.GeneratorBasedBuilder):
     """
-    The Citation GIA Test Collection was recently created for gene indexing at the NLM and includes 
-    151 PubMed abstracts with both mention-level and document-level annotations. 
-    They are selected because both have a focus on human genes.
+    The Citation GIA Test Collection was recently created for gene indexing at the
+    NLM and includes 151 PubMed abstracts with both mention-level and document-level
+    annotations. They are selected because both have a focus on human genes.
     """
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
@@ -94,7 +96,7 @@ class CitationGIATestCollection(datasets.GeneratorBasedBuilder):
             description="citation_gia_test_collection BigBio schema",
             schema="bigbio_kb",
             subset_id="citation_gia_test_collection",
-        )
+        ),
     ]
 
     DEFAULT_CONFIG_NAME = "citation_gia_test_collection_source"
@@ -126,7 +128,7 @@ class CitationGIATestCollection(datasets.GeneratorBasedBuilder):
                                 }
                             ],
                         }
-                    ]
+                    ],
                 }
             )
 
@@ -150,16 +152,18 @@ class CitationGIATestCollection(datasets.GeneratorBasedBuilder):
             datasets.SplitGenerator(
                 name=datasets.Split.TEST,
                 gen_kwargs={
-                    "filepath": os.path.join(data_dir[0], "GNormPlusCorpus/NLMIAT.BioC.xml"),
+                    "filepath": os.path.join(
+                        data_dir[0], "GNormPlusCorpus/NLMIAT.BioC.xml"
+                    ),
                     "split": "NLMIAT",
                 },
             ),
         ]
 
     def _get_entities(self, annot_d: dict) -> dict:
-        ''''
+        """'
         Converts annotation dict to entity dict.
-        '''
+        """
         ent = {
             "id": str(uuid.uuid4()),
             "type": annot_d["type"],
@@ -175,13 +179,15 @@ class CitationGIATestCollection(datasets.GeneratorBasedBuilder):
 
         return ent
 
-    def _get_offsets_entities(child, parent_text: str, child_text: str, offset: int) -> List[int]:
-        '''
-        Extracts child text offsets from parent text for entities. 
+    def _get_offsets_entities(
+        child, parent_text: str, child_text: str, offset: int
+    ) -> List[int]:
+        """
+        Extracts child text offsets from parent text for entities.
         Some offsets that were present in the datset were wrong mainly because of string encodings.
-        Also a little fraction of parent strings doesn't contain its respective child strings. 
-        Hence few assertion errors in the entitity offsets checking test. 
-        '''
+        Also a little fraction of parent strings doesn't contain its respective child strings.
+        Hence few assertion errors in the entitity offsets checking test.
+        """
         if child_text in parent_text:
             index = parent_text.index(child_text)
             start = index + offset
@@ -193,10 +199,10 @@ class CitationGIATestCollection(datasets.GeneratorBasedBuilder):
         return [start, end]
 
     def _process_annot(self, annot: ET.Element, passages: dict) -> dict:
-        ''''
+        """'
         Converts annotation XML Element to Python dict.
-        '''
-        parent_text = " ".join([p['text'] for p in passages.values()])
+        """
+        parent_text = " ".join([p["text"] for p in passages.values()])
         annot_d = dict()
         a_d = {a.tag: a.text for a in annot}
 
@@ -205,21 +211,21 @@ class CitationGIATestCollection(datasets.GeneratorBasedBuilder):
             if a.tag == "location":
                 offset = int(a.attrib["offset"])
                 annot_d["offsets"] = self._get_offsets_entities(
-                    html.escape(parent_text[offset:]),
-                    html.escape(a_d["text"]), offset)
+                    html.escape(parent_text[offset:]), html.escape(a_d["text"]), offset
+                )
 
             elif a.tag != "infon":
                 annot_d[a.tag] = html.escape(a.text)
 
             else:
                 annot_d[a.attrib["key"]] = html.escape(a.text)
-                
+
         return annot_d
 
     def _parse_elem(self, elem: ET.Element) -> dict:
-        ''''
+        """'
         Converts document XML Element to Python dict.
-        '''
+        """
         elem_d = dict()
         passages = dict()
         annotations = elem.findall(".//annotation")
@@ -230,8 +236,21 @@ class CitationGIATestCollection(datasets.GeneratorBasedBuilder):
 
         for child in elem:
             if child.tag == "passage":
-                elem_d[child.tag].append({c.tag: html.escape(" ".join(list(filter(
-                    lambda item: item, [t.strip('\n') for t in c.itertext()])))) for c in child})
+                elem_d[child.tag].append(
+                    {
+                        c.tag: html.escape(
+                            " ".join(
+                                list(
+                                    filter(
+                                        lambda item: item,
+                                        [t.strip("\n") for t in c.itertext()],
+                                    )
+                                )
+                            )
+                        )
+                        for c in child
+                    }
+                )
 
             elif child.tag == "id":
                 elem_d[child.tag] = html.escape(child.text)
@@ -242,11 +261,10 @@ class CitationGIATestCollection(datasets.GeneratorBasedBuilder):
             passages[infon] = passage
 
         elem_d["passages"] = passages
-        elem_d.pop('passage', None)
+        elem_d.pop("passage", None)
 
         for a in annotations:
-            elem_d["entities"].append(
-                self._process_annot(a, elem_d["passages"]))
+            elem_d["entities"].append(self._process_annot(a, elem_d["passages"]))
 
         return elem_d
 
@@ -260,31 +278,35 @@ class CitationGIATestCollection(datasets.GeneratorBasedBuilder):
                 row = self._parse_elem(elem)
                 uid += 1
                 passages = row["passages"]
-                yield uid,  {
+                yield uid, {
                     "id": str(uid),
                     "passages": [
                         {
                             "id": str(uuid.uuid4()),
                             "type": "title",
                             "text": [passages["title"]["text"]],
-                            "offsets": [[
-                                int(passages["title"]["offset"]),
-                                int(passages["title"]["offset"]) +
-                                len(passages["title"]["text"])
-                            ]],
+                            "offsets": [
+                                [
+                                    int(passages["title"]["offset"]),
+                                    int(passages["title"]["offset"])
+                                    + len(passages["title"]["text"]),
+                                ]
+                            ],
                         },
                         {
                             "id": str(uuid.uuid4()),
                             "type": "abstract",
                             "text": [passages["abstract"]["text"]],
-                            "offsets": [[
-                                int(passages["abstract"]["offset"]),
-                                int(passages["abstract"]["offset"]) +
-                                len(passages["abstract"]["text"])
-                            ]],
-                        }
+                            "offsets": [
+                                [
+                                    int(passages["abstract"]["offset"]),
+                                    int(passages["abstract"]["offset"])
+                                    + len(passages["abstract"]["text"]),
+                                ]
+                            ],
+                        },
                     ],
-                    "entities": [self._get_entities(a) for a in row["entities"]]
+                    "entities": [self._get_entities(a) for a in row["entities"]],
                 }
 
         elif self.config.schema == "bigbio_kb":
@@ -293,7 +315,7 @@ class CitationGIATestCollection(datasets.GeneratorBasedBuilder):
                 row = self._parse_elem(elem)
                 uid += 1
                 passages = row["passages"]
-                yield uid,  {
+                yield uid, {
                     "id": str(uid),
                     "document_id": str(uuid.uuid4()),
                     "passages": [
@@ -301,26 +323,29 @@ class CitationGIATestCollection(datasets.GeneratorBasedBuilder):
                             "id": str(uuid.uuid4()),
                             "type": "title",
                             "text": [passages["title"]["text"]],
-                            "offsets": [[
-                                int(passages["title"]["offset"]),
-                                int(passages["title"]["offset"]) +
-                                len(passages["title"]
-                                    ["text"])
-                            ]],
+                            "offsets": [
+                                [
+                                    int(passages["title"]["offset"]),
+                                    int(passages["title"]["offset"])
+                                    + len(passages["title"]["text"]),
+                                ]
+                            ],
                         },
                         {
                             "id": str(uuid.uuid4()),
                             "type": "abstract",
                             "text": [passages["abstract"]["text"]],
-                            "offsets": [[
-                                int(passages["abstract"]["offset"]),
-                                int(passages["abstract"]["offset"]) +
-                                len(passages["abstract"]["text"])
-                            ]],
-                        }
+                            "offsets": [
+                                [
+                                    int(passages["abstract"]["offset"]),
+                                    int(passages["abstract"]["offset"])
+                                    + len(passages["abstract"]["text"]),
+                                ]
+                            ],
+                        },
                     ],
                     "entities": [self._get_entities(a) for a in row["entities"]],
                     "relations": [],
                     "events": [],
-                    "coreferences": []
+                    "coreferences": [],
                 }

--- a/bigbio/biodatasets/codiesp/codiesp.py
+++ b/bigbio/biodatasets/codiesp/codiesp.py
@@ -52,36 +52,44 @@ _CITATION = """\
 """
 
 _DATASETNAME = "codiesp"
+_DISPLAYNAME = "CodiEsp"
 
 _DESCRIPTION = """\
-Synthetic corpus of 1,000 manually selected clinical case studies in Spanish that was designed for \
-the Clinical Case Coding in Spanish Shared Task, as part of the CLEF 2020 conference.
+Synthetic corpus of 1,000 manually selected clinical case studies in Spanish
+that was designed for the Clinical Case Coding in Spanish Shared Task, as part
+of the CLEF 2020 conference.
 
-The goal of the task was to automatically assign ICD10 codes (CIE-10, in Spanish) to clinical case documents,
-being evaluated against manually generated ICD10 codifications. The CodiEsp corpus was selected manually by \
-practicing physicians and clinical documentalists and annotated by clinical coding professionals meeting strict \
-quality criteria. They reached an inter-annotator agreement of 88.6\% for diagnosis coding, 88.9\% for procedure \
-coding and 80.5\% for the textual reference annotation.
+The goal of the task was to automatically assign ICD10 codes (CIE-10, in
+Spanish) to clinical case documents, being evaluated against manually generated
+ICD10 codifications. The CodiEsp corpus was selected manually by practicing
+physicians and clinical documentalists and annotated by clinical coding
+professionals meeting strict quality criteria. They reached an inter-annotator
+agreement of 88.6% for diagnosis coding, 88.9% for procedure coding and 80.5%
+for the textual reference annotation.
 
-The final collection of 1,000 clinical cases that make up the corpus had a total of 16,504 sentences and \
-396,988 words. All documents are in Spanish language and CIE10 is the coding terminology (the Spanish version \
-of ICD10-CM and ICD10-PCS). The CodiEsp corpus has been randomly sampled into three subsets. \
-The train set contains 500 clinical cases, while the development and test sets have 250 clinical cases each. \
-In addition to these, a collection of 176,294 abstracts from Lilacs and Ibecs with the corresponding ICD10 \
-codes (ICD10-CM and ICD10-PCS) was provided by the task organizers. Every abstract has at least one associated \
-code, with an average of 2.5 ICD10 codes per abstract.
+The final collection of 1,000 clinical cases that make up the corpus had a total
+of 16,504 sentences and 396,988 words. All documents are in Spanish language and
+CIE10 is the coding terminology (the Spanish version of ICD10-CM and ICD10-PCS).
+The CodiEsp corpus has been randomly sampled into three subsets. The train set
+contains 500 clinical cases, while the development and test sets have 250
+clinical cases each. In addition to these, a collection of 176,294 abstracts
+from Lilacs and Ibecs with the corresponding ICD10 codes (ICD10-CM and
+ICD10-PCS) was provided by the task organizers. Every abstract has at least one
+associated code, with an average of 2.5 ICD10 codes per abstract.
 
 The CodiEsp track was divided into three sub-tracks (2 main and 1 exploratory):
 
-CodiEsp-D: The Diagnosis Coding sub-task, which requires automatic ICD10-CM [CIE10-Diagnóstico] code assignment.
+- CodiEsp-D: The Diagnosis Coding sub-task, which requires automatic ICD10-CM
+  [CIE10-Diagnóstico] code assignment.
+- CodiEsp-P: The Procedure Coding sub-task, which requires automatic ICD10-PCS
+  [CIE10-Procedimiento] code assignment.
+- CodiEsp-X: The Explainable AI exploratory sub-task, which requires to submit
+  the reference to the predicted codes (both ICD10-CM and ICD10-PCS). The goal 
+  of this novel task was not only to predict the correct codes but also to 
+  present the reference in the text that supports the code predictions.
 
-CodiEsp-P: The Procedure Coding sub-task, which requires automatic ICD10-PCS [CIE10-Procedimiento] code assignment.
-
-CodiEsp-X: The Explainable AI exploratory sub-task, which requires to submit the reference to the predicted codes \
-(both ICD10-CM and ICD10-PCS). The goal of this novel task was not only to predict the correct codes but also to \
-present the reference in the text that supports the code predictions.
-
-For further information, please visit https://temu.bsc.es/codiesp or send an email to encargo-pln-life@bsc.es
+For further information, please visit https://temu.bsc.es/codiesp or send an
+email to encargo-pln-life@bsc.es
 """
 
 _HOMEPAGE = "https://temu.bsc.es/codiesp/"

--- a/bigbio/biodatasets/cord_ner/cord_ner.py
+++ b/bigbio/biodatasets/cord_ner/cord_ner.py
@@ -12,11 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
-CORD-NER dataset covers 75 fine-grained entity types: In addition to the common biomedical entity types (e.g., genes, chemicals and diseases), it covers many new entity types related explicitly to the COVID-19 studies (e.g., coronaviruses, viral proteins, evolution, materials, substrates and immune responses), which may benefit research on COVID-19 related virus, spreading mechanisms, and potential vaccines. CORD-NER annotation is a combination of four sources with different NER methods.
+CORD-NER dataset covers 75 fine-grained entity types: In addition to the common
+biomedical entity types (e.g., genes, chemicals and diseases), it covers many
+new entity types related explicitly to the COVID-19 studies (e.g.,
+coronaviruses, viral proteins, evolution, materials, substrates and immune
+responses), which may benefit research on COVID-19 related virus, spreading
+mechanisms, and potential vaccines. CORD-NER annotation is a combination of four
+sources with different NER methods.
 """
-
 import json
 import os
 from typing import Dict, List, Tuple
@@ -38,8 +42,8 @@ _CITATION = """\
                Yingjun Guan and
                Bangzheng Li and
                Jiawei Han},
-  title     = {Comprehensive Named Entity Recognition on {CORD-19} with Distant or
-               Weak Supervision},
+  title     = {Comprehensive Named Entity Recognition on {CORD-19} with 
+               Distant or Weak Supervision},
   journal   = {CoRR},
   volume    = {abs/2003.12218},
   year      = {2020},
@@ -52,12 +56,17 @@ _CITATION = """\
 }
 """
 
-
 _DATASETNAME = "cord_ner"
-
+_DISPLAYNAME = "CORD-NER"
 
 _DESCRIPTION = """\
-CORD-NER dataset covers 75 fine-grained entity types: In addition to the common biomedical entity types (e.g., genes, chemicals and diseases), it covers many new entity types related explicitly to the COVID-19 studies (e.g., coronaviruses, viral proteins, evolution, materials, substrates and immune responses), which may benefit research on COVID-19 related virus, spreading mechanisms, and potential vaccines. CORD-NER annotation is a combination of four sources with different NER methods.
+CORD-NER dataset covers 75 fine-grained entity types: In addition to the common
+biomedical entity types (e.g., genes, chemicals and diseases), it covers many
+new entity types related explicitly to the COVID-19 studies (e.g.,
+coronaviruses, viral proteins, evolution, materials, substrates and immune
+responses), which may benefit research on COVID-19 related virus, spreading
+mechanisms, and potential vaccines. CORD-NER annotation is a combination of four
+sources with different NER methods.
 """
 
 _HOMEPAGE = "https://xuanwang91.github.io/2020-03-20-cord19-ner/"
@@ -86,7 +95,6 @@ _URLS = {
 _SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
 
 _SOURCE_VERSION = "1.0.0"
-
 _BIGBIO_VERSION = "1.0.0"
 
 
@@ -130,12 +138,6 @@ class CordNERDataset(datasets.GeneratorBasedBuilder):
     DEFAULT_CONFIG_NAME = "cord_ner_source"
 
     def _info(self) -> datasets.DatasetInfo:
-
-        # Create the source schema; this schema will keep all keys/information/labels as close to the original dataset as possible.
-
-        # You can arbitrarily nest lists and dictionaries.
-        # For iterables, use lists over tuples or `datasets.Sequence`
-
         if self.config.schema == "source":
             if self.config.name == "cord_ner_source":
                 features = datasets.Features(

--- a/bigbio/biodatasets/ctebmsp/ctebmsp.py
+++ b/bigbio/biodatasets/ctebmsp/ctebmsp.py
@@ -56,6 +56,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "ctebmsp"
+_DISPLAYNAME = "CT-EBM-SP"
 
 _ABSTRACTS_DESCRIPTION = """\
 The "abstracts" subset of the Clinical Trials for Evidence-Based Medicine in Spanish
@@ -95,6 +96,7 @@ _URLS = {
 }
 
 _SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
 _SOURCE_VERSION = "1.0.0"
 _BIGBIO_VERSION = "1.0.0"
 

--- a/bigbio/biodatasets/ddi_corpus/ddi_corpus.py
+++ b/bigbio/biodatasets/ddi_corpus/ddi_corpus.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 """
-The DDI corpus has been manually annotated with drugs and pharmacokinetics and pharmacodynamics
-interactions. It contains 1025 documents from two different sources: DrugBank database and MedLine.
+The DDI corpus has been manually annotated with drugs and pharmacokinetics and
+pharmacodynamics interactions. It contains 1025 documents from two different
+sources: DrugBank database and MedLine.
 """
 
 import os
@@ -35,25 +36,34 @@ _PUBMED = True
 _LOCAL = False
 _CITATION = """\
 @article{HERREROZAZO2013914,
-    title        = {The DDI corpus: An annotated corpus with pharmacological substances and drug–drug interactions},
-    author       = {María Herrero-Zazo and Isabel Segura-Bedmar and Paloma Martínez and Thierry Declerck},
-    year         = 2013,
-    journal      = {Journal of Biomedical Informatics},
-    volume       = 46,
-    number       = 5,
-    pages        = {914--920},
-    doi          = {https://doi.org/10.1016/j.jbi.2013.07.011},
-    issn         = {1532-0464},
-    url          = {https://www.sciencedirect.com/science/article/pii/S1532046413001123},
-    keywords     = {Biomedical corpora, Drug interaction, Information extraction},
+  title        = {
+    The DDI corpus: An annotated corpus with pharmacological substances and
+    drug-drug interactions
+  },
+  author       = {
+    María Herrero-Zazo and Isabel Segura-Bedmar and Paloma Martínez and Thierry
+    Declerck
+  },
+  year         = 2013,
+  journal      = {Journal of Biomedical Informatics},
+  volume       = 46,
+  number       = 5,
+  pages        = {914--920},
+  doi          = {https://doi.org/10.1016/j.jbi.2013.07.011},
+  issn         = {1532-0464},
+  url          = {https://www.sciencedirect.com/science/article/pii/S1532046413001123},
+  keywords     = {Biomedical corpora, Drug interaction, Information extraction}
 }
+
 """
 
 _DATASETNAME = "ddi_corpus"
+_DISPLAYNAME = "DDI Corpus"
 
 _DESCRIPTION = """\
-The DDI corpus has been manually annotated with drugs and pharmacokinetics and pharmacodynamics
-interactions. It contains 1025 documents from two different sources: DrugBank database and MedLine.
+The DDI corpus has been manually annotated with drugs and pharmacokinetics and \
+pharmacodynamics interactions. It contains 1025 documents from two different \
+sources: DrugBank database and MedLine.
 """
 
 _HOMEPAGE = "https://github.com/isegura/DDICorpus"

--- a/bigbio/biodatasets/diann_iber_eval/diann_iber_eval.py
+++ b/bigbio/biodatasets/diann_iber_eval/diann_iber_eval.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 """
-DIANN's corpus consists of a collection of 500 abstracts from Elsevier journal papers
-related to the biomedical domain, where both Spanish and English versions are available,
-with annotations for disabilities appearing in these abstracts.
+DIANN's corpus consists of a collection of 500 abstracts from Elsevier journal
+papers related to the biomedical domain, where both Spanish and English versions
+are available, with annotations for disabilities appearing in these abstracts.
 """
 
 from collections import defaultdict
@@ -55,22 +55,25 @@ _CITATION = """\
 """
 
 _DATASETNAME = "diann_iber_eval"
+_DISPLAYNAME = "DIANN"
 
 _DESCRIPTION = """\
-DIANN's corpus consists of a collection of 500 abstracts from Elsevier journal papers
-related to the biomedical domain, where both Spanish and English versions are available.
+DIANN's corpus consists of a collection of 500 abstracts from Elsevier journal \
+papers related to the biomedical domain, where both Spanish and English versions \
+are available.
 
-This dataset contains annotations for disabilities appearing in these abstracts,
-usually expressed either with a specific word, such as "blindness", or as the limitation
-or lack of a human function, such as "lack of vision".
+This dataset contains annotations for disabilities appearing in these abstracts, \
+usually expressed either with a specific word, such as "blindness", or as the \
+limitation or lack of a human function, such as "lack of vision".
 
 (Spanish)
-El corpus DIANN se compone de una colección de 500 resúmenes de artículos de revista Elsevier
-del ámbito biomédico, con versiones en español e inglés.
+El corpus DIANN se compone de una colección de 500 resúmenes de artículos de \
+revista Elsevier del ámbito biomédico, con versiones en español e inglés.
 
-Este conjunto de datos contiene anotaciones para discapacidades que aparecen en dichos resúmenes,
-expresadas por medio de palabras específicas, como "ablepsia", or como la limitación o falta de
-una función, como "falta de visión".
+Este conjunto de datos contiene anotaciones para discapacidades que aparecen en \
+dichos resúmenes, expresadas por medio de palabras específicas, como \
+"ablepsia", or como la limitación o falta de una función, como "falta de \
+visión".
 """
 
 _HOMEPAGE = "http://nlp.uned.es/diann/"

--- a/bigbio/biodatasets/distemist/distemist.py
+++ b/bigbio/biodatasets/distemist/distemist.py
@@ -42,6 +42,8 @@ _CITATION = """\
 """
 
 _DATASETNAME = "distemist"
+_DISPLAYNAME = "DisTEMIST"
+
 _DESCRIPTION = """\
 The DisTEMIST corpus is a collection of 1000 clinical cases with disease annotations linked with Snomed-CT concepts.
 All documents are released in the context of the BioASQ DisTEMIST track for CLEF 2022.

--- a/bigbio/biodatasets/ebm_pico/ebm_pico.py
+++ b/bigbio/biodatasets/ebm_pico/ebm_pico.py
@@ -54,6 +54,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "ebm_pico"
+_DISPLAYNAME = "EBM NLP"
 
 _DESCRIPTION = """\
 This corpus release contains 4,993 abstracts annotated with (P)articipants,
@@ -65,7 +66,9 @@ _HOMEPAGE = "https://github.com/bepnye/EBM-NLP"
 
 _LICENSE = Licenses.UNKNOWN
 
-_URLS = {_DATASETNAME: "https://github.com/bepnye/EBM-NLP/raw/master/ebm_nlp_2_00.tar.gz"}
+_URLS = {
+    _DATASETNAME: "https://github.com/bepnye/EBM-NLP/raw/master/ebm_nlp_2_00.tar.gz"
+}
 
 _SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
 
@@ -138,7 +141,9 @@ def _get_entities_pico(
 
             for _indices in multiple_indices:
                 high_level_type = LABEL_DECODERS["starting_spans"][annotation_type][1]
-                fine_grained_type = LABEL_DECODERS["hierarchical_labels"][annotation_type][annotations[_indices[0]]]
+                fine_grained_type = LABEL_DECODERS["hierarchical_labels"][
+                    annotation_type
+                ][annotations[_indices[0]]]
                 annotation_text = " ".join([tokenized[ind] for ind in _indices])
 
                 char_start = document_content.find(annotation_text)
@@ -221,7 +226,9 @@ class EbmPico(datasets.GeneratorBasedBuilder):
         data_dir = dl_manager.download_and_extract(urls)
 
         documents_folder = Path(data_dir) / "ebm_nlp_2_00" / "documents"
-        annotations_folder = Path(data_dir) / "ebm_nlp_2_00" / "annotations" / "aggregated"
+        annotations_folder = (
+            Path(data_dir) / "ebm_nlp_2_00" / "annotations" / "aggregated"
+        )
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
@@ -241,7 +248,9 @@ class EbmPico(datasets.GeneratorBasedBuilder):
             ),
         ]
 
-    def _generate_examples(self, documents_folder, annotations_folder, split_folder: str) -> Tuple[int, Dict]:
+    def _generate_examples(
+        self, documents_folder, annotations_folder, split_folder: str
+    ) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
         annotation_types = ["interventions", "outcomes", "participants"]
 
@@ -264,11 +273,15 @@ class EbmPico(datasets.GeneratorBasedBuilder):
                     with open(
                         f"{annotations_folder}/hierarchical_labels/{annotation_type}/{split_folder}/{document}"
                     ) as fp:
-                        annotation_dict[annotation_type] = [int(x) for x in fp.read().splitlines()]
+                        annotation_dict[annotation_type] = [
+                            int(x) for x in fp.read().splitlines()
+                        ]
                 except OSError:
                     annotation_dict[annotation_type] = []
 
-            ents = _get_entities_pico(annotation_dict, tokenized=tokenized, document_content=document_content)
+            ents = _get_entities_pico(
+                annotation_dict, tokenized=tokenized, document_content=document_content
+            )
 
             if self.config.schema == "source":
 
@@ -279,7 +292,9 @@ class EbmPico(datasets.GeneratorBasedBuilder):
                         {
                             "text": ent["annotation_text"],
                             "annotation_type": ent["high_level_annotation_type"],
-                            "fine_grained_annotation_type": ent["fine_grained_annotation_type"],
+                            "fine_grained_annotation_type": ent[
+                                "fine_grained_annotation_type"
+                            ],
                             "start": ent["char_start"],
                             "end": ent["char_end"],
                         }

--- a/bigbio/biodatasets/ehr_rel/ehr_rel.py
+++ b/bigbio/biodatasets/ehr_rel/ehr_rel.py
@@ -54,6 +54,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "ehr_rel"
+_DISPLAYNAME = "EHR-Rel"
 
 _DESCRIPTION = """\
 EHR-Rel is a novel open-source1 biomedical concept relatedness dataset consisting of 3630 concept pairs, six times more

--- a/bigbio/biodatasets/essai/essai.py
+++ b/bigbio/biodatasets/essai/essai.py
@@ -16,10 +16,26 @@ _CITATION = """\
  @misc{dalloux, title={Datasets – Clément Dalloux}, url={http://clementdalloux.fr/?page_id=28}, journal={Clément Dalloux}, author={Dalloux, Clément}} 
 """
 
-_DatasetName = "essai"
+_DATASETNAME = "essai"
+_DISPLAYNAME = "ESSAI"
 
 _DESCRIPTION = """\
-We manually annotated two corpora from the biomedical field. The ESSAI corpus contains clinical trial protocols in French. They were mainly obtained from the National Cancer Institute The typical protocol consists of two parts: the summary of the trial, which indicates the purpose of the trial and the methods applied; and a detailed description of the trial with the inclusion and exclusion criteria. The CAS corpus contains clinical cases published in scientific literature and training material. They are published in different journals from French-speaking countries (France, Belgium, Switzerland, Canada, African countries, tropical countries) and are related to various medical specialties (cardiology, urology, oncology, obstetrics, pulmonology, gastro-enterology). The purpose of clinical cases is to describe clinical situations of patients. Hence, their content is close to the content of clinical narratives (description of diagnoses, treatments or procedures, evolution, family history, expected audience, etc.). In clinical cases, the negation is frequently used for describing the patient signs, symptoms, and diagnosis. Speculation is present as well but less frequently.
+We manually annotated two corpora from the biomedical field. The ESSAI corpus \
+contains clinical trial protocols in French. They were mainly obtained from the \
+National Cancer Institute The typical protocol consists of two parts: the \
+summary of the trial, which indicates the purpose of the trial and the methods \
+applied; and a detailed description of the trial with the inclusion and \
+exclusion criteria. The CAS corpus contains clinical cases published in \
+scientific literature and training material. They are published in different \
+journals from French-speaking countries (France, Belgium, Switzerland, Canada, \
+African countries, tropical countries) and are related to various medical \
+specialties (cardiology, urology, oncology, obstetrics, pulmonology, \
+gastro-enterology). The purpose of clinical cases is to describe clinical \
+situations of patients. Hence, their content is close to the content of clinical \
+narratives (description of diagnoses, treatments or procedures, evolution, \
+family history, expected audience, etc.). In clinical cases, the negation is \
+frequently used for describing the patient signs, symptoms, and diagnosis. \
+Speculation is present as well but less frequently.
 
 This version only contain the annotated ESSAI corpus
 """

--- a/bigbio/biodatasets/euadr/euadr.py
+++ b/bigbio/biodatasets/euadr/euadr.py
@@ -28,11 +28,22 @@ abstract = {Corpora with specific entities and relationships annotated are essen
 }
 """
 
-_DatasetName = "euadr"
+_DATASETNAME = "euadr"
+_DISPLAYNAME = "EU-ADR"
 
 _DESCRIPTION = """\
-Corpora with specific entities and relationships annotated are essential to train and evaluate text-mining systems that are developed to extract specific structured information from a large corpus. In this paper we describe an approach where a named-entity recognition system produces a first annotation and annotators revise this annotation using a web-based interface. The agreement figures achieved show that the inter-annotator agreement is much better than the agreement with the system provided annotations. The corpus has been annotated for drugs, disorders, genes and their inter-relationships. For each of the drug–disorder, drug–target, and target–disorder relations three experts have annotated a set of 100 abstracts. These annotated relationships will be used to train and evaluate text-mining software to capture these relationships in texts.
-
+Corpora with specific entities and relationships annotated are essential to \
+train and evaluate text-mining systems that are developed to extract specific \
+structured information from a large corpus. In this paper we describe an \
+approach where a named-entity recognition system produces a first annotation and \
+annotators revise this annotation using a web-based interface. The agreement \
+figures achieved show that the inter-annotator agreement is much better than the \
+agreement with the system provided annotations. The corpus has been annotated \
+for drugs, disorders, genes and their inter-relationships. For each of the \
+drug-disorder, drug-target, and target-disorder relations three experts \
+have annotated a set of 100 abstracts. These annotated relationships will be \
+used to train and evaluate text-mining software to capture these relationships \
+in texts.
 """
 
 _HOMEPAGE = "https://www.sciencedirect.com/science/article/pii/S1532046412000573"

--- a/bigbio/biodatasets/evidence_inference/evidence_inference.py
+++ b/bigbio/biodatasets/evidence_inference/evidence_inference.py
@@ -57,7 +57,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "evidence_inference"
-
+_DISPLAYNAME = "Evidence Inference 2.0"
 
 _DESCRIPTION = """\
 The dataset consists of biomedical articles describing randomized control trials (RCTs) that compare multiple

--- a/bigbio/biodatasets/gad/gad.py
+++ b/bigbio/biodatasets/gad/gad.py
@@ -9,7 +9,7 @@ from bigbio.utils.configs import BigBioConfig
 from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
-_DATASETNAME = "gad"
+
 _SOURCE_VIEW_NAME = "source"
 _UNIFIED_VIEW_NAME = "bigbio"
 
@@ -35,6 +35,9 @@ _DESCRIPTION = """\
 A corpus identifying associations between genes and diseases by a semi-automatic
 annotation procedure based on the Genetic Association Database
 """
+
+_DATASETNAME = "gad"
+_DISPLAYNAME = "GAD"
 
 _HOMEPAGE = "https://github.com/dmis-lab/biobert"  # This data source is used by the BLURB benchmark
 
@@ -163,10 +166,7 @@ class GAD(datasets.GeneratorBasedBuilder):
         else:
             raise ValueError(f"Invalid config: {self.config.name}")
 
-    def _blurb_split_generator(
-        self,
-        dl_manager: datasets.DownloadManager
-        ):
+    def _blurb_split_generator(self, dl_manager: datasets.DownloadManager):
         """Creates train/dev/test for BLURB split"""
 
         my_urls = _URLs[self.config.schema]
@@ -178,13 +178,13 @@ class GAD(datasets.GeneratorBasedBuilder):
 
         root_path = data_files["train"].parents[1]
         # Save the train + validation sets accordingly
-        with open(data_files["train"], 'r') as f:
+        with open(data_files["train"], "r") as f:
             train_data = f.readlines()
 
         data = {}
-        data['train'], data['dev'] = train_data[:4261], train_data[4261:]
+        data["train"], data["dev"] = train_data[:4261], train_data[4261:]
 
-        for batch in ['train', 'dev']:
+        for batch in ["train", "dev"]:
             fname = batch + "_blurb.tsv"
             fname = root_path / fname
 

--- a/bigbio/biodatasets/genetag/genetag.py
+++ b/bigbio/biodatasets/genetag/genetag.py
@@ -50,6 +50,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "genetag"
+_DISPLAYNAME = "GENETAG"
 
 _DESCRIPTION = """\
 Named entity recognition (NER) is an important first step for text mining the biomedical literature.

--- a/bigbio/biodatasets/genia_ptm_event_corpus/genia_ptm_event_corpus.py
+++ b/bigbio/biodatasets/genia_ptm_event_corpus/genia_ptm_event_corpus.py
@@ -54,13 +54,16 @@ _CITATION = """\
 """
 
 _DATASETNAME = "genia_ptm_event_corpus"
+_DISPLAYNAME = "PTM Events"
 
 _DESCRIPTION = """\
-Post-translational-modiﬁcations (PTM), amino acid modiﬁcations of proteins after translation, are one of the posterior
-processes of protein biosynthesis for many proteins, and they are critical for determining protein function such as its
-activity state, localization, turnover and interactions with other biomolecules. While there have been many studies of
-information extraction targeting individual PTM types, there was until recently little effort to address extraction of
-multiple PTM types at once in a unified framework.
+Post-translational-modiﬁcations (PTM), amino acid modiﬁcations of proteins \
+after translation, are one of the posterior processes of protein biosynthesis \
+for many proteins, and they are critical for determining protein function such \
+as its activity state, localization, turnover and interactions with other \
+biomolecules. While there have been many studies of information extraction \
+targeting individual PTM types, there was until recently little effort to \
+address extraction of multiple PTM types at once in a unified framework.
 """
 
 _HOMEPAGE = "http://www.geniaproject.org/other-corpora/ptm-event-corpus"

--- a/bigbio/biodatasets/genia_relation_corpus/genia_relation_corpus.py
+++ b/bigbio/biodatasets/genia_relation_corpus/genia_relation_corpus.py
@@ -73,6 +73,7 @@ doi = {10.1142/S0219720010005014}
 """
 
 _DATASETNAME = "genia_relation_corpus"
+_DISPLAYNAME = "GENIA Relation Corpus"
 
 _DESCRIPTION = """\
 The extraction of various relations stated to hold between biomolecular entities is one of the most frequently

--- a/bigbio/biodatasets/genia_term_corpus/genia_term_corpus.py
+++ b/bigbio/biodatasets/genia_term_corpus/genia_term_corpus.py
@@ -75,6 +75,7 @@ series = {JNLPBA '04}
 """
 
 _DATASETNAME = "genia_term_corpus"
+_DISPLAYNAME = "GENIA Term Corpus"
 
 _DESCRIPTION = """\
 The identification of linguistic expressions referring to entities of interest in molecular biology such as proteins,

--- a/bigbio/biodatasets/geokhoj_v1/geokhoj_v1.py
+++ b/bigbio/biodatasets/geokhoj_v1/geokhoj_v1.py
@@ -37,6 +37,7 @@ _LOCAL = False
 _CITATION = "NA"
 
 _DATASETNAME = "geokhoj_v1"
+_DISPLAYNAME = "GEOKhoj v1"
 
 _DESCRIPTION = """\
 GEOKhoj v1 is a annotated corpus of control/perturbation labels for 30,000 samples

--- a/bigbio/biodatasets/gnormplus/gnormplus.py
+++ b/bigbio/biodatasets/gnormplus/gnormplus.py
@@ -48,6 +48,7 @@ url={https://doi.org/10.1155/2015/918710}
 """
 
 _DATASETNAME = "gnormplus"
+_DISPLAYNAME = "GNormPlus"
 
 _DESCRIPTION = """\
 We re-annotated two existing gene corpora. The BioCreative II GN corpus is a widely used data set for benchmarking GN

--- a/bigbio/biodatasets/hallmarks_of_cancer/hallmarks_of_cancer.py
+++ b/bigbio/biodatasets/hallmarks_of_cancer/hallmarks_of_cancer.py
@@ -49,6 +49,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "hallmarks_of_cancer"
+_DISPLAYNAME = "Hallmarks of Cancer"
 
 _DESCRIPTION = """\
 The Hallmarks of Cancer (HOC) Corpus consists of 1852 PubMed publication
@@ -65,7 +66,7 @@ _LICENSE = Licenses.GPL_3p0
 
 _URLs = {
     "corpus": "https://github.com/sb895/Hallmarks-of-Cancer/archive/refs/heads/master.zip",
-    "split_indices": "https://microsoft.github.io/BLURB/sample_code/data_generation.tar.gz"    
+    "split_indices": "https://microsoft.github.io/BLURB/sample_code/data_generation.tar.gz",
 }
 
 _SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
@@ -73,17 +74,17 @@ _SOURCE_VERSION = "1.0.0"
 _BIGBIO_VERSION = "1.0.0"
 
 _CLASS_NAMES = [
-    'evading growth suppressors',
-    'tumor promoting inflammation',
-    'enabling replicative immortality',
-    'cellular energetics',
-    'resisting cell death',
-    'activating invasion and metastasis',
-    'genomic instability and mutation',
-    'none',
-    'inducing angiogenesis',
-    'sustaining proliferative signaling',
-    'avoiding immune destruction'
+    "evading growth suppressors",
+    "tumor promoting inflammation",
+    "enabling replicative immortality",
+    "cellular energetics",
+    "resisting cell death",
+    "activating invasion and metastasis",
+    "genomic instability and mutation",
+    "none",
+    "inducing angiogenesis",
+    "sustaining proliferative signaling",
+    "avoiding immune destruction",
 ]
 
 
@@ -143,21 +144,24 @@ class HallmarksOfCancerDataset(datasets.GeneratorBasedBuilder):
                 name=datasets.Split.TRAIN,
                 gen_kwargs={
                     "corpuspath": Path(data_dir["corpus"]),
-                    "indicespath": Path(data_dir["split_indices"]) / "data_generation/indexing/HoC/train_pmid.tsv"                
+                    "indicespath": Path(data_dir["split_indices"])
+                    / "data_generation/indexing/HoC/train_pmid.tsv",
                 },
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.TEST,
                 gen_kwargs={
                     "corpuspath": Path(data_dir["corpus"]),
-                    "indicespath": Path(data_dir["split_indices"]) / "data_generation/indexing/HoC/test_pmid.tsv"
+                    "indicespath": Path(data_dir["split_indices"])
+                    / "data_generation/indexing/HoC/test_pmid.tsv",
                 },
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.VALIDATION,
                 gen_kwargs={
                     "corpuspath": Path(data_dir["corpus"]),
-                    "indicespath": Path(data_dir["split_indices"]) / "data_generation/indexing/HoC/dev_pmid.tsv"              
+                    "indicespath": Path(data_dir["split_indices"])
+                    / "data_generation/indexing/HoC/dev_pmid.tsv",
                 },
             ),
         ]
@@ -183,13 +187,15 @@ class HallmarksOfCancerDataset(datasets.GeneratorBasedBuilder):
                 sentence, label = example_pair
 
                 label = label.strip()
-                
+
                 if label == "":
                     label = "none"
 
                 multi_labels = [m_label.strip() for m_label in label.split("AND")]
                 unique_multi_labels = {
-                    m_label.split("--")[0].lower().lstrip() for m_label in multi_labels if m_label != "NULL"
+                    m_label.split("--")[0].lower().lstrip()
+                    for m_label in multi_labels
+                    if m_label != "NULL"
                 }
 
                 arrow_file_unique_key = 100 * document_index + example_index

--- a/bigbio/biodatasets/hprd50/hprd50.py
+++ b/bigbio/biodatasets/hprd50/hprd50.py
@@ -58,6 +58,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "hprd50"
+_DISPLAYNAME = "HPRD50"
 
 _DESCRIPTION = """\
 HPRD50 is a dataset of randomly selected, hand-annotated abstracts of biomedical papers

--- a/bigbio/biodatasets/iepa/iepa.py
+++ b/bigbio/biodatasets/iepa/iepa.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 """
-The IEPA benchmark PPI corpus is designed for relation extraction. It was created from 303 PubMed abstracts,
-each of which contains a specific pair of co-occurring chemicals.
+The IEPA benchmark PPI corpus is designed for relation extraction. It was
+created from 303 PubMed abstracts, each of which contains a specific pair of
+co-occurring chemicals.
 """
 
 # Comment from Author
@@ -49,10 +50,12 @@ _CITATION = """\
 """
 
 _DATASETNAME = "iepa"
+_DISPLAYNAME = "IEPA"
 
 _DESCRIPTION = """\
-The IEPA benchmark PPI corpus is designed for relation extraction. It was created from 303 PubMed abstracts,
-each of which contains a specific pair of co-occurring chemicals.
+The IEPA benchmark PPI corpus is designed for relation extraction. It was \
+created from 303 PubMed abstracts, each of which contains a specific pair of \
+co-occurring chemicals.
 """
 
 _HOMEPAGE = "http://psb.stanford.edu/psb-online/proceedings/psb02/abstracts/p326.html"

--- a/bigbio/biodatasets/jnlpba/jnlpba.py
+++ b/bigbio/biodatasets/jnlpba/jnlpba.py
@@ -49,7 +49,8 @@ pages = "73--78",
 }
 """
 
-_DATASETNAME = "JNLPBA"
+_DATASETNAME = "jnlpba"
+_DISPLAYNAME = "JNLPBA"
 
 _DESCRIPTION = """\
 NER For Bio-Entities

--- a/bigbio/biodatasets/linnaeus/linnaeus.py
+++ b/bigbio/biodatasets/linnaeus/linnaeus.py
@@ -52,6 +52,7 @@ publisher={BioMed Central}
 """
 
 _DATASETNAME = "linnaeus"
+_DISPLAYNAME = "LINNAEUS"
 
 _DESCRIPTION = """\
 Linnaeus is a novel corpus of full-text documents manually annotated for species mentions.

--- a/bigbio/biodatasets/lll/lll.py
+++ b/bigbio/biodatasets/lll/lll.py
@@ -55,6 +55,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "lll"
+_DISPLAYNAME = "LLL05"
 
 _DESCRIPTION = """\
 The LLL05 challenge task is to learn rules to extract protein/gene interactions from biology abstracts from the Medline

--- a/bigbio/biodatasets/mantra_gsc/mantra_gsc.py
+++ b/bigbio/biodatasets/mantra_gsc/mantra_gsc.py
@@ -62,6 +62,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "mantra_gsc"
+_DISPLAYNAME = "Mantra GSC"
 
 _DESCRIPTION = """\
 We selected text units from different parallel corpora (Medline abstract titles, drug labels, biomedical patent claims)

--- a/bigbio/biodatasets/mayosrs/mayosrs.py
+++ b/bigbio/biodatasets/mayosrs/mayosrs.py
@@ -45,9 +45,10 @@ _CITATION = """\
 """
 
 _DATASETNAME = "mayosrs"
+_DISPLAYNAME = "MayoSRS"
 
 _DESCRIPTION = """\
-MayoSRS consists of 101 clinical term pairs whose relatedness was determined by
+MayoSRS consists of 101 clinical term pairs whose relatedness was determined by \
 nine medical coders and three physicians from the Mayo Clinic.
 """
 
@@ -62,7 +63,6 @@ _URLS = {
 _SUPPORTED_TASKS = [Tasks.SEMANTIC_SIMILARITY]
 
 _SOURCE_VERSION = "1.0.0"
-
 _BIGBIO_VERSION = "1.0.0"
 
 

--- a/bigbio/biodatasets/med_qa/med_qa.py
+++ b/bigbio/biodatasets/med_qa/med_qa.py
@@ -54,6 +54,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "med_qa"
+_DISPLAYNAME = "MedQA"
 
 _DESCRIPTION = """\
 In this work, we present the first free-form multiple-choice OpenQA dataset for solving medical problems, MedQA,

--- a/bigbio/biodatasets/medal/medal.py
+++ b/bigbio/biodatasets/medal/medal.py
@@ -49,6 +49,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "medal"
+_DISPLAYNAME = "MeDAL"
 
 _DESCRIPTION = """\
 The Repository for Medical Dataset for Abbreviation Disambiguation for Natural Language Understanding (MeDAL) is
@@ -73,10 +74,11 @@ _SOURCE_VERSION = "1.0.0"
 
 _BIGBIO_VERSION = "1.0.0"
 
+
 class MedalDataset(datasets.GeneratorBasedBuilder):
     """The Repository for Medical Dataset for Abbreviation Disambiguation for Natural Language Understanding (MeDAL) is
-a large medical text dataset curated for abbreviation disambiguation, designed for natural language understanding
-pre-training in the medical domain."""
+    a large medical text dataset curated for abbreviation disambiguation, designed for natural language understanding
+    pre-training in the medical domain."""
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
@@ -123,7 +125,9 @@ pre-training in the medical domain."""
             citation=_CITATION,
         )
 
-    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
 
         urls = _URLS
@@ -168,7 +172,7 @@ pre-training in the medical domain."""
 
         Returns
         -------
-        dict 
+        dict
             "word": str,
             "offsets": tuple (int, int)
         """
@@ -178,7 +182,7 @@ pre-training in the medical domain."""
         offset_end = offset_start + len(word)
 
         # return word and offsets
-        return {"word":word, "offsets":(offset_start, offset_end)}
+        return {"word": word, "offsets": (offset_start, offset_end)}
 
     def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""

--- a/bigbio/biodatasets/meddialog/meddialog.py
+++ b/bigbio/biodatasets/meddialog/meddialog.py
@@ -24,6 +24,7 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "meddialog"
+_DISPLAYNAME = "MedDialog"
 
 _LANGUAGES = [Lang.EN, Lang.ZH]
 _PUBMED = False

--- a/bigbio/biodatasets/meddocan/meddocan.py
+++ b/bigbio/biodatasets/meddocan/meddocan.py
@@ -46,6 +46,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "meddocan"
+_DISPLAYNAME = "MEDDOCAN"
 
 _DESCRIPTION = """\
 MEDDOCAN: Medical Document Anonymization Track

--- a/bigbio/biodatasets/medhop/medhop.py
+++ b/bigbio/biodatasets/medhop/medhop.py
@@ -69,7 +69,8 @@ pairs of drugs. The correct answer has to be inferred by combining
 information from a chain of reactions of drugs and proteins.
 """
 
-_DATASETNAME = "MedHop"
+_DATASETNAME = "medhop"
+_DISPLAYNAME = "MedHop"
 
 _HOMEPAGE = "http://qangaroo.cs.ucl.ac.uk/"
 

--- a/bigbio/biodatasets/medical_data/medical_data.py
+++ b/bigbio/biodatasets/medical_data/medical_data.py
@@ -37,6 +37,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "medical_data"
+_DISPLAYNAME = "Medical Data"
 
 _DESCRIPTION = """\
     This dataset is designed to do multiclass classification on medical drugs

--- a/bigbio/biodatasets/mediqa_nli/mediqa_nli.py
+++ b/bigbio/biodatasets/mediqa_nli/mediqa_nli.py
@@ -63,6 +63,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "mediqa_nli"
+_DISPLAYNAME = "MEDIQA NLI"
 
 _DESCRIPTION = """\
 Natural Language Inference (NLI) is the task of determining whether a given hypothesis can be

--- a/bigbio/biodatasets/mediqa_qa/mediqa_qa.py
+++ b/bigbio/biodatasets/mediqa_qa/mediqa_qa.py
@@ -41,6 +41,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "mediqa_qa"
+_DISPLAYNAME = "MEDIQA QA"
 
 _DESCRIPTION = """\
 The MEDIQA challenge is an ACL-BioNLP 2019 shared task aiming to attract further research efforts in Natural Language Inference (NLI), Recognizing Question Entailment (RQE), and their applications in medical Question Answering (QA).

--- a/bigbio/biodatasets/mediqa_rqe/mediqa_rqe.py
+++ b/bigbio/biodatasets/mediqa_rqe/mediqa_rqe.py
@@ -41,6 +41,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "mediqa_rqe"
+_DISPLAYNAME = "MEDIQA RQE"
 
 _DESCRIPTION = """\
 The MEDIQA challenge is an ACL-BioNLP 2019 shared task aiming to attract further research efforts in Natural Language Inference (NLI), Recognizing Question Entailment (RQE), and their applications in medical Question Answering (QA).

--- a/bigbio/biodatasets/medmentions/medmentions.py
+++ b/bigbio/biodatasets/medmentions/medmentions.py
@@ -61,6 +61,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "medmentions"
+_DISPLAYNAME = "MedMentions"
 
 _DESCRIPTION = """\
 MedMentions is a new manually annotated resource for the recognition of biomedical concepts.

--- a/bigbio/biodatasets/mednli/mednli.py
+++ b/bigbio/biodatasets/mednli/mednli.py
@@ -61,6 +61,7 @@ _CITATION = """\
 
 
 _DATASETNAME = "mednli"
+_DISPLAYNAME = "MedNLI"
 
 _DESCRIPTION = """\
 State of the art models using deep neural networks have become very good in learning an accurate

--- a/bigbio/biodatasets/meqsum/meqsum.py
+++ b/bigbio/biodatasets/meqsum/meqsum.py
@@ -47,6 +47,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "meqsum"
+_DISPLAYNAME = "MeQSum"
 
 _DESCRIPTION = """\
 Dataset for medical question summarization introduced in the ACL 2019 paper "On the Summarization of Consumer Health

--- a/bigbio/biodatasets/minimayosrs/minimayosrs.py
+++ b/bigbio/biodatasets/minimayosrs/minimayosrs.py
@@ -45,6 +45,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "minimayosrs"
+_DISPLAYNAME = "MiniMayoSRS"
 
 _DESCRIPTION = """\
 MiniMayoSRS is a subset of the MayoSRS and consists of 30 term pairs on which a higher inter-annotator agreement was

--- a/bigbio/biodatasets/mirna/mirna.py
+++ b/bigbio/biodatasets/mirna/mirna.py
@@ -81,6 +81,7 @@ language={eng}
 """
 
 _DATASETNAME = "mirna"
+_DISPLAYNAME = "miRNA"
 
 _DESCRIPTION = """\
 The corpus consists of 301 Medline citations. The documents were screened for
@@ -271,7 +272,9 @@ class miRNADataset(datasets.GeneratorBasedBuilder):
                             "type": a.attrib["type"],
                             "text": (a.attrib["text"],),
                             "offsets": [(start + startOffset, start + endOffset + 1)],
-                            "normalized": [{"db_name": "miRNA-corpus", "db_id": a.attrib["id"]}],
+                            "normalized": [
+                                {"db_name": "miRNA-corpus", "db_id": a.attrib["id"]}
+                            ],
                         }
                     )
 
@@ -306,9 +309,17 @@ class miRNADataset(datasets.GeneratorBasedBuilder):
 
             for uid, doc in enumerate(reader):
 
-                sentences, sentences_entities, relations = self._get_passages_and_entities(doc)
+                (
+                    sentences,
+                    sentences_entities,
+                    relations,
+                ) = self._get_passages_and_entities(doc)
 
-                if len(sentences) < 1 or len(sentences_entities) < 1 or len(sentences_entities) != len(sentences):
+                if (
+                    len(sentences) < 1
+                    or len(sentences_entities) < 1
+                    or len(sentences_entities) != len(sentences)
+                ):
                     continue
 
                 for p, pe, re in zip(sentences, sentences_entities, relations):
@@ -326,9 +337,17 @@ class miRNADataset(datasets.GeneratorBasedBuilder):
 
             for idx, doc in enumerate(reader):
 
-                sentences, sentences_entities, relations = self._get_passages_and_entities(doc)
+                (
+                    sentences,
+                    sentences_entities,
+                    relations,
+                ) = self._get_passages_and_entities(doc)
 
-                if len(sentences) < 1 or len(sentences_entities) < 1 or len(sentences_entities) != len(sentences):
+                if (
+                    len(sentences) < 1
+                    or len(sentences_entities) < 1
+                    or len(sentences_entities) != len(sentences)
+                ):
                     continue
 
                 # global id

--- a/bigbio/biodatasets/mlee/mlee.py
+++ b/bigbio/biodatasets/mlee/mlee.py
@@ -28,7 +28,6 @@ from bigbio.utils.configs import BigBioConfig
 from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
-_DATASETNAME = "mlee"
 _SOURCE_VIEW_NAME = "source"
 _UNIFIED_VIEW_NAME = "bigbio"
 
@@ -54,6 +53,9 @@ MLEE is an event extraction corpus consisting of manually annotated abstracts of
 on angiogenesis. It contains annotations for entities, relations, events and coreferences
 The annotations span molecular, cellular, tissue, and organ-level processes.
 """
+
+_DATASETNAME = "mlee"
+_DISPLAYNAME = "MLEE"
 
 _HOMEPAGE = "http://www.nactem.ac.uk/MLEE/"
 

--- a/bigbio/biodatasets/mqp/mqp.py
+++ b/bigbio/biodatasets/mqp/mqp.py
@@ -47,6 +47,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "mqp"
+_DISPLAYNAME = "MQP"
 
 _DESCRIPTION = """\
 Medical Question Pairs dataset by McCreery et al (2020) contains pairs of medical questions and paraphrased versions of 

--- a/bigbio/biodatasets/msh_wsd/msh_wsd.py
+++ b/bigbio/biodatasets/msh_wsd/msh_wsd.py
@@ -66,8 +66,6 @@ _CITATION = """\
 
 """
 
-_DATASETNAME = "msh_wsd"
-
 _DESCRIPTION = """\
 Evaluation of Word Sense Disambiguation methods (WSD) in the biomedical domain is difficult because the available
 resources are either too small or too focused on specific types of entities (e.g. diseases or genes). We have
@@ -78,6 +76,9 @@ ambiguous words. Each instance containing the ambiguous word was assigned a CUI 
 For each ambiguous term/abbreviation, the data set contains a maximum of 100 instances per sense obtained from
 MEDLINE; totaling 37,888 ambiguity cases in 37,090 MEDLINE citations.
 """
+
+_DATASETNAME = "msh_wsd"
+_DISPLAYNAME = "MSH WSD"
 
 _HOMEPAGE = "https://lhncbc.nlm.nih.gov/ii/areas/WSD/collaboration.html"
 

--- a/bigbio/biodatasets/muchmore/muchmore.py
+++ b/bigbio/biodatasets/muchmore/muchmore.py
@@ -103,6 +103,9 @@ decomposition); Chunks; Semantic Classes (UMLS: Unified Medical Language System,
 MeSH: Medical Subject Headings, EuroWordNet); Semantic Relations from UMLS.
 """
 
+_DATASETNAME = "muchmore"
+_DISPLAYNAME = "MuchMore"
+
 _HOMEPAGE = "https://muchmore.dfki.de/resources1.htm"
 
 # TODO: website says the following, but don't see a specific license

--- a/bigbio/biodatasets/multi_xscience/multi_xscience.py
+++ b/bigbio/biodatasets/multi_xscience/multi_xscience.py
@@ -48,6 +48,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "multi_xscience"
+_DISPLAYNAME = "Multi-XScience"
 
 _DESCRIPTION = """\
 Multi-document summarization is a challenging task for which there exists little large-scale datasets. 

--- a/bigbio/biodatasets/mutation_finder/mutation_finder.py
+++ b/bigbio/biodatasets/mutation_finder/mutation_finder.py
@@ -45,6 +45,7 @@ url = {http://dx.doi.org/10.1093/bioinformatics/btm235}
 """
 
 _DATASETNAME = "mutation_finder"
+_DISPLAYNAME = "MutationFinder"
 
 _DESCRIPTION = """\
 Gold standard corpus for mutation extraction systems consisting of 1515 human-annotated mutation mentions in 813

--- a/bigbio/biodatasets/n2c2_2006_deid/n2c2_2006_deid.py
+++ b/bigbio/biodatasets/n2c2_2006_deid/n2c2_2006_deid.py
@@ -69,6 +69,7 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "n2c2_2006"
+_DISPLAYNAME = "n2c2 2006 De-identification"
 
 # https://academic.oup.com/jamia/article/14/5/550/720189
 _LANGUAGES = [Lang.EN]

--- a/bigbio/biodatasets/n2c2_2006_smokers/n2c2_2006_smokers.py
+++ b/bigbio/biodatasets/n2c2_2006_smokers/n2c2_2006_smokers.py
@@ -67,6 +67,7 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "n2c2_2006"
+_DISPLAYNAME = "n2c2 2006 Smoking Status"
 
 # https://academic.oup.com/jamia/article/15/1/14/779738
 _LANGUAGES = [Lang.EN]

--- a/bigbio/biodatasets/n2c2_2008/n2c2_2008.py
+++ b/bigbio/biodatasets/n2c2_2008/n2c2_2008.py
@@ -75,6 +75,7 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "n2c2_2008"
+_DISPLAYNAME = "n2c2 2008 Obesity"
 
 # https://academic.oup.com/jamia/article/16/4/561/766997
 _LANGUAGES = [Lang.EN]

--- a/bigbio/biodatasets/n2c2_2009/n2c2_2009.py
+++ b/bigbio/biodatasets/n2c2_2009/n2c2_2009.py
@@ -85,6 +85,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "n2c2_2009"
+_DISPLAYNAME = "n2c2 2009 Medications"
 
 _DESCRIPTION = """\
 The Third i2b2 Workshop on Natural Language Processing Challenges for Clinical Records
@@ -661,7 +662,7 @@ class N2C22009MedicationDataset(datasets.GeneratorBasedBuilder):
             "coreferences": [],
         }
 
-    def _generate_examples(self, data_dir, split) -> (int, dict):
+    def _generate_examples(self, data_dir, split):
         train_test_set = _read_train_test_data_from_tar_gz(data_dir)
         train_set = _get_train_set(data_dir, train_test_set)
         test_set = _get_test_set(train_set, train_test_set)

--- a/bigbio/biodatasets/n2c2_2010/n2c2_2010.py
+++ b/bigbio/biodatasets/n2c2_2010/n2c2_2010.py
@@ -82,6 +82,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "n2c2_2010"
+_DISPLAYNAME = "n2c2 2010 Concepts, Assertions, and Relations"
 
 _DESCRIPTION = """\
 The i2b2/VA corpus contained de-identified discharge summaries from Beth Israel
@@ -580,7 +581,7 @@ class N2C22010RelationsDataset(datasets.GeneratorBasedBuilder):
             "coreferences": [],
         }
 
-    def _generate_examples(self, data_dir, split) -> (int, dict):
+    def _generate_examples(self, data_dir, split):
         if split == "train":
             samples = _read_tar_gz(
                 os.path.join(

--- a/bigbio/biodatasets/n2c2_2011/n2c2_2011.py
+++ b/bigbio/biodatasets/n2c2_2011/n2c2_2011.py
@@ -76,6 +76,7 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "n2c2_2011"
+_DISPLAYNAME = "n2c2 2011 Coreference"
 
 # https://academic.oup.com/jamia/article/19/5/786/716138
 _LANGUAGES = [Lang.EN]

--- a/bigbio/biodatasets/n2c2_2014_deid/n2c2_2014_deid.py
+++ b/bigbio/biodatasets/n2c2_2014_deid/n2c2_2014_deid.py
@@ -81,6 +81,7 @@ author = {Amber Stubbs and Christopher Kotfila and Özlem Uzuner}
 """
 
 _DATASETNAME = "n2c2_2014_deid"
+_DISPLAYNAME = "n2c2 2014 De-identification"
 
 _DESCRIPTION = """\
 The 2014 i2b2/UTHealth Natural Language Processing (NLP) shared task featured two tracks.
@@ -127,7 +128,7 @@ class N2C22014DeidDataset(datasets.GeneratorBasedBuilder):
             description="n2c2_2014 BigBio schema",
             schema="bigbio_kb",
             subset_id="n2c2_2014_deid",
-        )
+        ),
     ]
 
     DEFAULT_CONFIG_NAME = "n2c2_2014_deid_source"
@@ -155,7 +156,6 @@ class N2C22014DeidDataset(datasets.GeneratorBasedBuilder):
         elif self.config.schema == "bigbio_kb":
             features = schemas.kb_features
 
-
         return datasets.DatasetInfo(
             description=_DESCRIPTION,
             features=features,
@@ -164,10 +164,14 @@ class N2C22014DeidDataset(datasets.GeneratorBasedBuilder):
             citation=_CITATION,
         )
 
-    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
         if self.config.data_dir is None:
-            raise ValueError("This is a local dataset. Please pass the data_dir kwarg to load_dataset.")
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
         else:
             data_dir = self.config.data_dir
         return [
@@ -202,7 +206,9 @@ class N2C22014DeidDataset(datasets.GeneratorBasedBuilder):
                 for x in self._read_tar_gz(full_path):
                     xml_flag = x["xml_flag"]
                     if xml_flag:
-                        document = self._read_task1_file(file_object=x["file_object"], file_name=x["file_name"])
+                        document = self._read_task1_file(
+                            file_object=x["file_object"], file_name=x["file_name"]
+                        )
                         document["id"] = next(uid)
 
         elif self.config.schema == "bigbio_kb":
@@ -212,31 +218,33 @@ class N2C22014DeidDataset(datasets.GeneratorBasedBuilder):
                 for x in self._read_tar_gz(full_path):
                     xml_flag = x["xml_flag"]
                     if xml_flag:
-                        document = self._read_task1_file(file_object=x["file_object"], file_name=x["file_name"])
+                        document = self._read_task1_file(
+                            file_object=x["file_object"], file_name=x["file_name"]
+                        )
                         document["id"] = next(uid)
                         entity_list = document.pop("phi")
                         full_text = document.pop("text")
                         entities_ = []
                         for entity in entity_list:
                             entities_.append(
-                                    {
-                                        "id": next(uid),
-                                        "type": entity["type"],
-                                        "text": entity["text"],
-                                        "offsets": entity["offsets"],
-                                        "normalized": entity["normalized"],
-                                    }
-                                )
+                                {
+                                    "id": next(uid),
+                                    "type": entity["type"],
+                                    "text": entity["text"],
+                                    "offsets": entity["offsets"],
+                                    "normalized": entity["normalized"],
+                                }
+                            )
                         document["entities"] = entities_
 
                         document["passages"] = [
-                                {
-                                    "id": next(uid),
-                                    "type": "full_text",
-                                    "text": [full_text],
-                                    "offsets": [[0, len(full_text)]],
-                                },
-                            ]
+                            {
+                                "id": next(uid),
+                                "type": "full_text",
+                                "text": [full_text],
+                                "offsets": [[0, len(full_text)]],
+                            },
+                        ]
 
                         # additional fields required that can be empty
                         document["relations"] = []
@@ -261,7 +269,11 @@ class N2C22014DeidDataset(datasets.GeneratorBasedBuilder):
                 xml_flag = True
             else:
                 xml_flag = False
-            yield {"file_object": file_object, "file_name": file_name, "xml_flag": xml_flag}
+            yield {
+                "file_object": file_object,
+                "file_name": file_name,
+                "xml_flag": xml_flag,
+            }
 
     def _read_task1_file(self, file_object, file_name):
         xmldoc = et.parse(file_object).getroot()

--- a/bigbio/biodatasets/n2c2_2014_risk_factors/n2c2_2014_risk_factors.py
+++ b/bigbio/biodatasets/n2c2_2014_risk_factors/n2c2_2014_risk_factors.py
@@ -83,6 +83,7 @@ abstract = {The 2014 i2b2/UTHealth Natural Language Processing (NLP) shared task
 """
 
 _DATASETNAME = "n2c2_2014_risk_factors"
+_DISPLAYNAME = "n2c2 2014 Cardiac Risk Factors"
 
 _DESCRIPTION = """\
 The 2014 i2b2/UTHealth Natural Language Processing (NLP) shared task featured two tracks.
@@ -101,7 +102,7 @@ the patient's medical history.
 
 _HOMEPAGE = "https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/"
 
-_LICENSE =  Licenses.DUA
+_LICENSE = Licenses.DUA
 # _LICENSE = "DUA-C/NC"
 
 _SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
@@ -131,7 +132,7 @@ class N2C22014RiskFactorsDataset(datasets.GeneratorBasedBuilder):
             description="n2c2_2014 BigBio schema",
             schema="bigbio_text",
             subset_id="n2c2_2014_risk_factors",
-        )
+        ),
     ]
 
     DEFAULT_CONFIG_NAME = "n2c2_2014_source"
@@ -170,10 +171,14 @@ class N2C22014RiskFactorsDataset(datasets.GeneratorBasedBuilder):
             citation=_CITATION,
         )
 
-    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
         if self.config.data_dir is None:
-            raise ValueError("This is a local dataset. Please pass the data_dir kwarg to load_dataset.")
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
         else:
             data_dir = self.config.data_dir
         return [
@@ -208,7 +213,9 @@ class N2C22014RiskFactorsDataset(datasets.GeneratorBasedBuilder):
                 for x in self._read_tar_gz(full_path):
                     xml_flag = x["xml_flag"]
                     if xml_flag:
-                        document = self._read_task2_file(file_object=x["file_object"], file_name=x["file_name"])
+                        document = self._read_task2_file(
+                            file_object=x["file_object"], file_name=x["file_name"]
+                        )
                         document["id"] = next(uid)
 
         elif self.config.schema == "bigbio_text":
@@ -219,7 +226,9 @@ class N2C22014RiskFactorsDataset(datasets.GeneratorBasedBuilder):
                     xml_flag = x["xml_flag"]
                     if xml_flag:
                         if task == "track2":
-                            document = self._read_task2_file(file_object=x["file_object"], file_name=x["file_name"])
+                            document = self._read_task2_file(
+                                file_object=x["file_object"], file_name=x["file_name"]
+                            )
                             document["id"] = next(uid)
 
                             labels = []
@@ -251,7 +260,11 @@ class N2C22014RiskFactorsDataset(datasets.GeneratorBasedBuilder):
                 xml_flag = True
             else:
                 xml_flag = False
-            yield {"file_object": file_object, "file_name": file_name, "xml_flag": xml_flag}
+            yield {
+                "file_object": file_object,
+                "file_name": file_name,
+                "xml_flag": xml_flag,
+            }
 
     def _read_task2_file(self, file_object, file_name):
         # Fix the file
@@ -265,12 +278,19 @@ class N2C22014RiskFactorsDataset(datasets.GeneratorBasedBuilder):
         text = xmldoc.findall("TEXT")[0].text
         risk_factors = []
         for entity in entities:
-            risk_factor = {x: "" for x in ["indicator", "time", "status", "type1", "type2", "comment"]}
+            risk_factor = {
+                x: ""
+                for x in ["indicator", "time", "status", "type1", "type2", "comment"]
+            }
             for key, value in entity.attrib.items():
                 risk_factor[key] = value
 
             risk_factor["risk_factor"] = entity.tag
             risk_factors.append(risk_factor)
 
-        document = {"document_id": file_name, "text": text, "cardiac_risk_factors": risk_factors}
+        document = {
+            "document_id": file_name,
+            "text": text,
+            "cardiac_risk_factors": risk_factors,
+        }
         return document

--- a/bigbio/biodatasets/n2c2_2018_track1/n2c2_2018_track1.py
+++ b/bigbio/biodatasets/n2c2_2018_track1/n2c2_2018_track1.py
@@ -73,6 +73,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "n2c2_2018_track1"
+_DISPLAYNAME = "n2c2 2018 Selection Criteria"
 
 _DESCRIPTION = """\
 Track 1 of the 2018 National NLP Clinical Challenges shared tasks focused
@@ -284,7 +285,7 @@ class N2C22018CohortSelectionDataset(datasets.GeneratorBasedBuilder):
             "labels": labels,
         }
 
-    def _generate_examples(self, file_path) -> (int, dict):
+    def _generate_examples(self, file_path):
         samples = _read_zip(file_path)
 
         _id = 0

--- a/bigbio/biodatasets/n2c2_2018_track2/n2c2_2018_track2.py
+++ b/bigbio/biodatasets/n2c2_2018_track2/n2c2_2018_track2.py
@@ -77,6 +77,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "n2c2_2018_track2"
+_DISPLAYNAME = "n2c2 2018 ADE"
 
 _DESCRIPTION = """\
 The National NLP Clinical Challenges (n2c2), organized in 2018, continued the

--- a/bigbio/biodatasets/nagel/nagel.py
+++ b/bigbio/biodatasets/nagel/nagel.py
@@ -40,6 +40,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "nagel"
+_DISPLAYNAME = "Nagel Corpus"
 
 _DESCRIPTION = """\
 A set of 100 abstracts annotated by Kevin Nagel with protein, residue, organism triples.
@@ -165,9 +166,7 @@ class NagelDataset(datasets.GeneratorBasedBuilder):
 
     # method parameters are unpacked from `gen_kwargs` as given in `_split_generators`
 
-    def _generate_examples(
-        self, filepath, filepath_standoff, folder_path, split
-    ) -> (int, dict):
+    def _generate_examples(self, filepath, filepath_standoff, folder_path, split):
 
         so_annot = pd.read_csv(
             filepath_standoff,

--- a/bigbio/biodatasets/ncbi_disease/ncbi_disease.py
+++ b/bigbio/biodatasets/ncbi_disease/ncbi_disease.py
@@ -44,6 +44,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "ncbi_disease"
+_DISPLAYNAME = "NCBI Disease"
 
 _DESCRIPTION = """\
 The NCBI disease corpus is fully annotated at the mention and concept level to serve as a research

--- a/bigbio/biodatasets/nlm_gene/nlm_gene.py
+++ b/bigbio/biodatasets/nlm_gene/nlm_gene.py
@@ -30,36 +30,37 @@ _LANGUAGES = [Lang.EN]
 _PUBMED = True
 _LOCAL = False
 _CITATION = """\
-@Article{islamaj2021nlm,
-    title       =  {NLM-Gene, a richly annotated gold standard dataset for gene entities that addresses ambiguity and
-                    multi-species gene recognition},
-    author      =   {Islamaj,
-                    Rezarta and
-                    Wei, Chih-Hsuan and
-                    Cissel, David and
-                    Miliaras, Nicholas and
-                    Printseva, Olga and
-                    Rodionov, Oleg and
-                    Sekiya, Keiko and
-                    Ward, Janice and
-                    Lu, Zhiyong},
-    journal     =   {Journal of Biomedical Informatics},
-    volume      =   {118},
-    pages       =   {103779},
-    year        =   {2021},
-    publisher   =  {Elsevier}
+@article{islamaj2021nlm,
+  title        = {
+    NLM-Gene, a richly annotated gold standard dataset for gene entities that
+    addresses ambiguity and multi-species gene recognition
+  },
+  author       = {
+    Islamaj, Rezarta and Wei, Chih-Hsuan and Cissel, David and Miliaras,
+    Nicholas and Printseva, Olga and Rodionov, Oleg and Sekiya, Keiko and Ward,
+    Janice and Lu, Zhiyong
+  },
+  year         = 2021,
+  journal      = {Journal of Biomedical Informatics},
+  publisher    = {Elsevier},
+  volume       = 118,
+  pages        = 103779
 }
 """
 
 _DATASETNAME = "nlm_gene"
+_DISPLAYNAME = "NLM-Gene"
 
 _DESCRIPTION = """\
-NLM-Gene consists of 550 PubMed articles, from 156 journals, and contains more than 15 thousand unique gene names,
-corresponding to more than five thousand gene identifiers (NCBI Gene taxonomy). This corpus contains gene annotation
-data from 28 organisms. The annotated articles contain on average 29 gene names, and 10 gene identifiers per article.
-These characteristics demonstrate that this article set is an important benchmark dataset to test the accuracy of gene
-recognition algorithms both on multi-species and ambiguous data. The NLM-Gene corpus will be invaluable for advancing
-text-mining techniques for gene identification tasks in biomedical text.
+NLM-Gene consists of 550 PubMed articles, from 156 journals, and contains more \
+than 15 thousand unique gene names, corresponding to more than five thousand \
+gene identifiers (NCBI Gene taxonomy). This corpus contains gene annotation data \
+from 28 organisms. The annotated articles contain on average 29 gene names, and \
+10 gene identifiers per article. These characteristics demonstrate that this \
+article set is an important benchmark dataset to test the accuracy of gene \
+recognition algorithms both on multi-species and ambiguous data. The NLM-Gene \
+corpus will be invaluable for advancing text-mining techniques for gene \
+identification tasks in biomedical text.
 """
 
 _HOMEPAGE = "https://zenodo.org/record/5089049"
@@ -74,7 +75,6 @@ _URLS = {
 _SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION]
 
 _SOURCE_VERSION = "1.0.0"
-
 _BIGBIO_VERSION = "1.0.0"
 
 

--- a/bigbio/biodatasets/nlm_wsd/nlm_wsd.py
+++ b/bigbio/biodatasets/nlm_wsd/nlm_wsd.py
@@ -72,6 +72,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "nlm_wsd"
+_DISPLAYNAME = "NLM WSD"
 
 _DESCRIPTION = """\
 In order to support research investigating the automatic resolution of word sense ambiguity using natural language
@@ -97,7 +98,6 @@ _URLS = {
 _SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_DISAMBIGUATION]
 
 _SOURCE_VERSION = "1.0.0"
-
 _BIGBIO_VERSION = "1.0.0"
 
 

--- a/bigbio/biodatasets/nlmchem/nlmchem.py
+++ b/bigbio/biodatasets/nlmchem/nlmchem.py
@@ -43,6 +43,7 @@ publisher={Nature Publishing Group}
 """
 
 _DATASETNAME = "nlmchem"
+_DISPLAYNAME = "NLM-Chem"
 
 _DESCRIPTION = """\
 NLM-Chem corpus consists of 150 full-text articles from the PubMed Central Open Access dataset,

--- a/bigbio/biodatasets/ntcir_13_medweb/ntcir_13_medweb.py
+++ b/bigbio/biodatasets/ntcir_13_medweb/ntcir_13_medweb.py
@@ -82,6 +82,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "ntcir_13_medweb"
+_DISPLAYNAME = "NTCIR-13 MedWeb"
 
 _DESCRIPTION = """\
 NTCIR-13 MedWeb (Medical Natural Language Processing for Web Document) task requires

--- a/bigbio/biodatasets/osiris/osiris.py
+++ b/bigbio/biodatasets/osiris/osiris.py
@@ -48,6 +48,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "osiris"
+_DISPLAYNAME = "OSIRIS"
 
 _DESCRIPTION = """\
 The OSIRIS corpus is a set of MEDLINE abstracts manually annotated

--- a/bigbio/biodatasets/paramed/paramed.py
+++ b/bigbio/biodatasets/paramed/paramed.py
@@ -47,6 +47,7 @@ _CITATION = """\
 }
 """
 _DATASETNAME = "paramed"
+_DISPLAYNAME = "ParaMed"
 
 _DESCRIPTION = """\
 NEJM is a Chinese-English parallel corpus crawled from the New England Journal of Medicine website. 

--- a/bigbio/biodatasets/pcr/pcr.py
+++ b/bigbio/biodatasets/pcr/pcr.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-A corpus for plant and chemical entities and for the relationships between them. The corpus contains 2218 plant
-and chemical entities and 600 plant-chemical relationships which are drawn from 1109 sentences in 245 PubMed
-abstracts.
+A corpus for plant and chemical entities and for the relationships between them.
+The corpus contains 2218 plant and chemical entities and 600 plant-chemical
+relationships which are drawn from 1109 sentences in 245 PubMed abstracts.
 """
 from pathlib import Path
 from typing import Dict, Iterator, Tuple
@@ -33,22 +33,28 @@ _PUBMED = True
 _LOCAL = False
 _CITATION = """\
 @article{choi2016corpus,
-  title={A corpus for plant-chemical relationships in the biomedical domain},
-  author={Choi, Wonjun and Kim, Baeksoo and Cho, Hyejin and Lee, Doheon and Lee, Hyunju},
-  journal={BMC bioinformatics},
-  volume={17},
-  number={1},
-  pages={1--15},
-  year={2016},
-  publisher={Springer}
+  title        = {A corpus for plant-chemical relationships in the biomedical domain},
+  author       = {
+    Choi, Wonjun and Kim, Baeksoo and Cho, Hyejin and Lee, Doheon and Lee,
+    Hyunju
+  },
+  year         = 2016,
+  journal      = {BMC bioinformatics},
+  publisher    = {Springer},
+  volume       = 17,
+  number       = 1,
+  pages        = {1--15}
 }
 """
 
 _DATASETNAME = "pcr"
+_DISPLAYNAME = "PCR"
 
 _DESCRIPTION = """
-A corpus for plant / herb and chemical entities and for the relationships between them. The corpus contains 2218 plant
-and chemical entities and 600 plant-chemical relationships which are drawn from 1109 sentences in 245 PubMed abstracts.
+A corpus for plant / herb and chemical entities and for the relationships \
+between them. The corpus contains 2218 plant and chemical entities and 600 \
+plant-chemical relationships which are drawn from 1109 sentences in 245 PubMed \
+abstracts.
 """
 
 _HOMEPAGE = "http://210.107.182.73/plantchemcorpus.htm"
@@ -64,8 +70,8 @@ _BIGBIO_VERSION = "1.0.0"
 
 class PCRDataset(datasets.GeneratorBasedBuilder):
     """
-    The corpus of plant-chemical relation consists of plants / herbs and chemicals and relations
-    between them.
+    The corpus of plant-chemical relation consists of plants / herbs and
+    chemicals and relations between them.
     """
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)

--- a/bigbio/biodatasets/pdr/pdr.py
+++ b/bigbio/biodatasets/pdr/pdr.py
@@ -48,6 +48,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "pdr"
+_DISPLAYNAME = "PDR"
 
 _DESCRIPTION = """
 The corpus of plant-disease relation consists of plants and diseases and their relation to PubMed abstract.

--- a/bigbio/biodatasets/pharmaconer/pharmaconer.py
+++ b/bigbio/biodatasets/pharmaconer/pharmaconer.py
@@ -58,6 +58,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "pharmaconer"
+_DISPLAYNAME = "PharmaCoNER"
 
 _GENERAL_DESCRIPTION = """\
 PharmaCoNER: Pharmacological Substances, Compounds and Proteins Named Entity Recognition track

--- a/bigbio/biodatasets/pho_ner/pho_ner.py
+++ b/bigbio/biodatasets/pho_ner/pho_ner.py
@@ -38,6 +38,7 @@ _CITATION = """@inproceedings{PhoNER_COVID19,
 """
 
 _DATASETNAME = "pho_ner"
+_DISPLAYNAME = "PhoNER_COVID19"
 
 _DESCRIPTION = """PhoNER_COVID19 is a dataset for recognizing COVID-19 related named entities in Vietnamese, 
 consisting of 35K entities over 10K sentences. We define 10 entity types with the aim of extracting key information 

--- a/bigbio/biodatasets/pico_extraction/pico_extraction.py
+++ b/bigbio/biodatasets/pico_extraction/pico_extraction.py
@@ -52,6 +52,8 @@ _CITATION = """\
 """
 
 _DATASETNAME = "pico_extraction"
+_DISPLAYNAME = "PICO Annotation"
+
 
 _DESCRIPTION = """\
 This dataset contains annotations for Participants, Interventions, and Outcomes (referred to as PICO task).
@@ -220,7 +222,7 @@ class PicoExtractionDataset(datasets.GeneratorBasedBuilder):
             ),
         ]
 
-    def _generate_examples(self, split, sentence_file, annotation_files) -> (int, dict):
+    def _generate_examples(self, split, sentence_file, annotation_files):
         """Yields examples as (key, example) tuples."""
 
         sentences, annotation_dict = _pico_extraction_data_loader(

--- a/bigbio/biodatasets/pmc_patients/pmc_patients.py
+++ b/bigbio/biodatasets/pmc_patients/pmc_patients.py
@@ -45,6 +45,7 @@ _CITATION = """\
 }"""
 
 _DATASETNAME = "pmc_patients"
+_DISPLAYNAME = "PMC-Patients"
 
 _DESCRIPTION = """\
 This dataset is used for calculating the similarity between two patient descriptions.

--- a/bigbio/biodatasets/progene/progene.py
+++ b/bigbio/biodatasets/progene/progene.py
@@ -48,7 +48,8 @@ _CITATION = """\
 }
 """
 
-_DATASETNAME = "PROGENE"
+_DATASETNAME = "progene"
+_DISPLAYNAME = "ProGene"
 
 _DESCRIPTION = """\
 The Protein/Gene corpus was developed at the JULIE Lab Jena under supervision of Prof. Udo Hahn.

--- a/bigbio/biodatasets/psytar/psytar.py
+++ b/bigbio/biodatasets/psytar/psytar.py
@@ -85,6 +85,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "psytar"
+_DISPLAYNAME = "PsyTAR"
 
 _DESCRIPTION = """\
 The "Psychiatric Treatment Adverse Reactions" (PsyTAR) dataset contains 891 drugs

--- a/bigbio/biodatasets/pubhealth/pubhealth.py
+++ b/bigbio/biodatasets/pubhealth/pubhealth.py
@@ -44,6 +44,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "pubhealth"
+_DISPLAYNAME = "PUBHEALTH"
 
 _DESCRIPTION = """\
 A dataset of 11,832 claims for fact- checking, which are related a range of health topics

--- a/bigbio/biodatasets/pubmed_qa/pubmed_qa.py
+++ b/bigbio/biodatasets/pubmed_qa/pubmed_qa.py
@@ -44,6 +44,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "pubmed_qa"
+_DISPLAYNAME = "PubMedQA"
 
 _DESCRIPTION = """\
 PubMedQA is a novel biomedical question answering (QA) dataset collected from PubMed abstracts.

--- a/bigbio/biodatasets/pubtator_central/pubtator_central.py
+++ b/bigbio/biodatasets/pubtator_central/pubtator_central.py
@@ -72,6 +72,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "pubtator_central"
+_DISPLAYNAME = "PubTator Central"
 
 _DESCRIPTION = """\
 PubTator Central (PTC, https://www.ncbi.nlm.nih.gov/research/pubtator/) is a web service for

--- a/bigbio/biodatasets/quaero/quaero.py
+++ b/bigbio/biodatasets/quaero/quaero.py
@@ -71,7 +71,8 @@ _LICENSE = Licenses.GFDL_1p3
 
 _URL = "https://quaerofrenchmed.limsi.fr/QUAERO_FrenchMed_BioC.zip"
 
-_DATASET_NAME = "QUAERO French Medical Corpus"
+_DATASET_NAME = "quaero"
+_DISPLAYNAME = "QUAERO"
 
 _SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
 _SOURCE_VERSION = "1.0.0"

--- a/bigbio/biodatasets/scai_chemical/scai_chemical.py
+++ b/bigbio/biodatasets/scai_chemical/scai_chemical.py
@@ -44,6 +44,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "scai_chemical"
+_DISPLAYNAME = "SCAI Chemical"
 
 _DESCRIPTION = """\
 SCAI Chemical is a corpus of MEDLINE abstracts that has been annotated

--- a/bigbio/biodatasets/scai_disease/scai_disease.py
+++ b/bigbio/biodatasets/scai_disease/scai_disease.py
@@ -46,6 +46,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "scai_disease"
+_DISPLAYNAME = "SCAI Disease"
 
 _DESCRIPTION = """\
 SCAI Disease is a dataset annotated in 2010 with mentions of diseases and

--- a/bigbio/biodatasets/scicite/scicite.py
+++ b/bigbio/biodatasets/scicite/scicite.py
@@ -55,6 +55,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "scicite"
+_DISPLAYNAME = "SciCite"
 
 _DESCRIPTION = """\
 SciCite is a dataset of 11K manually annotated citation intents based on

--- a/bigbio/biodatasets/scielo/scielo.py
+++ b/bigbio/biodatasets/scielo/scielo.py
@@ -29,19 +29,25 @@ _PUBMED = False
 _LOCAL = False
 _CITATION = """\
 @inproceedings{soares2018large,
-  title={A Large Parallel Corpus of Full-Text Scientific Articles},
-  author={Soares, Felipe and Moreira, Viviane and Becker, Karin},
-  booktitle={Proceedings of the Eleventh International Conference on Language Resources and Evaluation (LREC-2018)},
-  year={2018}
+  title        = {A Large Parallel Corpus of Full-Text Scientific Articles},
+  author       = {Soares, Felipe and Moreira, Viviane and Becker, Karin},
+  year         = 2018,
+  booktitle    = {
+    Proceedings of the Eleventh International Conference on Language Resources
+    and Evaluation (LREC-2018)
+  }
 }
 """
 
 _DATASETNAME = "scielo"
+_DISPLAYNAME = "SciELO"
 
 _DESCRIPTION = """\
-A parallel corpus of full-text scientific articles collected from Scielo database in the following languages: \
-English, Portuguese and Spanish. The corpus is sentence aligned for all language pairs, \
-as well as trilingual aligned for a small subset of sentences. Alignment was carried out using the Hunalign algorithm.
+A parallel corpus of full-text scientific articles collected from Scielo \
+database in the following languages: English, Portuguese and Spanish. The corpus \
+is sentence aligned for all language pairs, as well as trilingual aligned for a \
+small subset of sentences. Alignment was carried out using the Hunalign \
+algorithm.
 """
 
 _HOMEPAGE = "https://sites.google.com/view/felipe-soares/datasets#h.p_92uSCyAjWSRB"

--- a/bigbio/biodatasets/scifact/scifact.py
+++ b/bigbio/biodatasets/scifact/scifact.py
@@ -44,6 +44,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "scifact"
+_DISPLAYNAME = "SciFact"
 
 _SOURCE_CORPUS_DESCRIPTION = """\
     SciFact is a dataset of 1.4K expert-written scientific claims paired with evidence-containing abstracts, and annotated with labels and rationales.

--- a/bigbio/biodatasets/sciq/sciq.py
+++ b/bigbio/biodatasets/sciq/sciq.py
@@ -24,6 +24,7 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "sciq"
+_DISPLAYNAME = "SciQ"
 
 _LANGUAGES = [Lang.EN]
 _PUBMED = False
@@ -45,10 +46,12 @@ _CITATION = """
 }
 """
 
-_DESCRIPTION = """
-The SciQ dataset contains 13,679 crowdsourced science exam questions about Physics, Chemistry and Biology, \
-among others. The questions are in multiple-choice format with 4 answer options each. \
-For most questions, an additional paragraph with supporting evidence for the correct answer is provided.
+_DESCRIPTION = """\
+The SciQ dataset contains 13,679 crowdsourced science exam questions about \
+Physics, Chemistry and Biology, among others. The questions are in \
+multiple-choice format with 4 answer options each. For most questions, an \
+additional paragraph with supporting evidence for the correct answer is \
+provided.
 """
 
 _HOMEPAGE = "https://allenai.org/data/sciq"

--- a/bigbio/biodatasets/scitail/scitail.py
+++ b/bigbio/biodatasets/scitail/scitail.py
@@ -46,6 +46,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "scitail"
+_DISPLAYNAME = "SciTail"
 
 _DESCRIPTION = """\
 The SciTail dataset is an entailment dataset created from multiple-choice science exams and

--- a/bigbio/biodatasets/seth_corpus/seth_corpus.py
+++ b/bigbio/biodatasets/seth_corpus/seth_corpus.py
@@ -50,6 +50,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "seth_corpus"
+_DISPLAYNAME = "SETH Corpus"
 
 _DESCRIPTION = (
     """SNP named entity recognition corpus consisting of 630 PubMed citations."""

--- a/bigbio/biodatasets/spl_adr_200db/spl_adr_200db.py
+++ b/bigbio/biodatasets/spl_adr_200db/spl_adr_200db.py
@@ -88,6 +88,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "spl_adr_200db"
+_DISPLAYNAME = "SPL ADR"
 
 _DESCRIPTION = """\
 The United States Food and Drug Administration (FDA) partnered with the National Library

--- a/bigbio/biodatasets/swedish_medical_ner/swedish_medical_ner.py
+++ b/bigbio/biodatasets/swedish_medical_ner/swedish_medical_ner.py
@@ -42,6 +42,7 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "swedish_medical_ner"
+_DISPLAYNAME = "Swedish Medical NER"
 
 _LANGUAGES = [Lang.SV]
 _PUBMED = False

--- a/bigbio/biodatasets/thomas2011/thomas2011.py
+++ b/bigbio/biodatasets/thomas2011/thomas2011.py
@@ -52,7 +52,7 @@ from bigbio.utils.configs import BigBioConfig
 from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import CustomLicense
 
-# TODO: Add BibTeX citation
+
 _LANGUAGES = [Lang.EN]
 _PUBMED = True
 _LOCAL = False
@@ -69,6 +69,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "thomas2011"
+_DISPLAYNAME = "SNP Corpus"
 
 _DESCRIPTION = """\
 SNP normalization corpus downloaded from (http://www.scai.fraunhofer.de/snp-normalization-corpus.html).
@@ -93,8 +94,6 @@ Also the additional rules are subject to these agreement.
 The annotations are published for academic use only and usage for development of commercial products is not permitted.
 """
 )
-
-#
 
 # this is a backup url in case the official one will stop working
 # _URLS = ["http://github.com/rockt/SETH/zipball/master/"]

--- a/bigbio/biodatasets/tmvar_v1/tmvar_v1.py
+++ b/bigbio/biodatasets/tmvar_v1/tmvar_v1.py
@@ -43,6 +43,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "tmvar_v1"
+_DISPLAYNAME = "tmVar v1"
 
 _DESCRIPTION = """This dataset contains 500 PubMed articles manually annotated with mutation mentions of various kinds. It can be used for NER tasks only.
 The dataset is split into train(334) and test(166) splits"""

--- a/bigbio/biodatasets/tmvar_v2/tmvar_v2.py
+++ b/bigbio/biodatasets/tmvar_v2/tmvar_v2.py
@@ -43,6 +43,7 @@ publisher={Oxford University Press}
 """
 
 _DATASETNAME = "tmvar_v2"
+_DISPLAYNAME = "tmVar v2"
 
 _DESCRIPTION = """This dataset contains 158 PubMed articles manually annotated with mutation mentions of various kinds and dbsnp normalizations for each of them.
 It can be used for NER tasks and NED tasks, This dataset has a single split"""

--- a/bigbio/biodatasets/tmvar_v3/tmvar_v3.py
+++ b/bigbio/biodatasets/tmvar_v3/tmvar_v3.py
@@ -12,9 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""\This dataset contains 500 PubMed articles manually annotated with mutation mentions of various kinds and dbsnp normalizations for each of them. 
-In addition, it contains variant normalization options such as allele-specific identifiers from the ClinGen Allele Registry
-It can be used for NER tasks and NED tasks, This dataset does NOT have splits"""
+"""
+This dataset contains 500 PubMed articles manually annotated with mutation 
+mentions of various kinds and dbsnp normalizations for each of them.  In 
+addition, it contains variant normalization options such as allele-specific 
+identifiers from the ClinGen Allele Registry It can be used for NER tasks and 
+NED tasks, This dataset does NOT have splits.
+"""
 import itertools
 
 import datasets
@@ -27,30 +31,38 @@ from bigbio.utils.license import Licenses
 
 _CITATION = """\
 @misc{https://doi.org/10.48550/arxiv.2204.03637,
-  doi = {10.48550/ARXIV.2204.03637},
-  
-  url = {https://arxiv.org/abs/2204.03637},
-  
-  author = {Wei, Chih-Hsuan and Allot, Alexis and Riehle, Kevin and Milosavljevic, Aleksandar and Lu, Zhiyong},
-  
-  keywords = {Computation and Language (cs.CL), FOS: Computer and information sciences, FOS: Computer and information sciences},
-  
-  title = {tmVar 3.0: an improved variant concept recognition and normalization tool},
-  
-  publisher = {arXiv},
-  
-  year = {2022},
-  
-  copyright = {Creative Commons Attribution 4.0 International}
+  title        = {tmVar 3.0: an improved variant concept recognition and normalization tool},
+  author       = {
+    Wei, Chih-Hsuan and Allot, Alexis and Riehle, Kevin and Milosavljevic,
+    Aleksandar and Lu, Zhiyong
+  },
+  year         = 2022,
+  publisher    = {arXiv},
+  doi          = {10.48550/ARXIV.2204.03637},
+  url          = {https://arxiv.org/abs/2204.03637},
+  copyright    = {Creative Commons Attribution 4.0 International},
+  keywords     = {
+    Computation and Language (cs.CL), FOS: Computer and information sciences,
+    FOS: Computer and information sciences
+  }
 }
+
 """
 _LANGUAGES = [Lang.EN]
 _PUBMED = True
 _LOCAL = False
+
 _DATASETNAME = "tmvar_v3"
-_DESCRIPTION = """This dataset contains 500 PubMed articles manually annotated with mutation mentions of various kinds and dbsnp normalizations for each of them. 
-In addition, it contains variant normalization options such as allele-specific identifiers from the ClinGen Allele Registry
-It can be used for NER tasks and NED tasks, This dataset does NOT have splits"""
+_DISPLAYNAME = "tmVar v3"
+
+_DESCRIPTION = """\
+This dataset contains 500 PubMed articles manually annotated with mutation \
+mentions of various kinds and dbsnp normalizations for each of them.  In \
+addition, it contains variant normalization options such as allele-specific \
+identifiers from the ClinGen Allele Registry It can be used for NER tasks and \
+NED tasks, This dataset does NOT have splits.
+"""
+
 _HOMEPAGE = "https://www.ncbi.nlm.nih.gov/research/bionlp/Tools/tmvar/"
 
 _LICENSE = Licenses.UNKNOWN

--- a/bigbio/biodatasets/twadrl/twadrl.py
+++ b/bigbio/biodatasets/twadrl/twadrl.py
@@ -25,7 +25,7 @@ from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
 
 _DATASETNAME = "twadrl"
-
+_DISPLAYNAME = "TwADR-L"
 _LANGUAGES = [Lang.EN]
 _PUBMED = False
 _LOCAL = False

--- a/bigbio/biodatasets/umnsrs/umnsrs.py
+++ b/bigbio/biodatasets/umnsrs/umnsrs.py
@@ -49,6 +49,7 @@ _CITATION = """\
 """
 
 _DATASETNAME = "umnsrs"
+_DISPLAYNAME = "UMNSRS"
 
 _DESCRIPTION = """\
 UMNSRS, developed by Pakhomov, et al., consists of 725 clinical term pairs whose semantic similarity and relatedness.

--- a/bigbio/biodatasets/verspoor_2013/verspoor_2013.py
+++ b/bigbio/biodatasets/verspoor_2013/verspoor_2013.py
@@ -14,14 +14,16 @@
 # limitations under the License.
 
 """
-This dataset contains annotations for a small corpus of full text journal publications
-on the subject of inherited colorectal cancer. It is suitable for Named Entity Recognition and
-Relation Extraction tasks. It uses the Variome Annotation Schema,  a schema that aims to
-capture the core concepts and relations relevant to cataloguing  and interpreting human
-genetic variation and its relationship to disease, as described in the published literature.
-The schema was inspired by the needs of the database curators of the International Society
-for Gastrointestinal Hereditary Tumours (InSiGHT) database, but is intended to have
-application to genetic variation information in a range of diseases.
+This dataset contains annotations for a small corpus of full text journal
+publications on the subject of inherited colorectal cancer. It is suitable for
+Named Entity Recognition and Relation Extraction tasks. It uses the Variome
+Annotation Schema,  a schema that aims to capture the core concepts and
+relations relevant to cataloguing  and interpreting human genetic variation and
+its relationship to disease, as described in the published literature. The
+schema was inspired by the needs of the database curators of the International
+Society for Gastrointestinal Hereditary Tumours (InSiGHT) database, but is
+intended to have application to genetic variation information in a range of
+diseases.
 """
 
 from pathlib import Path
@@ -40,27 +42,34 @@ _PUBMED = True
 _LOCAL = False
 _CITATION = """\
 @article{verspoor2013annotating,
-title={Annotating the biomedical literature for the human variome},
-author={Verspoor, Karin and Jimeno Yepes, Antonio and Cavedon, Lawrence and McIntosh, Tara and Herten-Crabb, Asha and Thomas, Zo{"e} and Plazzer, John-Paul},
-journal={Database},
-volume={2013},
-year={2013},
-publisher={Oxford Academic}
+  title        = {Annotating the biomedical literature for the human variome},
+  author       = {
+    Verspoor, Karin and Jimeno Yepes, Antonio and Cavedon, Lawrence and
+    McIntosh, Tara and Herten-Crabb, Asha and Thomas, Zo{"e} and Plazzer,
+    John-Paul
+  },
+  year         = 2013,
+  journal      = {Database},
+  publisher    = {Oxford Academic},
+  volume       = 2013
 }
-"""  # noqa: E501
-
+"""
 
 _DATASETNAME = "verspoor_2013"
+_DISPLAYNAME = "Verspoor 2013"
 
 _DESCRIPTION = """\
-This dataset contains annotations for a small corpus of full text journal publications
-on the subject of inherited colorectal cancer. It is suitable for Named Entity Recognition and
-Relation Extraction tasks. It uses the Variome Annotation Schema,  a schema that aims to
-capture the core concepts and relations relevant to cataloguing  and interpreting human
-genetic variation and its relationship to disease, as described in the published literature.
-The schema was inspired by the needs of the database curators of the International Society
-for Gastrointestinal Hereditary Tumours (InSiGHT) database, but is intended to have
-application to genetic variation information in a range of diseases."""
+This dataset contains annotations for a small corpus of full text journal \
+publications on the subject of inherited colorectal cancer. It is suitable for \
+Named Entity Recognition and Relation Extraction tasks. It uses the Variome \
+Annotation Schema,  a schema that aims to capture the core concepts and \
+relations relevant to cataloguing  and interpreting human genetic variation and \
+its relationship to disease, as described in the published literature. The \
+schema was inspired by the needs of the database curators of the International \
+Society for Gastrointestinal Hereditary Tumours (InSiGHT) database, but is \
+intended to have application to genetic variation information in a range of \
+diseases.
+"""
 
 
 _HOMEPAGE = "NA"
@@ -80,14 +89,16 @@ _BIGBIO_VERSION = "1.0.0"
 
 
 class Verspoor2013Dataset(datasets.GeneratorBasedBuilder):
-    """This dataset contains annotations for a small corpus of full text journal publications
+    """\
+    This dataset contains annotations for a small corpus of full text journal publications
     on the subject of inherited colorectal cancer. It is suitable for Named Entity Recognition and
     Relation Extraction tasks. It uses the Variome Annotation Schema,  a schema that aims to
     capture the core concepts and relations relevant to cataloguing  and interpreting human
     genetic variation and its relationship to disease, as described in the published literature.
     The schema was inspired by the needs of the database curators of the International Society
     for Gastrointestinal Hereditary Tumours (InSiGHT) database, but is intended to have
-    application to genetic variation information in a range of diseases."""
+    application to genetic variation information in a range of diseases.
+    """
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)

--- a/bigbio/dataloader.py
+++ b/bigbio/dataloader.py
@@ -407,6 +407,7 @@ class BigBioConfigHelper:
     citation: str
     description: str
     homepage: str
+    display_name: str
     license: str
 
     _ds_module: datasets.load.DatasetModule = field(repr=False)
@@ -520,6 +521,7 @@ class BigBioConfigHelpers:
                         citation=py_module._CITATION,
                         description=py_module._DESCRIPTION,
                         homepage=py_module._HOMEPAGE,
+                        display_name=py_module._DISPLAYNAME,
                         license=py_module._LICENSE,
                         _ds_module=ds_module,
                         _py_module=py_module,

--- a/bigbio/utils/constants.py
+++ b/bigbio/utils/constants.py
@@ -24,6 +24,7 @@ METADATA: dict = {
     "_LANGUAGES": Lang,
     "_PUBMED": bool,
     "_LICENSE": Licenses,
+    "_DISPLAYNAME": str,
 }
 
 


### PR DESCRIPTION
This PR adds a `_DISPLAYNAME` variable to every dataloader. This corresponds to the dataset as mentioned in the original publication and is useful for generating table results automatically. 
Other misc fixes:  
- Misc citation and docstring clean-up.
- Misc dataset fixes around missing or inconsistently named variables.
This addresses Issue #708 