### PR TITLE
Create dataloader for PMC-Patients Task 1: Patient Note Recognition (PNR)

### DIFF
--- a/bigbio/biodatasets/pmc_patients_pnr/pmc_patients_pnr.py
+++ b/bigbio/biodatasets/pmc_patients_pnr/pmc_patients_pnr.py
@@ -60,7 +60,7 @@ _URLS = {
     _DATASETNAME: "https://drive.google.com/u/0/uc?id=1vFCLy_CF8fxPDZvDtHPR6Dl6x9l0TyvW&export=download",
 }
 
-_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+_SUPPORTED_TASKS = []
 
 _SOURCE_VERSION = "1.2.0"
 

--- a/bigbio/biodatasets/pmc_patients_pnr/pmc_patients_pnr.py
+++ b/bigbio/biodatasets/pmc_patients_pnr/pmc_patients_pnr.py
@@ -14,7 +14,11 @@
 # limitations under the License.
 
 """
-PMC-Patients dataset consists of 4 tasks. One of the task is Patient Note Recognition (PNR). PMC-Patients PNR dataset is modeled as a paragraph-level sequential labeling task, similar to the named entity recognition (NER) task. For each article, given input as a sequence of texts p1, p2, ..., pn, where n is the number of paragraphs, the output is a sequence of BIO tags t1, t2, ..., tn.
+PMC-Patients dataset consists of 4 tasks. One of the task is Patient Note Recognition (PNR).
+PMC-Patients PNR dataset is modeled as a paragraph-level sequential labeling task,
+similar to the named entity recognition (NER) task.
+For each article, given input as a sequence of texts p1, p2, ..., pn, where n is the number of paragraphs,
+the output is a sequence of BIO tags t1, t2, ..., tn.
 """
 
 import json
@@ -22,9 +26,7 @@ import os
 from typing import Dict, List, Tuple
 
 import datasets
-import pandas as pd
 
-from bigbio.utils import schemas
 from bigbio.utils.configs import BigBioConfig
 from bigbio.utils.constants import Lang, Tasks
 from bigbio.utils.license import Licenses
@@ -66,7 +68,12 @@ _BIGBIO_VERSION = "1.0.0"
 
 
 class PMCPatientsPNRDataset(datasets.GeneratorBasedBuilder):
-    """PMC-Patients dataset consists of 4 tasks. One of the task is Patient Note Recognition (PNR). PMC-Patients PNR dataset is modeled as a paragraph-level sequential labeling task, similar to the named entity recognition (NER) task. For each article, given input as a sequence of texts p1, p2, ..., pn, where n is the number of paragraphs, the output is a sequence of BIO tags t1, t2, ..., tn. 
+    """
+    PMC-Patients dataset consists of 4 tasks. One of the task is Patient Note Recognition (PNR).
+    PMC-Patients PNR dataset is modeled as a paragraph-level sequential labeling task,
+    similar to the named entity recognition (NER) task.
+    For each article, given input as a sequence of texts p1, p2, ..., pn, where n is the number of paragraphs,
+    the output is a sequence of BIO tags t1, t2, ..., tn.
     """
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
@@ -142,9 +149,7 @@ class PMCPatientsPNRDataset(datasets.GeneratorBasedBuilder):
             ),
         ]
 
-    def _generate_examples(
-        self, filepath, split: str, data_dir: str
-    ) -> Tuple[int, Dict]:
+    def _generate_examples(self, filepath, split: str, data_dir: str) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
 
         with open(filepath, "r") as j:

--- a/bigbio/biodatasets/pmc_patients_pnr/pmc_patients_pnr.py
+++ b/bigbio/biodatasets/pmc_patients_pnr/pmc_patients_pnr.py
@@ -1,0 +1,161 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+PMC-Patients dataset consists of 4 tasks. One of the task is Patient Note Recognition (PNR). PMC-Patients PNR dataset is modeled as a paragraph-level sequential labeling task, similar to the named entity recognition (NER) task. For each article, given input as a sequence of texts p1, p2, ..., pn, where n is the number of paragraphs, the output is a sequence of BIO tags t1, t2, ..., tn.
+"""
+
+import json
+import os
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from bigbio.utils import schemas
+from bigbio.utils.configs import BigBioConfig
+from bigbio.utils.constants import Lang, Tasks
+from bigbio.utils.license import Licenses
+
+_LANGUAGES = [Lang.EN]
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@misc{zhao2022pmcpatients,
+      title={PMC-Patients: A Large-scale Dataset of Patient Notes and Relations Extracted from Case
+          Reports in PubMed Central},
+      author={Zhengyun Zhao and Qiao Jin and Sheng Yu},
+      year={2022},
+      eprint={2202.13876},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}"""
+
+_DATASETNAME = "pmc_patients_pnr"
+_DISPLAYNAME = "PMC-Patients Task 1: Patient Note Recognition (PNR)"
+
+_DESCRIPTION = """\
+PMC-Patients PNR is a paragraph-level sequential modeling to recognize patient notes.
+"""
+
+_HOMEPAGE = "https://github.com/zhao-zy15/PMC-Patients"
+
+_LICENSE = Licenses.CC_BY_NC_SA_4p0
+
+_URLS = {
+    _DATASETNAME: "https://drive.google.com/u/0/uc?id=1vFCLy_CF8fxPDZvDtHPR6Dl6x9l0TyvW&export=download",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.2.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class PMCPatientsPNRDataset(datasets.GeneratorBasedBuilder):
+    """PMC-Patients dataset consists of 4 tasks. One of the task is Patient Note Recognition (PNR). PMC-Patients PNR dataset is modeled as a paragraph-level sequential labeling task, similar to the named entity recognition (NER) task. For each article, given input as a sequence of texts p1, p2, ..., pn, where n is the number of paragraphs, the output is a sequence of BIO tags t1, t2, ..., tn. 
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="pmc_patients_pnr_source",
+            version=SOURCE_VERSION,
+            description="pmc_patients_pnr source schema",
+            schema="source",
+            subset_id="pmc_patients_pnr",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "pmc_patients_pnr_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "texts": [datasets.Value("string")],
+                    "tags": [datasets.Value("string")],
+                }
+            )
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir,
+                        "datasets/task_1_patient_note_recognition/PNR_train.json",
+                    ),
+                    "split": "train",
+                    "data_dir": data_dir,
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir,
+                        "datasets/task_1_patient_note_recognition/PNR_test.json",
+                    ),
+                    "split": "test",
+                    "data_dir": data_dir,
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir,
+                        "datasets/task_1_patient_note_recognition/PNR_dev.json",
+                    ),
+                    "split": "dev",
+                    "data_dir": data_dir,
+                },
+            ),
+        ]
+
+    def _generate_examples(
+        self, filepath, split: str, data_dir: str
+    ) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        with open(filepath, "r") as j:
+            file = json.load(j)
+
+        if self.config.schema == "source":
+
+            for uid, article in enumerate(file):
+                feature_dict = {
+                    "id": uid,
+                    "texts": article["texts"],
+                    "tags": article["tags"],
+                }
+                yield uid, feature_dict


### PR DESCRIPTION
Hello, I noticed that this repo has `pmc_patients` for PMC-Patients Task 2: Patient-Patient Similarity (PPS), but there was no dataloader for PMC-Patients Task 1: Patient Note Recognition (PNR), so I created this pull request for this addition.

Regarding the dataloader schema, since the PMC-Patients PNR is not suitable for all the schemas that have been provided [here](https://github.com/holylovenia/biomedical/blob/master/task_schemas.md), I followed @galtay's recommendation (via @SamuelCahyawijaya; thanks for relaying the info to me) to implement the source schema only and leave the `_SUPPORTED_TASKS` empty.

- **Name:** PMC-Patients
- **Description:** PMC-Patients dataset consists of 4 tasks. One of the task is Patient Note Recognition (PNR). PMC-Patients PNR dataset is modeled as a paragraph-level sequential labeling task, similar to the named entity recognition (NER) task. For each article, given input as a sequence of texts p1, p2, ..., pn, where n is the number of paragraphs, the output is a sequence of BIO tags t1, t2, ..., tn.
- **Paper:** [PMC-Patients: A Large-scale Dataset of Patient Notes and Relations Extracted from Case Reports in PubMed Central](https://arxiv.org/pdf/2202.13876.pdf)
- **Data:** [Google Drive](https://drive.google.com/u/0/uc?id=1vFCLy_CF8fxPDZvDtHPR6Dl6x9l0TyvW&export=download)

### Checkbox

- [ ] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `biodatasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_BIGBIO_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [ ] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `BigBioConfig` for the source schema and one for a bigbio schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_bigbio biodatasets/my_dataset/my_dataset.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
