### PR TITLE
Automating hub migration

### DIFF
--- a/hub/convert_all_scripts.sh
+++ b/hub/convert_all_scripts.sh
@@ -8,6 +8,6 @@ for dset in anat_em an_em ask_a_patient bc5cdr bc7_litcovid bioasq_2021_mesinesp
     TARGET=$SOURCEDIR"/"$dset"/"$dset".py"
     SAVENAME=$SAVEDIR"/"$dset"_hub.py"
     echo $dset
-    python make_hub_script.py --script $TARGET --savename
+    python make_hub_script.py --script $TARGET --savename $SAVENAME
     echo "------------"
 done

--- a/hub/convert_all_scripts.sh
+++ b/hub/convert_all_scripts.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+SOURCEDIR="/home/natasha/Projects/hfbiomed/biomedical/bigbio/biodatasets"
+SAVEDIR="/home/natasha/Projects/hfbiomed/biomedical/hub"
+
+for dset in anat_em an_em ask_a_patient bc5cdr bc7_litcovid bioasq_2021_mesinesp bioasq_task_b bioasq_task_c_2017 bioinfer biology_how_why_corpus biomrc bionlp_shared_task_2009 bionlp_st_2011_epi bionlp_st_2011_ge bionlp_st_2011_id bionlp_st_2011_rel bionlp_st_2013_cg bionlp_st_2013_ge bionlp_st_2013_gro bionlp_st_2013_pc bionlp_st_2019_bb biored biorelex bioscope bio_simlex bio_sim_verb biosses blurb cadec cantemist cas cellfinder chebi_nactem chemdner chemprot chia citation_gia_test_collection codiesp cord_ner ctebmsp ddi_corpus diann_iber_eval distemist ebm_pico ehr_rel essai euadr evidence_inference gad genetag genia_ptm_event_corpus genia_relation_corpus genia_term_corpus geokhoj_v1 gnormplus hallmarks_of_cancer hprd50 iepa jnlpba linnaeus lll mantra_gsc mayosrs medal meddialog meddocan medhop medical_data mediqa_nli mediqa_qa mediqa_rqe medmentions mednli med_qa meqsum minimayosrs mirna mlee mqp msh_wsd muchmore multi_xscience mutation_finder n2c2_2006_deid n2c2_2006_smokers n2c2_2008 n2c2_2009 n2c2_2010 n2c2_2011 n2c2_2014_deid n2c2_2014_risk_factors n2c2_2018_track1 n2c2_2018_track2 nagel ncbi_disease nlmchem nlm_gene nlm_wsd ntcir_13_medweb osiris paramed pcr pdr pharmaconer pho_ner pico_extraction pmc_patients progene psytar pubhealth pubmed_qa pubtator_central quaero scai_chemical scai_disease scicite scielo scifact sciq scitail seth_corpus spl_adr_200db swedish_medical_ner thomas2011 tmvar_v1 tmvar_v2 tmvar_v3 twadrl umnsrs verspoor_2013; do
+    
+    TARGET=$SOURCEDIR"/"$dset"/"$dset".py"
+    SAVENAME=$SAVEDIR"/"$dset"_hub.py"
+    echo $dset
+    python make_hub_script.py --script $TARGET --savename
+    echo "------------"
+done

--- a/hub/hubscripts/an_em_hub.py
+++ b/hub/hubscripts/an_em_hub.py
@@ -1,0 +1,302 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+AnEM corpus is a domain- and species-independent resource manually annotated for anatomical
+entity mentions using a fine-grained classification system. The corpus consists of 500 documents
+(over 90,000 words) selected randomly from citation abstracts and full-text papers with
+the aim of making the corpus representative of the entire available biomedical scientific
+literature. The corpus annotation covers mentions of both healthy and pathological anatomical
+entities and contains over 3,000 annotated mentions.
+"""
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{ohta-etal-2012-open,
+  author    = {Ohta, Tomoko and Pyysalo, Sampo and Tsujii, Jun{'}ichi and Ananiadou, Sophia},
+  title     = {Open-domain Anatomical Entity Mention Detection},
+  journal   = {},
+  volume    = {W12-43},
+  year      = {2012},
+  url       = {https://aclanthology.org/W12-4304},
+  doi       = {},
+  biburl    = {},
+  bibsource = {},
+  publisher = {Association for Computational Linguistics}
+}
+"""
+
+_DATASETNAME = "an_em"
+_DISPLAYNAME = "AnEM"
+
+_DESCRIPTION = """\
+AnEM corpus is a domain- and species-independent resource manually annotated for anatomical
+entity mentions using a fine-grained classification system. The corpus consists of 500 documents
+(over 90,000 words) selected randomly from citation abstracts and full-text papers with
+the aim of making the corpus representative of the entire available biomedical scientific
+literature. The corpus annotation covers mentions of both healthy and pathological anatomical
+entities and contains over 3,000 annotated mentions.
+"""
+
+
+_HOMEPAGE = "http://www.nactem.ac.uk/anatomy/"
+
+_LICENSE = 'Creative Commons Attribution Share Alike 3.0 Unported'
+
+_URLS = {
+    _DATASETNAME: "http://www.nactem.ac.uk/anatomy/data/AnEM-1.0.4.tar.gz",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.COREFERENCE_RESOLUTION,
+    Tasks.RELATION_EXTRACTION,
+]
+
+_SOURCE_VERSION = "1.0.4"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class AnEMDataset(datasets.GeneratorBasedBuilder):
+    """Anatomical Entity Mention (AnEM) corpus"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="an_em_source",
+            version=SOURCE_VERSION,
+            description="AnEM source schema",
+            schema="source",
+            subset_id="an_em",
+        ),
+        BigBioConfig(
+            name="an_em_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="AnEM BigBio schema",
+            schema="bigbio_kb",
+            subset_id="an_em",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "an_em_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "document_type": datasets.Value("string"),
+                    "text_type": datasets.Value("string"),
+                    "entities": [
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "entity_id": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [
+                        {
+                            "entity_id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "relations": [
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        data_dir = Path(dl_manager.download_and_extract(urls))
+        all_data = data_dir / "AnEM-1.0.4" / "standoff"
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": all_data,
+                    "split_path": data_dir
+                    / "AnEM-1.0.4"
+                    / "development"
+                    / "train-files.list",
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": all_data,
+                    "split_path": data_dir / "AnEM-1.0.4" / "test" / "test-files.list",
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": all_data,
+                    "split_path": data_dir
+                    / "AnEM-1.0.4"
+                    / "development"
+                    / "test-files.list",
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split_path, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        with open(split_path, "r") as sp:
+            split_list = [line.rstrip() for line in sp]
+
+        if self.config.schema == "source":
+            for file in filepath.iterdir():
+
+                # Use brat text files and consider files in the provided split list
+                if (file.suffix != ".txt") or (file.stem not in split_list):
+                    continue
+                brat_parsed = parse.parse_brat_file(file)
+                source_example = self._brat_to_source(file, brat_parsed)
+
+                yield source_example["document_id"], source_example
+
+        elif self.config.schema == "bigbio_kb":
+            for file in filepath.iterdir():
+
+                # Use brat text files and consider files in the provided split list
+                if (file.suffix != ".txt") or (file.stem not in split_list):
+                    continue
+                brat_parsed = parse.parse_brat_file(file)
+                bigbio_kb_example = parse.brat_parse_to_bigbio_kb(brat_parsed)
+
+                bigbio_kb_example["id"] = bigbio_kb_example["document_id"]
+
+                doc_type, text_type = self.get_document_type_and_text_type(file)
+                bigbio_kb_example["passages"][0]["type"] = text_type
+
+                yield bigbio_kb_example["id"], bigbio_kb_example
+
+    def _brat_to_source(self, filepath, brat_example):
+        """
+        Converts parsed brat example to source schema example
+        """
+        document_type, text_type = self.get_document_type_and_text_type(filepath)
+
+        source_example = {
+            "document_id": brat_example["document_id"],
+            "text": brat_example["text"],
+            "document_type": document_type,
+            "text_type": text_type,
+            "entities": [
+                {
+                    "offsets": brat_entity["offsets"],
+                    "text": brat_entity["text"],
+                    "type": brat_entity["type"],
+                    "entity_id": f"{brat_example['document_id']}_{brat_entity['id']}",
+                }
+                for brat_entity in brat_example["text_bound_annotations"]
+            ],
+            "equivalences": [
+                {
+                    "entity_id": brat_entity["id"],
+                    "ref_ids": [
+                        f"{brat_example['document_id']}_{ids}"
+                        for ids in brat_entity["ref_ids"]
+                    ],
+                }
+                for brat_entity in brat_example["equivalences"]
+            ],
+            "relations": [
+                {
+                    "id": f"{brat_example['document_id']}_{brat_entity['id']}",
+                    "head": {
+                        "ref_id": f"{brat_example['document_id']}_{brat_entity['head']['ref_id']}",
+                        "role": brat_entity["head"]["role"],
+                    },
+                    "tail": {
+                        "ref_id": f"{brat_example['document_id']}_{brat_entity['tail']['ref_id']}",
+                        "role": brat_entity["tail"]["role"],
+                    },
+                    "type": brat_entity["type"],
+                }
+                for brat_entity in brat_example["relations"]
+            ],
+        }
+
+        return source_example
+
+    def get_document_type_and_text_type(self, input_file: Path) -> Tuple[str, str]:
+        """
+        Implementation used from
+        https://github.com/bigscience-workshop/biomedical/blob/master/biodatasets/anat_em/anat_em.py
+
+        Extracts the document type (PubMed(PM) or PubMedCentral (PMC)) and the respective
+        text type (abstract for PM and sec or caption for (PMC) from the name of the given
+        file, e.g.:
+
+        PMID-9778569.txt -> ("PM", "abstract")
+
+        PMC-1274342-sec-02.txt -> ("PMC", "sec")
+
+        PMC-1592597-caption-02.ann -> ("PMC", "caption")
+
+        """
+        name_parts = str(input_file.stem).split("-")
+
+        if name_parts[0] == "PMID":
+            return "PM", "abstract"
+
+        elif name_parts[0] == "PMC":
+            return "PMC", name_parts[2]
+        else:
+            raise AssertionError(f"Unexpected file prefix {name_parts[0]}")

--- a/hub/hubscripts/anat_em_hub.py
+++ b/hub/hubscripts/anat_em_hub.py
@@ -1,0 +1,227 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+The extended Anatomical Entity Mention corpus (AnatEM) consists of 1212 documents
+(approx. 250,000 words) manually annotated to identify over 13,000 mentions of anatomical
+entities. Each annotation is assigned one of 12 granularity-based types such as Cellular
+component, Tissue and Organ, defined with reference to the Common Anatomy Reference Ontology
+(see https://bioportal.bioontology.org/ontologies/CARO).
+"""
+from pathlib import Path
+from typing import Dict, Iterator, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{pyysalo2014anatomical,
+  title={Anatomical entity mention recognition at literature scale},
+  author={Pyysalo, Sampo and Ananiadou, Sophia},
+  journal={Bioinformatics},
+  volume={30},
+  number={6},
+  pages={868--875},
+  year={2014},
+  publisher={Oxford University Press}
+}
+"""
+
+_DATASETNAME = "anat_em"
+_DISPLAYNAME = "AnatEM"
+
+
+_DESCRIPTION = """\
+The extended Anatomical Entity Mention corpus (AnatEM) consists of 1212 \
+documents (approx. 250,000 words) manually annotated to identify over 13,000 \
+mentions of anatomical entities. Each annotation is assigned one of 12 \
+granularity-based types such as Cellular component, Tissue and Organ, defined \
+with reference to the Common Anatomy Reference Ontology.
+"""
+
+_HOMEPAGE = "http://nactem.ac.uk/anatomytagger/#AnatEM"
+
+_LICENSE = 'Creative Commons Attribution Share Alike 3.0 Unported'
+
+_URLS = {_DATASETNAME: "http://nactem.ac.uk/anatomytagger/AnatEM-1.0.2.tar.gz"}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.0.2"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class AnatEMDataset(datasets.GeneratorBasedBuilder):
+    """The extended Anatomical Entity Mention corpus (AnatEM)"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="anat_em_source",
+            version=SOURCE_VERSION,
+            description="AnatEM source schema",
+            schema="source",
+            subset_id="anat_em",
+        ),
+        BigBioConfig(
+            name="anat_em_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="AnatEM BigBio schema",
+            schema="bigbio_kb",
+            subset_id="anat_em",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "anat_em_source"
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "document_type": datasets.Value("string"),  # Either PMC or PM
+                    "text": datasets.Value("string"),
+                    "text_type": datasets.Value(
+                        "string"
+                    ),  # Either abstract (for PM) or sec / caption (for PMC)
+                    "entities": [
+                        {
+                            "entity_id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        urls = _URLS[_DATASETNAME]
+        data_dir = Path(dl_manager.download_and_extract(urls))
+
+        standoff_dir = data_dir / "AnatEM-1.0.2" / "standoff"
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"split_dir": standoff_dir / "train"},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"split_dir": standoff_dir / "test"},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"split_dir": standoff_dir / "devel"},
+            ),
+        ]
+
+    def _generate_examples(self, split_dir: Path) -> Iterator[Tuple[str, Dict]]:
+        if self.config.name == "anat_em_source":
+            for file in split_dir.iterdir():
+                # Ignore hidden files and annotation files - we just consider the brat text files
+                if file.name.startswith("._") or file.name.endswith(".ann"):
+                    continue
+
+                # Read brat annotations for the given text file and convert example to the source format
+                brat_example = parsing.parse_brat_file(file)
+                source_example = self._to_source_example(file, brat_example)
+
+                yield source_example["document_id"], source_example
+
+        elif self.config.name == "anat_em_bigbio_kb":
+            for file in split_dir.iterdir():
+                # Ignore hidden files and annotation files - we just consider the brat text files
+                if file.name.startswith("._") or file.name.endswith(".ann"):
+                    continue
+
+                # Read brat annotations for the given text file and convert example to the BigBio-KB format
+                brat_example = parsing.parse_brat_file(file)
+                kb_example = parsing.brat_parse_to_bigbio_kb(brat_example)
+                kb_example["id"] = kb_example["document_id"]
+
+                # Fix text type annotation for the converted example
+                _, text_type = self.get_document_type_and_text_type(file)
+                kb_example["passages"][0]["type"] = text_type
+
+                yield kb_example["id"], kb_example
+
+    def _to_source_example(self, input_file: Path, brat_example: Dict) -> Dict:
+        """
+        Converts an example extracted using the default brat parsing logic to the source format
+        of the given corpus.
+        """
+        document_type, text_type = self.get_document_type_and_text_type(input_file)
+
+        source_example = {
+            "document_id": brat_example["document_id"],
+            "document_type": document_type,
+            "text": brat_example["text"],
+            "text_type": text_type,
+        }
+
+        id_prefix = brat_example["document_id"] + "_"
+
+        source_example["entities"] = []
+        for entity_annotation in brat_example["text_bound_annotations"]:
+            entity_ann = entity_annotation.copy()
+
+            entity_ann["entity_id"] = id_prefix + entity_ann["id"]
+            entity_ann.pop("id")
+
+            source_example["entities"].append(entity_ann)
+
+        return source_example
+
+    def get_document_type_and_text_type(self, input_file: Path) -> Tuple[str, str]:
+        """
+        Extracts the document type (PubMed(PM) or PubMedCentral (PMC)) and the respective
+        text type (abstract for PM and sec or caption for (PMC) from the name of the given
+        file, e.g.:
+
+        PMID-9778569.txt -> ("PM", "abstract")
+
+        PMC-1274342-sec-02.txt -> ("PMC", "sec")
+
+        PMC-1592597-caption-02.ann -> ("PMC", "caption")
+
+        """
+        name_parts = str(input_file.stem).split("-")
+
+        if name_parts[0] == "PMID":
+            return "PM", "abstract"
+
+        elif name_parts[0] == "PMC":
+            return "PMC", name_parts[2]
+        else:
+            raise AssertionError(f"Unexpected file prefix {name_parts[0]}")

--- a/hub/hubscripts/ask_a_patient_hub.py
+++ b/hub/hubscripts/ask_a_patient_hub.py
@@ -1,0 +1,170 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import glob
+import os
+import re
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "ask_a_patient"
+_DISPLAYNAME = "AskAPatient"
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """
+@inproceedings{limsopatham-collier-2016-normalising,
+    title = "Normalising Medical Concepts in Social Media Texts by Learning Semantic Representation",
+    author = "Limsopatham, Nut  and
+      Collier, Nigel",
+    booktitle = "Proceedings of the 54th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
+    month = aug,
+    year = "2016",
+    address = "Berlin, Germany",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/P16-1096",
+    doi = "10.18653/v1/P16-1096",
+    pages = "1014--1023",
+}
+"""
+
+_DESCRIPTION = """
+The AskAPatient dataset contains medical concepts written on social media \
+mapped to how they are formally written in medical ontologies (SNOMED-CT and AMT).
+"""
+
+_HOMEPAGE = "https://zenodo.org/record/55013"
+
+_LICENSE = 'Creative Commons Attribution 4.0 International'
+
+_URLs = "https://zenodo.org/record/55013/files/datasets.zip"
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class AskAPatient(datasets.GeneratorBasedBuilder):
+    """AskAPatient: Dataset for Normalising Medical Concepts in Social Media Text."""
+
+    DEFAULT_CONFIG_NAME = "ask_a_patient_source"
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="ask_a_patient_source",
+            version=SOURCE_VERSION,
+            description="AskAPatient source schema",
+            schema="source",
+            subset_id="ask_a_patient",
+        ),
+        BigBioConfig(
+            name="ask_a_patient_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="AskAPatient simplified BigBio schema",
+            schema="bigbio_kb",
+            subset_id="ask_a_patient",
+        ),
+    ]
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "cui": datasets.Value("string"),
+                    "medical_concept": datasets.Value("string"),
+                    "social_media_text": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            supervised_keys=None,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        dl_dir = dl_manager.download_and_extract(_URLs)
+        dataset_dir = os.path.join(dl_dir, "datasets", "AskAPatient")
+        # dataset supports k-folds
+        splits = []
+        for split_name in [
+            datasets.Split.TRAIN,
+            datasets.Split.VALIDATION,
+            datasets.Split.TEST,
+        ]:
+            for fold_filepath in glob.glob(
+                os.path.join(dataset_dir, f"AskAPatient.fold-*.{split_name}.txt")
+            ):
+                fold_id = re.search("AskAPatient\.fold-(\d)\.", fold_filepath).group(1)
+                split_id = f"{split_name}_{fold_id}"
+                splits.append(
+                    datasets.SplitGenerator(
+                        name=split_id,
+                        gen_kwargs={"filepath": fold_filepath, "split_id": split_id},
+                    )
+                )
+        return splits
+
+    def _generate_examples(self, filepath, split_id):
+        with open(filepath, "r", encoding="latin-1") as f:
+            for i, line in enumerate(f):
+                id = f"{split_id}_{i}"
+                cui, medical_concept, social_media_text = line.strip().split("\t")
+                if self.config.schema == "source":
+                    yield id, {
+                        "cui": cui,
+                        "medical_concept": medical_concept,
+                        "social_media_text": social_media_text,
+                    }
+                elif self.config.schema == "bigbio_kb":
+                    text_type = "social_media_text"
+                    offset = (0, len(social_media_text))
+                    yield id, {
+                        "id": id,
+                        "document_id": id,
+                        "passages": [
+                            {
+                                "id": f"{id}_passage",
+                                "type": text_type,
+                                "text": [social_media_text],
+                                "offsets": [offset],
+                            }
+                        ],
+                        "entities": [
+                            {
+                                "id": f"{id}_entity",
+                                "type": text_type,
+                                "text": [social_media_text],
+                                "offsets": [offset],
+                                "normalized": [
+                                    {"db_name": "SNOMED-CT|AMT", "db_id": cui}
+                                ],
+                            }
+                        ],
+                        "events": [],
+                        "coreferences": [],
+                        "relations": [],
+                    }

--- a/hub/hubscripts/bc5cdr_hub.py
+++ b/hub/hubscripts/bc5cdr_hub.py
@@ -1,0 +1,371 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+To this end, we set up a challenge task through BioCreative V to automatically
+extract CDRs from the literature. More specifically, we designed two challenge
+tasks: disease named entity recognition (DNER) and chemical-induced disease
+(CID) relation extraction. To assist system development and assessment, we
+created a large annotated text corpus that consists of human annotations of
+all chemicals, diseases and their interactions in 1,500 PubMed articles.
+
+-- 'Overview of the BioCreative V Chemical Disease Relation (CDR) Task'
+"""
+import collections
+import itertools
+import os
+
+import datasets
+from bioc import biocxml
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{DBLP:journals/biodb/LiSJSWLDMWL16,
+  author    = {Jiao Li and
+               Yueping Sun and
+               Robin J. Johnson and
+               Daniela Sciaky and
+               Chih{-}Hsuan Wei and
+               Robert Leaman and
+               Allan Peter Davis and
+               Carolyn J. Mattingly and
+               Thomas C. Wiegers and
+               Zhiyong Lu},
+  title     = {BioCreative {V} {CDR} task corpus: a resource for chemical disease
+               relation extraction},
+  journal   = {Database J. Biol. Databases Curation},
+  volume    = {2016},
+  year      = {2016},
+  url       = {https://doi.org/10.1093/database/baw068},
+  doi       = {10.1093/database/baw068},
+  timestamp = {Thu, 13 Aug 2020 12:41:41 +0200},
+  biburl    = {https://dblp.org/rec/journals/biodb/LiSJSWLDMWL16.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+"""
+
+_DATASETNAME = "bc5cdr"
+_DISPLAYNAME = "BC5CDR"
+
+_DESCRIPTION = """\
+The BioCreative V Chemical Disease Relation (CDR) dataset is a large annotated \
+text corpus of human annotations of all chemicals, diseases and their \
+interactions in 1,500 PubMed articles.
+"""
+
+_HOMEPAGE = "http://www.biocreative.org/tasks/biocreative-v/track-3-cdr/"
+
+_LICENSE = 'Public Domain Mark 1.0'
+
+_URLs = {
+    "source": "http://www.biocreative.org/media/store/files/2016/CDR_Data.zip",
+    "bigbio_kb": "http://www.biocreative.org/media/store/files/2016/CDR_Data.zip",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.NAMED_ENTITY_DISAMBIGUATION,
+    Tasks.RELATION_EXTRACTION,
+]
+_SOURCE_VERSION = "01.05.16"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class Bc5cdrDataset(datasets.GeneratorBasedBuilder):
+    """
+    BioCreative V Chemical Disease Relation (CDR) Task.
+    """
+
+    DEFAULT_CONFIG_NAME = "bc5cdr_source"
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="bc5cdr_source",
+            version=SOURCE_VERSION,
+            description="BC5CDR source schema",
+            schema="source",
+            subset_id="bc5cdr",
+        ),
+        BigBioConfig(
+            name="bc5cdr_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="BC5CDR simplified BigBio schema",
+            schema="bigbio_kb",
+            subset_id="bc5cdr",
+        ),
+    ]
+
+    def _info(self):
+
+        if self.config.schema == "source":
+            # this is a variation on the BioC format
+            features = datasets.Features(
+                {
+                    "passages": [
+                        {
+                            "document_id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                            "entities": [
+                                {
+                                    "id": datasets.Value("string"),
+                                    "offsets": [[datasets.Value("int32")]],
+                                    "text": [datasets.Value("string")],
+                                    "type": datasets.Value("string"),
+                                    "normalized": [
+                                        {
+                                            "db_name": datasets.Value("string"),
+                                            "db_id": datasets.Value("string"),
+                                        }
+                                    ],
+                                }
+                            ],
+                            "relations": [
+                                {
+                                    "id": datasets.Value("string"),
+                                    "type": datasets.Value("string"),
+                                    "arg1_id": datasets.Value("string"),
+                                    "arg2_id": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ]
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            supervised_keys=None,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+        my_urls = _URLs[self.config.schema]
+        data_dir = dl_manager.download_and_extract(my_urls)
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # These kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "CDR_Data/CDR.Corpus.v010516/CDR_TrainingSet.BioC.xml"
+                    ),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                # These kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "CDR_Data/CDR.Corpus.v010516/CDR_TestSet.BioC.xml"
+                    ),
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                # These kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir,
+                        "CDR_Data/CDR.Corpus.v010516/CDR_DevelopmentSet.BioC.xml",
+                    ),
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _get_bioc_entity(self, span, doc_text, db_id_key="MESH"):
+        """Parse BioC entity annotation.
+
+        Parameters
+        ----------
+        span : BioCAnnotation
+            BioC entity annotation
+        doc_text : string
+            document text, required to construct text spans
+        db_id_key : str, optional
+            database name used for normalization, by default "MESH"
+
+        Returns
+        -------
+        dict
+            entity information
+        """
+        # offsets = [(loc.offset, loc.offset + loc.length) for loc in span.locations]
+        # texts = [doc_text[i:j] for i, j in offsets]
+        offsets, texts = get_texts_and_offsets_from_bioc_ann(span)
+        db_ids = span.infons[db_id_key] if db_id_key else "-1"
+
+        # some entities are not linked and
+        # some entities are linked to multiple normalized ids
+        if db_ids == "-1":
+            db_ids_list = []
+        else:
+            db_ids_list = db_ids.split("|")
+
+        normalized = [{"db_name": db_id_key, "db_id": db_id} for db_id in db_ids_list]
+
+        return {
+            "id": span.id,
+            "offsets": offsets,
+            "text": texts,
+            "type": span.infons["type"],
+            "normalized": normalized,
+        }
+
+    def _get_relations(self, relations, entities):
+        """
+        BC5CDR provides abstract-level annotations for entity-linked relation
+        pairs rather than materializing links between all surface form
+        mentions of relations. An example from train id=2670794, the relation
+            - (chemical, disease) (D014148, D004211)
+        is materialized as 6 mentions of entity pairs
+            - 2x ('tranexamic acid', 'intravascular coagulation')
+            - 4x ('AMCA', 'intravascular coagulation')
+        """
+        # index entities by normalized id
+        index = collections.defaultdict(list)
+        for ent in entities:
+            for norm in ent["normalized"]:
+                index[norm["db_id"]].append(ent)
+        index = dict(index)
+
+        # transform doc-level relations to mention-level
+        rela_mentions = []
+        for rela in relations:
+            arg1 = rela.infons["Chemical"]
+            arg2 = rela.infons["Disease"]
+            # all mention pairs
+            all_pairs = itertools.product(index[arg1], index[arg2])
+            for a, b in all_pairs:
+                # create relations linked by entity ids
+                rela_mentions.append(
+                    {
+                        "id": None,
+                        "type": rela.infons["relation"],
+                        "arg1_id": a["id"],
+                        "arg2_id": b["id"],
+                        "normalized": [],
+                    }
+                )
+        return rela_mentions
+
+    def _get_document_text(self, xdoc):
+        """Build document text for unit testing entity span offsets."""
+        text = ""
+        for passage in xdoc.passages:
+            pad = passage.offset - len(text)
+            text += (" " * pad) + passage.text
+        return text
+
+    def _generate_examples(
+        self,
+        filepath,
+        split,  # method parameters are unpacked from `gen_kwargs` as given in `_split_generators`
+    ):
+        """Yields examples as (key, example) tuples."""
+        if self.config.schema == "source":
+            reader = biocxml.BioCXMLDocumentReader(str(filepath))
+
+            for uid, xdoc in enumerate(reader):
+                doc_text = self._get_document_text(xdoc)
+                yield uid, {
+                    "passages": [
+                        {
+                            "document_id": xdoc.id,
+                            "type": passage.infons["type"],
+                            "text": passage.text,
+                            "entities": [
+                                self._get_bioc_entity(span, doc_text)
+                                for span in passage.annotations
+                            ],
+                            "relations": [
+                                {
+                                    "id": rel.id,
+                                    "type": rel.infons["relation"],
+                                    "arg1_id": rel.infons["Chemical"],
+                                    "arg2_id": rel.infons["Disease"],
+                                }
+                                for rel in xdoc.relations
+                            ],
+                        }
+                        for passage in xdoc.passages
+                    ]
+                }
+
+        elif self.config.schema == "bigbio_kb":
+            reader = biocxml.BioCXMLDocumentReader(str(filepath))
+            uid = 0  # global unique id
+
+            for i, xdoc in enumerate(reader):
+                data = {
+                    "id": uid,
+                    "document_id": xdoc.id,
+                    "passages": [],
+                    "entities": [],
+                    "relations": [],
+                    "events": [],
+                    "coreferences": [],
+                }
+                uid += 1
+                doc_text = self._get_document_text(xdoc)
+
+                char_start = 0
+                # passages must not overlap and spans must cover the entire document
+                for passage in xdoc.passages:
+                    offsets = [[char_start, char_start + len(passage.text)]]
+                    char_start = char_start + len(passage.text) + 1
+                    data["passages"].append(
+                        {
+                            "id": uid,
+                            "type": passage.infons["type"],
+                            "text": [passage.text],
+                            "offsets": offsets,
+                        }
+                    )
+                    uid += 1
+
+                # entities
+                for passage in xdoc.passages:
+                    for span in passage.annotations:
+                        ent = self._get_bioc_entity(span, doc_text, db_id_key="MESH")
+                        ent["id"] = uid  # override BioC default id
+                        data["entities"].append(ent)
+                        uid += 1
+
+                # relations
+                relations = self._get_relations(xdoc.relations, data["entities"])
+                for rela in relations:
+                    rela["id"] = uid  # assign unique id
+                    data["relations"].append(rela)
+                    uid += 1
+
+                yield i, data

--- a/hub/hubscripts/bc7_litcovid_hub.py
+++ b/hub/hubscripts/bc7_litcovid_hub.py
@@ -1,0 +1,215 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import text_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{chen2021overview,
+  title        = {
+    Overview of the BioCreative VII LitCovid Track: multi-label topic
+    classification for COVID-19 literature annotation
+  },
+  author       = {
+    Chen, Qingyu and Allot, Alexis and Leaman, Robert and Do{\\u{g}}an, Rezarta
+    Islamaj and Lu, Zhiyong
+  },
+  year         = 2021,
+  booktitle    = {Proceedings of the seventh BioCreative challenge evaluation workshop}
+}
+
+"""
+
+_DATASETNAME = "bc7_litcovid"
+_DISPLAYNAME = "BC7-LitCovid"
+
+_DESCRIPTION = """\
+The training and development datasets contain the publicly-available \
+text of over 30 thousand COVID-19-related articles and their metadata \
+(e.g., title, abstract, journal). Articles in both datasets have been \
+manually reviewed and articles annotated by in-house models.
+"""
+
+_HOMEPAGE = "https://biocreative.bioinformatics.udel.edu/tasks/biocreative-vii/track-5/"
+
+_LICENSE = 'License information unavailable'
+
+_BASE = "https://ftp.ncbi.nlm.nih.gov/pub/lu/LitCovid/biocreative/BC7-LitCovid-"
+
+_URLS = {
+    _DATASETNAME: {
+        "train": _BASE + "Train.csv",
+        "validation": _BASE + "Dev.csv",
+        "test": _BASE + "Test-GS.csv",
+    },
+}
+
+_SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+_CLASS_NAMES = [
+    "Epidemic Forecasting",
+    "Treatment",
+    "Prevention",
+    "Mechanism",
+    "Case Report",
+    "Transmission",
+    "Diagnosis",
+]
+
+
+class BC7LitCovidDataset(datasets.GeneratorBasedBuilder):
+    """
+    Track 5 - LitCovid track Multi-label topic classification for
+    COVID-19 literature annotation
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="bc7_litcovid_source",
+            version=SOURCE_VERSION,
+            description="bc7_litcovid source schema",
+            schema="source",
+            subset_id="bc7_litcovid",
+        ),
+        BigBioConfig(
+            name="bc7_litcovid_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="bc7_litcovid BigBio schema",
+            schema="bigbio_text",
+            subset_id="bc7_litcovid",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "bc7_litcovid_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+
+            features = datasets.Features(
+                {
+                    "pmid": datasets.Value("string"),
+                    "journal": datasets.Value("string"),
+                    "title": datasets.Value("string"),
+                    "abstract": datasets.Value("string"),
+                    "keywords": datasets.Sequence(datasets.Value("string")),
+                    "pub_type": datasets.Sequence(datasets.Value("string")),
+                    "authors": datasets.Sequence(datasets.Value("string")),
+                    "doi": datasets.Value("string"),
+                    "labels": datasets.Sequence(
+                        datasets.ClassLabel(names=_CLASS_NAMES)
+                    ),
+                }
+            )
+
+        elif self.config.schema == "bigbio_text":
+            features = text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        # Download all the CSV
+        urls = _URLS[_DATASETNAME]
+        path_train = dl_manager.download(urls["train"])
+        path_validation = dl_manager.download(urls["validation"])
+        path_test = dl_manager.download(urls["test"])
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": path_train,
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": path_validation,
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": path_test,
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        idx = 0
+
+        # Load the CSV and convert it to the string format
+        df = pd.read_csv(filepath, sep=",").astype(str).replace({"nan": None})
+
+        for index, e in df.iterrows():
+
+            if self.config.schema == "source":
+
+                yield idx, {
+                    "pmid": e["pmid"],
+                    "journal": e["journal"],
+                    "title": e["title"],
+                    "abstract": e["abstract"],
+                    "keywords": e["keywords"].split(";")
+                    if e["keywords"] is not None
+                    else [],
+                    "pub_type": e["pub_type"].split(";")
+                    if e["pub_type"] is not None
+                    else [],
+                    "authors": e["authors"].split(";")
+                    if e["authors"] is not None
+                    else [],
+                    "doi": e["doi"],
+                    "labels": e["label"].split(";"),
+                }
+
+            elif self.config.schema == "bigbio_text":
+
+                yield idx, {
+                    "id": idx,
+                    "document_id": e["pmid"],
+                    "text": e["abstract"],
+                    "labels": e["label"].split(";"),
+                }
+
+            idx += 1

--- a/hub/hubscripts/bio_sim_verb_hub.py
+++ b/hub/hubscripts/bio_sim_verb_hub.py
@@ -1,0 +1,169 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This repository contains the evaluation datasets for the paper Bio-SimVerb and
+Bio-SimLex: Wide-coverage Evaluation Sets of Word Similarity in Biomedicine by
+Billy Chiu, Sampo Pyysalo and Anna Korhonen.
+"""
+
+import csv
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import pairs_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+# TODO: Add BibTeX citation
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{article,
+  title        = {
+    Bio-SimVerb and Bio-SimLex: Wide-coverage evaluation sets of word
+    similarity in biomedicine
+  },
+  author       = {Chiu, Billy and Pyysalo, Sampo and Vulić, Ivan and Korhonen, Anna},
+  year         = 2018,
+  month        = {02},
+  journal      = {BMC Bioinformatics},
+  volume       = 19,
+  pages        = {},
+  doi          = {10.1186/s12859-018-2039-z}
+}
+"""
+
+_DATASETNAME = "bio_sim_verb"
+_DISPLAYNAME = "Bio-SimVerb"
+
+_DESCRIPTION = """
+This repository contains the evaluation datasets for the paper Bio-SimVerb and \
+Bio-SimLex: Wide-coverage Evaluation Sets of Word Similarity in Biomedicine by \
+Billy Chiu, Sampo Pyysalo and Anna Korhonen.
+"""
+
+_HOMEPAGE = "https://github.com/cambridgeltl/bio-simverb"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: "https://raw.githubusercontent.com/cambridgeltl/bio-simverb/master/wvlib/word-similarities/bio-simverb/Bio-SimVerb.txt",
+}
+
+_SUPPORTED_TASKS = [Tasks.SEMANTIC_SIMILARITY]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+# TODO: Name the dataset class to match the script name using CamelCase instead of snake_case
+#  Append "Dataset" to the class name: BioASQ --> BioasqDataset
+class BioSimVerb(datasets.GeneratorBasedBuilder):
+    """Evaluation of word similarity in biomedical texts."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="bio_sim_verb_source",
+            version=SOURCE_VERSION,
+            description="bio_sim_verb source schema",
+            schema="source",
+            subset_id="bio_sim_verb",
+        ),
+        BigBioConfig(
+            name="bio_sim_verb_bigbio_pairs",
+            version=BIGBIO_VERSION,
+            description="bio_sim_verb BigBio schema",
+            schema="bigbio_pairs",
+            subset_id="bio_sim_verb",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "bio_sim_verb_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "text_1": datasets.Value("string"),
+                    "text_2": datasets.Value("string"),
+                    "label": datasets.Value("float32"),
+                }
+            )
+
+        # Using in pairs schema
+        elif self.config.schema == "bigbio_pairs":
+            features = pairs_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={"filepath": data_dir, "split": "train"},
+            )
+        ]
+
+    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        with open(filepath, encoding="utf-8") as csv_file:
+            csv_reader = csv.reader(
+                csv_file,
+                quotechar='"',
+                delimiter="\t",
+                quoting=csv.QUOTE_ALL,
+                skipinitialspace=True,
+            )
+
+            if self.config.schema == "source":
+                for id_, row in enumerate(csv_reader):
+                    text_1, text_2, label = row
+                    yield id_, {
+                        "text_1": text_1,
+                        "text_2": text_2,
+                        "label": float(label),
+                    }
+
+            elif self.config.schema == "bigbio_pairs":
+                uid = 0
+                for id_, row in enumerate(csv_reader):
+                    uid += 1
+                    text_1, text_2, label = row
+                    yield id_, {
+                        "id": str(uid),
+                        "document_id": "NULL",
+                        "text_1": text_1,
+                        "text_2": text_2,
+                        "label": str(label),
+                    }

--- a/hub/hubscripts/bio_simlex_hub.py
+++ b/hub/hubscripts/bio_simlex_hub.py
@@ -1,0 +1,163 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Bio-SimLex enables intrinsic evaluation of word representations. This evaluation
+can serve as a predictor of performance on various downstream tasks in the
+biomedical domain. The results on Bio-SimLex using standard word representation
+models highlight the importance of developing dedicated evaluation resources for
+NLP in biomedicine for particular word classes (e.g. verbs).
+"""
+
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import pairs_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{article,
+  title        = {
+    Bio-SimVerb and Bio-SimLex: Wide-coverage evaluation sets of word
+    similarity in biomedicine
+  },
+  author       = {Chiu, Billy and Pyysalo, Sampo and Vulić, Ivan and Korhonen, Anna},
+  year         = 2018,
+  month        = {02},
+  journal      = {BMC Bioinformatics},
+  volume       = 19,
+  pages        = {},
+  doi          = {10.1186/s12859-018-2039-z}
+}
+"""
+
+_DATASETNAME = "bio_simlex"
+_DISPLAYNAME = "Bio-SimLex"
+
+_DESCRIPTION = """\
+Bio-SimLex enables intrinsic evaluation of word representations. This evaluation \
+can serve as a predictor of performance on various downstream tasks in the \
+biomedical domain. The results on Bio-SimLex using standard word representation \
+models highlight the importance of developing dedicated evaluation resources for \
+NLP in biomedicine for particular word classes (e.g. verbs).
+"""
+
+_HOMEPAGE = "https://github.com/cambridgeltl/bio-simverb"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: "https://github.com/cambridgeltl/bio-simverb/blob/master/wvlib/word-similarities/\
+bio-simlex/Bio-SimLex.txt?raw=true"
+}
+
+_SUPPORTED_TASKS = [Tasks.SEMANTIC_SIMILARITY]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class BioSimlexDataset(datasets.GeneratorBasedBuilder):
+    """
+    Bio-SimLex enables intrinsic evaluation of word representations. Config schema
+    as source gives score between 0-10 for pairs of words. The source schema casts
+    labels as `float`, but the bigbio schema casts them as `str`.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="bio_simlex_source",
+            version=SOURCE_VERSION,
+            description="bio_simlex source schema",
+            schema="source",
+            subset_id="bio_simlex",
+        ),
+        BigBioConfig(
+            name="bio_simlex_bigbio_pairs",
+            version=BIGBIO_VERSION,
+            description="bio_simlex BigBio schema",
+            schema="bigbio_pairs",
+            subset_id="bio_simlex",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "bio_simlex_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "text_1": datasets.Value("string"),
+                    "text_2": datasets.Value("string"),
+                    "score": datasets.Value("float32"),
+                }
+            )
+
+        elif self.config.schema == "bigbio_pairs":
+            features = pairs_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        url = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(url)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_dir,
+                    "split": "train",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        with open(filepath, "r", encoding="utf-8") as f:
+            for id_, line in enumerate(f):
+                word1, word2, score = line.split("\t")
+                if self.config.schema == "source":
+                    yield id_, {
+                        "text_1": word1,
+                        "text_2": word2,
+                        "score": float(score),
+                    }
+
+                elif self.config.schema == "bigbio_pairs":
+                    yield id_, {
+                        "id": str(id_),
+                        "document_id": str(id_),
+                        "text_1": word1,
+                        "text_2": word2,
+                        "label": str(score.strip()),
+                    }

--- a/hub/hubscripts/bioasq_2021_mesinesp_hub.py
+++ b/hub/hubscripts/bioasq_2021_mesinesp_hub.py
@@ -1,0 +1,315 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+The main aim of MESINESP2 is to promote the development of practically relevant
+semantic indexing tools for biomedical content in non-English language. We have
+generated a manually annotated corpus, where domain experts have labeled a set
+of scientific literature, clinical trials, and patent abstracts. All the
+documents were labeled with DeCS descriptors, which is a structured controlled
+vocabulary created by BIREME to index scientific publications on BvSalud, the
+largest database of scientific documents in Spanish, which hosts records from
+the databases LILACS, MEDLINE, IBECS, among others.
+
+MESINESP track at BioASQ9 explores the efficiency of systems for assigning DeCS
+to different types of biomedical documents. To that purpose, we have divided the
+task into three subtracks depending on the document type. Then, for each one we
+generated an annotated corpus which was provided to participating teams:
+
+- [Subtrack 1 corpus] MESINESP-L – Scientific Literature: It contains all
+  Spanish records from LILACS and IBECS databases at the Virtual Health Library
+  (VHL) with non-empty abstract written in Spanish.
+- [Subtrack 2 corpus] MESINESP-T- Clinical Trials contains records from Registro
+  Español de Estudios Clínicos (REEC). REEC doesn't provide documents with the
+  structure title/abstract needed in BioASQ, for that reason we have built
+  artificial abstracts based on the content available in the data crawled using
+  the REEC API.
+- [Subtrack 3 corpus] MESINESP-P – Patents: This corpus includes patents in
+  Spanish extracted from Google Patents which have the IPC code “A61P” and
+  “A61K31”. In addition, we also provide a set of complementary data such as:
+  the DeCS terminology file, a silver standard with the participants' predictions
+  to the task background set and the entities of medications, diseases, symptoms
+  and medical procedures extracted from the BSC NERs documents.
+"""
+
+import json
+import os
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import text.features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['Spanish']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@conference {396,
+    title = {Overview of BioASQ 2021-MESINESP track. Evaluation of
+    advance hierarchical classification techniques for scientific
+    literature, patents and clinical trials.},
+    booktitle = {Proceedings of the 9th BioASQ Workshop
+    A challenge on large-scale biomedical semantic indexing
+    and question answering},
+    year = {2021},
+    url = {http://ceur-ws.org/Vol-2936/paper-11.pdf},
+    author = {Gasco, Luis and Nentidis, Anastasios and Krithara, Anastasia
+     and Estrada-Zavala, Darryl and Toshiyuki Murasaki, Renato and Primo-Pe{\~n}a,
+     Elena and Bojo-Canales, Cristina and Paliouras, Georgios and Krallinger, Martin}
+}
+
+"""
+
+_DATASETNAME = "bioasq_2021_mesinesp"
+_DISPLAYNAME = "MESINESP 2021"
+
+_DESCRIPTION = """\
+The main aim of MESINESP2 is to promote the development of practically relevant \
+semantic indexing tools for biomedical content in non-English language. We have \
+generated a manually annotated corpus, where domain experts have labeled a set \
+of scientific literature, clinical trials, and patent abstracts. All the \
+documents were labeled with DeCS descriptors, which is a structured controlled \
+vocabulary created by BIREME to index scientific publications on BvSalud, the \
+largest database of scientific documents in Spanish, which hosts records from \
+the databases LILACS, MEDLINE, IBECS, among others.
+
+MESINESP track at BioASQ9 explores the efficiency of systems for assigning DeCS \
+to different types of biomedical documents. To that purpose, we have divided the \
+task into three subtracks depending on the document type. Then, for each one we \
+generated an annotated corpus which was provided to participating teams:
+
+- [Subtrack 1 corpus] MESINESP-L – Scientific Literature: It contains all \
+  Spanish records from LILACS and IBECS databases at the Virtual Health Library \
+  (VHL) with non-empty abstract written in Spanish.
+- [Subtrack 2 corpus] MESINESP-T- Clinical Trials contains records from Registro \
+  Español de Estudios Clínicos (REEC). REEC doesn't provide documents with the \
+  structure title/abstract needed in BioASQ, for that reason we have built \
+  artificial abstracts based on the content available in the data crawled using \
+  the REEC API.
+- [Subtrack 3 corpus] MESINESP-P – Patents: This corpus includes patents in \
+  Spanish extracted from Google Patents which have the IPC code “A61P” and \
+  “A61K31”. In addition, we also provide a set of complementary data such as: \
+  the DeCS terminology file, a silver standard with the participants' predictions \
+  to the task background set and the entities of medications, diseases, symptoms \
+  and medical procedures extracted from the BSC NERs documents.
+"""
+
+_HOMEPAGE = "https://zenodo.org/record/5602914#.YhSXJ5PMKWt"
+
+_LICENSE = 'Creative Commons Attribution 4.0 International'
+
+_URLS = {
+    _DATASETNAME: {
+        "subtrack1": "https://zenodo.org/record/5602914/files/Subtrack1-Scientific_Literature.zip?download=1",
+        "subtrack2": "https://zenodo.org/record/5602914/files/Subtrack2-Clinical_Trials.zip?download=1",
+        "subtrack3": "https://zenodo.org/record/5602914/files/Subtrack3-Patents.zip?download=1",
+    },
+}
+
+_SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
+
+_SOURCE_VERSION = "1.0.6"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class Bioasq2021MesinespDataset(datasets.GeneratorBasedBuilder):
+    """\
+    A dataset to promote the development of practically relevant
+    semantic indexing tools for biomedical content in non-English language.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="bioasq_2021_mesinesp_subtrack1_all_source",
+            version=SOURCE_VERSION,
+            description="bioasq_2021_mesinesp source schema subtrack1",
+            schema="source",
+            subset_id="bioasq_2021_mesinesp_subtrack1_all",
+        ),
+        BigBioConfig(
+            name="bioasq_2021_mesinesp_subtrack1_only_articles_source",
+            version=SOURCE_VERSION,
+            description="bioasq_2021_mesinesp source schema subtrack1",
+            schema="source",
+            subset_id="bioasq_2021_mesinesp_subtrack1_only_articles",
+        ),
+        BigBioConfig(
+            name="bioasq_2021_mesinesp_subtrack2_source",
+            version=SOURCE_VERSION,
+            description="bioasq_2021_mesinesp source schema subtrack2",
+            schema="source",
+            subset_id="bioasq_2021_mesinesp_subtrack2",
+        ),
+        BigBioConfig(
+            name="bioasq_2021_mesinesp_subtrack3_source",
+            version=SOURCE_VERSION,
+            description="bioasq_2021_mesinesp source schema subtrack3",
+            schema="source",
+            subset_id="bioasq_2021_mesinesp_subtrack3",
+        ),
+        BigBioConfig(
+            name="bioasq_2021_mesinesp_subtrack1_all_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="bioasq_2021_mesinesp BigBio schema subtrack1",
+            schema="bigbio_text",
+            subset_id="bioasq_2021_mesinesp_subtrack1_all",
+        ),
+        BigBioConfig(
+            name="bioasq_2021_mesinesp_subtrack1_only_articles_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="bioasq_2021_mesinesp BigBio schema subtrack1",
+            schema="bigbio_text",
+            subset_id="bioasq_2021_mesinesp_subtrack1_only_articles",
+        ),
+        BigBioConfig(
+            name="bioasq_2021_mesinesp_subtrack2_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="bioasq_2021_mesinesp BigBio schema subtrack2",
+            schema="bigbio_text",
+            subset_id="bioasq_2021_mesinesp_subtrack2",
+        ),
+        BigBioConfig(
+            name="bioasq_2021_mesinesp_subtrack3_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="bioasq_2021_mesinesp BigBio schema subtrack3",
+            schema="bigbio_text",
+            subset_id="bioasq_2021_mesinesp_subtrack3",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "bioasq_2021_mesinesp_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "abstractText": datasets.Value("string"),
+                    "db": datasets.Value("string"),
+                    "decsCodes": datasets.Sequence(datasets.Value("string")),
+                    "id": datasets.Value("string"),
+                    "journal": datasets.Value("string"),
+                    "title": datasets.Value("string"),
+                    "year": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == "bigbio_text":
+            features = text.features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        if "subtrack1" in self.config.name:
+            track = "1"
+        elif "subtrack2" in self.config.name:
+            track = "2"
+        else:
+            track = "3"
+
+        urls = _URLS[_DATASETNAME][f"subtrack{track}"]
+        if self.config.data_dir is None:
+            try:
+                data_dir = dl_manager.download_and_extract(urls)
+            except ConnectionError:
+                raise ConnectionError(
+                    "Could not download. Save locally and use `data_dir` kwarg"
+                )
+        else:
+            data_dir = self.config.data_dir
+
+        if track == "1":
+            top_folder = "Subtrack1-Scientific_Literature"
+        elif track == "2":
+            top_folder = "Subtrack2-Clinical_Trials"
+        else:
+            top_folder = "Subtrack3-Patents"
+        if track == "1":
+            if "all" in self.config.name:
+                train_filepath = "training_set_subtrack1_all.json"
+            else:
+                train_filepath = "training_set_subtrack1_only_articles.json"
+        else:
+            train_filepath = f"training_set_subtrack{track}.json"
+
+        dev_filepath = f"development_set_subtrack{track}.json"
+        test_filepath = f"test_set_subtrack{track}.json"
+
+        split_gens = [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, top_folder, "Train", train_filepath
+                    ),
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, top_folder, "Development", dev_filepath
+                    ),
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, top_folder, "Test", test_filepath
+                    ),
+                },
+            ),
+        ]
+
+        # track 3 doesn't have Train data
+        if track == "3":
+            return split_gens[1:]
+
+        return split_gens
+
+    def _generate_examples(self, filepath) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        if self.config.schema == "source":
+
+            with open(filepath) as fp:
+                data = json.load(fp)
+
+            for key, example in enumerate(data["articles"]):
+                yield key, example
+
+        elif self.config.schema == "bigbio_text":
+            with open(filepath) as fp:
+                data = json.load(fp)
+
+            for key, example in enumerate(data["articles"]):
+                yield key, {
+                    "id": example["id"],
+                    "document_id": "NULL",
+                    "text": example["abstractText"],
+                    "labels": example["decsCodes"],
+                }

--- a/hub/hubscripts/bioasq_task_b_hub.py
+++ b/hub/hubscripts/bioasq_task_b_hub.py
@@ -1,0 +1,795 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+BioASQ Task B On Biomedical Semantic QA (Involves IR, QA, Summarization qnd
+More). This task uses benchmark datasets containing development and test
+questions, in English, along with gold standard (reference) answers constructed
+by a team of biomedical experts. The participants have to respond with relevant
+concepts, articles, snippets and RDF triples, from designated resources, as well
+as exact and 'ideal' answers.
+
+Fore more information about the challenge, the organisers and the relevant
+publications please visit: http://bioasq.org/
+"""
+import glob
+import json
+import os
+import re
+
+import datasets
+
+from .bigbiohub import qa_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = True
+_CITATION = """\
+@article{tsatsaronis2015overview,
+	title        = {
+		An overview of the BIOASQ large-scale biomedical semantic indexing and
+		question answering competition
+	},
+	author       = {
+		Tsatsaronis, George and Balikas, Georgios and Malakasiotis, Prodromos
+        and Partalas, Ioannis and Zschunke, Matthias and Alvers, Michael R and
+		Weissenborn, Dirk and Krithara, Anastasia and Petridis, Sergios and
+		Polychronopoulos, Dimitris and others
+	},
+	year         = 2015,
+	journal      = {BMC bioinformatics},
+	publisher    = {BioMed Central Ltd},
+	volume       = 16,
+	number       = 1,
+	pages        = 138
+}
+"""
+
+_DATASETNAME = "bioasq_task_b"
+_DISPLAYNAME = "BioASQ Task B"
+
+_BIOASQ_10B_DESCRIPTION = """\
+The data are intended to be used as training and development data for BioASQ
+10, which will take place during 2022. There is one file containing the data:
+ - training10b.json
+
+The file contains the data of the first nine editions of the challenge: 4234
+questions [1] with their relevant documents, snippets, concepts and RDF
+triples, exact and ideal answers.
+
+Differences with BioASQ-training9b.json
+- 492 new questions added from BioASQ9
+    - The question with id 56c1f01eef6e394741000046 had identical body with
+    602498cb1cb411341a00009e. All relevant elements from both questions
+    are available in the merged question with id 602498cb1cb411341a00009e.
+    - The question with id 5c7039207c78d69471000065 had identical body with
+    601c317a1cb411341a000014. All relevant elements from both questions
+    are available in the merged question with id 601c317a1cb411341a000014.
+	- The question with id 5e4b540b6d0a27794100001c had identical body with
+    602828b11cb411341a0000fc. All relevant elements from both questions
+    are available in the merged question with id 602828b11cb411341a0000fc.
+    - The question with id 5fdb42fba43ad31278000027 had identical body with
+    5d35eb01b3a638076300000f. All relevant elements from both questions
+    are available in the merged question with id 5d35eb01b3a638076300000f.
+    - The question with id 601d76311cb411341a000045 had identical body with
+    6060732b94d57fd87900003d. All relevant elements from both questions
+    are available in the merged question with id 6060732b94d57fd87900003d.
+
+[1] 4234 questions : 1252 factoid, 1148 yesno, 1018 summary, 816 list
+"""
+
+_BIOASQ_9B_DESCRIPTION = """\
+The data are intended to be used as training and development data for BioASQ 9,
+which will take place during 2021. There is one file containing the data:
+ - training9b.json
+
+The file contains the data of the first seven editions of the challenge: 3742
+questions [1] with their relevant documents, snippets, concepts and RDF triples,
+exact and ideal answers.
+
+Differences with BioASQ-training8b.json
+- 499 new questions added from BioASQ8
+    - The question with id 5e30e689fbd6abf43b00003a had identical body with
+    5880e417713cbdfd3d000001. All relevant elements from both questions
+    are available in the merged question with id 5880e417713cbdfd3d000001.
+
+[1] 3742 questions : 1091 factoid, 1033 yesno, 899 summary, 719 list
+"""
+
+_BIOASQ_8B_DESCRIPTION = """\
+The data are intended to be used as training and development data for BioASQ 8,
+which will take place during 2020. There is one file containing the data:
+ - training8b.json
+
+The file contains the data of the first seven editions of the challenge: 3243
+questions [1] with their relevant documents, snippets, concepts and RDF triples,
+exact and ideal answers.
+
+Differences with BioASQ-training7b.json
+- 500 new questions added from BioASQ7
+- 4 questions were removed
+    - The question with id 5717fb557de986d80d000009 had identical body with
+    571e06447de986d80d000016. All relevant elements from both questions
+    are available in the merged question with id 571e06447de986d80d000016.
+    - The question with id 5c589ddb86df2b917400000b had identical body with
+    5c6b7a9e7c78d69471000029. All relevant elements from both questions
+    are available in the merged question with id 5c6b7a9e7c78d69471000029.
+    - The question with id 52ffb5d12059c6d71c00007c had identical body with
+    52e7870a98d023950500001a. All relevant elements from both questions
+    are available in the merged question with id 52e7870a98d023950500001a.
+    - The question with id 53359338d6d3ac6a3400004f had identical body with
+    589a246878275d0c4a000030. All relevant elements from both questions
+    are available in the merged question with id 589a246878275d0c4a000030.
+
+**** UPDATE 25/02/2020 *****
+The previous version of the dataset contained an inconsistency on question with
+id "5c9904eaecadf2e73f00002e", where the "ideal_answer" field was missing.
+This has been fixed.
+"""
+
+_BIOASQ_7B_DESCRIPTION = """\
+The data are intended to be used as training and development data for BioASQ 7,
+which will take place during 2019. There is one file containing the data:
+ - BioASQ-trainingDataset7b.json
+
+The file contains the data of the first six editions of the challenge: 2747
+questions [1] with their relevant documents, snippets, concepts and RDF triples,
+exact and ideal answers.
+
+Differences with BioASQ-trainingDataset6b.json
+- 500 new questions added from BioASQ6
+    - 4 questions were removed
+        - The question with id 569ed752ceceede94d000004 had identical body with
+        a new question from BioASQ6. All relevant elements from both questions
+        are available in the merged question with id 5abd31e0fcf456587200002c
+        - 3 questions were removed as incomplete: 54d643023706e89528000007,
+        532819afd6d3ac6a3400000f, 517545168ed59a060a00002b
+    - 4 questions were revised for various confusions that have been identified
+        - In 2 questions the ideal answer has been revised :
+        51406e6223fec90375000009, 5172f8118ed59a060a000019
+        - In 4 questions the snippets and documents list has been revised :
+        51406e6223fec90375000009, 5172f8118ed59a060a000019,
+        51593dc8d24251bc05000099, 5158a5b8d24251bc05000097
+        - In 198 questions the documents list has updated with missing
+        documents from the relevant snippets list. [2]
+
+[1] 2747 questions : 779 factoid, 745 yesno, 667 summary, 556 list
+[2] 55031181e9bde69634000014, 51406e6223fec90375000009, 54d643023706e89528000007,
+    52bf1b0a03868f1b06000009, 52bf19c503868f1b06000001, 51593dc8d24251bc05000099,
+    530a5117970c65fa6b000007, 553a8d78f321868558000003, 531a3fe3b166e2b806000038,
+    532819afd6d3ac6a3400000f, 5158a5b8d24251bc05000097, 553653a5bc4f83e828000007,
+    535d2cf09a4572de6f000004, 53386282d6d3ac6a3400005a, 517a8ce98ed59a060a000045,
+    55391ce8bc4f83e828000018, 5547d700f35db75526000007, 5713bf261174fb1755000011,
+    6f15c5a2ac5ed1459000012, 52b2e498f828ad283c000010, 570a7594cf1c325851000026,
+    530cefaaad0bf1360c000012, 530f685c329f5fcf1e000002, 550c4011a103b78016000009,
+    552faababc4f83e828000005, 54cf48acf693c3b16b00000b, 550313aae9bde6963400001f,
+    551177626a8cde6b72000005, 54eded8c94afd6150400000c, 550c3754a103b78016000007,
+    56f555b609dd18d46b000007, 54c26e29f693c3b16b000003, 54da0c524b1fd0d33c00000b,
+    52bf1d3c03868f1b0600000d, 5343bdd6aeec6fbd07000001, 52cb9b9b03868f1b0600002d,
+    55423875ec76f5e50c000002, 571366ba1174fb1755000005, 56c4d14ab04e159d0e000003,
+    550c44d1a103b7801600000a, 5547a01cf35db75526000005, 55422640ccca0ce74b000004,
+    54ecb66d445c3b5a5f000002, 553656c4bc4f83e828000009, 5172f8118ed59a060a000019,
+    513711055274a5fb0700000e, 54d892ee014675820d000005, 52e6c92598d0239505000019,
+    5353aedb288f4dae47000006, 52bf1f1303868f1b06000014, 5519113b622b19434500000f,
+    52b2f1724003448f5500000b, 5525317687ecba3764000007, 554a0cadf35db7552600000f,
+    55152bd246478f2f2c000002, 516c3960298dcd4e51000073, 571e417bbb137a4b0c00000a,
+    551910d3622b194345000008, 54dc8ed6c0bb8dce23000002, 511a4ec01159fa8212000004,
+    54d8ea2c4b1fd0d33c000002, 5148e1d6d24251bc0500003a, 515dbb3b298dcd4e51000018,
+    56f7c15a09dd18d46b000012, 51475d5cd24251bc0500001b, 54db7c4ac0bb8dce23000001,
+    57152ebbcb4ef8864c000002, 57134d511174fb1755000002, 55149f156a8cde6b72000013,
+    56bcd422d36b5da378000005, 54ede5c394afd61504000006, 517545168ed59a060a00002b,
+    5710ed19a5ed216440000003, 53442472aeec6fbd07000008, 55088e412e93f0133a000001,
+    54d762653706e89528000014, 550aef0ec2af5d5b7000000a, 552435602c8b63434a000009,
+    552446612c8b63434a00000c, 54d901ec4b1fd0d33c000006, 54cf45e7f693c3b16b00000a,
+    52fc8b772059c6d71c00006e, 5314d05adae131f84700000d, 5512c91b6a8cde6b7200000b,
+    56c5a7605795f9a73e000002, 55030a6ce9bde6963400000f, 553fac39c6a5098552000001,
+    531a3a58b166e2b806000037, 5509bd6a1180f13250000002, 54f9c40ddd3fc62544000001,
+    553c8fd1f32186855800000a, 56bce51cd36b5da37800000a, 550316a6e9bde69634000029,
+    55031286e9bde6963400001b, 536e46f27d100faa09000012, 5502abd1e9bde69634000008,
+    551af9106b348bb82c000002, 54edeb4394afd6150400000b, 5717cdd2070aa3d072000001,
+    56c5ade15795f9a73e000003, 531464a6e3eabad021000014, 58a0d87a78275d0c4a000053,
+    58a3160d60087bc10a00000a, 58a5d54860087bc10a000025, 58a0da5278275d0c4a000054,
+    58a3264e60087bc10a00000d, 589c8ef878275d0c4a000042, 58a3428d60087bc10a00001b,
+    58a3196360087bc10a00000b, 58a341eb60087bc10a000018, 58a3275960087bc10a00000f,
+    58a342e760087bc10a00001c, 58bd645702b8c60953000010, 58bc8e5002b8c60953000006,
+    58bc8e7a02b8c60953000007, 58a1da4e78275d0c4a000059, 58bcb83d02b8c6095300000f,
+    58bc9a5002b8c60953000008, 589dee3778275d0c4a000050, 58a32efe60087bc10a000013,
+    58a327bf60087bc10a000011, 58bca08702b8c6095300000a, 58bc9dbb02b8c60953000009,
+    58c99fcc02b8c60953000029, 58bca2f302b8c6095300000c, 58cbf1f402b8c60953000036,
+    58cdb41302b8c60953000042, 58cdb80302b8c60953000043, 58cdbaf302b8c60953000044,
+    58cb305c02b8c60953000032, 58caf86f02b8c60953000030, 58c1b2f702b8c6095300001e,
+    58bde18b02b8c60953000014, 58eb7898eda5a57672000006, 58caf88c02b8c60953000031,
+    58e11bf76fddd3e83e00000c, 58cdbbd102b8c60953000045, 58df779d6fddd3e83e000001,
+    58dbb4f08acda3452900001a, 58dbb8968acda3452900001b, 58add7699ef3c34033000009,
+    58dbbbf08acda3452900001d, 58dbba438acda3452900001c, 58dd2cb08acda34529000029,
+    58eb9542eda5a57672000007, 58f3ca5c70f9fc6f0f00000d, 58e9e7aa3e8b6dc87c00000d,
+    58e3d9ab3e8b6dc87c000002, 58eb4ce7eda5a57672000004, 58f3c8f470f9fc6f0f00000c,
+    58f3c62970f9fc6f0f00000b, 58adca6d9ef3c34033000007, 58f4b3ee70f9fc6f0f000013,
+    593ff22b70f9fc6f0f000023, 5a679875b750ff4455000004, 5a774585faa1ab7d2e000005,
+    5a6f7245b750ff4455000050, 5a787544faa1ab7d2e00000b, 5a74d9980384be9551000008,
+    5a6a02a3b750ff4455000021, 5a6e47b1b750ff4455000049, 5a87124561bb38fb24000001,
+    5a6e42f1b750ff4455000046, 5a8b1264fcd1d6a10c00001d, 5a981e66fcd1d6a10c00002f,
+    5a8718c861bb38fb24000008, 5a7615af83b0d9ea6600001f, 5a87140a61bb38fb24000003,
+    5a77072c9e632bc06600000a, 5a897601fcd1d6a10c000008, 5a871a6861bb38fb24000009,
+    5a74e9ad0384be955100000a, 5a79d25dfaa1ab7d2e00000f, 5a6900ebb750ff445500001d,
+    5a87145861bb38fb24000004, 5a871b8d61bb38fb2400000a, 5a897a06fcd1d6a10c00000b,
+    5a8dc6b4fcd1d6a10c000026, 5a8712af61bb38fb24000002, 5a8714e261bb38fb24000005,
+    5aa304f1d6d6b54f79000004, 5a981bcffcd1d6a10c00002d, 5aa3fa73d6d6b54f79000008,
+    5aa55b45d6d6b54f7900000d, 5a981dd0fcd1d6a10c00002e, 5a9700adfcd1d6a10c00002c,
+    5a9d8ffe1d1251d03b000022, 5a96c74cfcd1d6a10c000029, 5aa50086d6d6b54f7900000c,
+    5a95765bfcd1d6a10c000028, 5a96f40cfcd1d6a10c00002b, 5ab144fefcf4565872000012,
+    5aa67b4fd6d6b54f7900000f, 5abd5a62fcf4565872000031, 5abbe429fcf456587200001c,
+    5aaef38dfcf456587200000f, 5abce6acfcf4565872000022, 5aae6499fcf456587200000c
+"""
+
+_BIOASQ_6B_DESCRIPTION = """\
+The data are intended to be used as training and development data for BioASQ 6,
+which will take place during 2018. There is one file containing the data:
+ - BioASQ-trainingDataset6b.json
+
+Differences with BioASQ-trainingDataset5b.json
+- 500 new questions added from BioASQ5
+    - 48 pairs of questions with identical bodies have been merged into one
+    question having only one question-id, but all the documents, snippets,
+    concepts, RDF triples and answers of both questions of the pair.
+        - This normalization lead to the removal of 48 deprecated question
+        ids [2] from the dataset and to the update of the 48 remaining
+        questions [3].
+        - In cases where a pair of questions with identical bodies had some
+        inconsistency (e.g. different question type), the inconsistency has
+        been solved merging the pair manually consulting the BioASQ expert team.
+    - 12 questions were revised for various confusions that have been
+    identified
+        - In 8 questions the question type has been changed to better suit to
+        the question body. The change of type lead to corresponding changes
+        in exact answers existence and format : 54fc4e2e6ea36a810c000003,
+        530b01a6970c65fa6b000008, 530cf54dab4de4de0c000009,
+        531b2fc3b166e2b80600003c, 532819afd6d3ac6a3400000f,
+        532aad53d6d3ac6a34000010, 5710ade4cf1c32585100002c,
+        52f65f372059c6d71c000027
+		- In 6 questions the ideal answer has been revised :
+        532aad53d6d3ac6a34000010, 5710ade4cf1c32585100002c,
+        53147b52e3eabad021000015, 5147c8a6d24251bc05000027,
+        5509bd6a1180f13250000002, 58bbb71f22d3005309000016
+		- In 5 questions the exact answer has been revised :
+        5314bd7ddae131f847000006, 53130a77e3eabad02100000f,
+        53148a07dae131f847000002, 53147b52e3eabad021000015,
+        5147c8a6d24251bc05000027
+		- In 2 questions the question body has been revised :
+        52f65f372059c6d71c000027, 5503145ee9bde69634000022
+    - In lists of ideal answers, documents, snippets, concepts and RDF triples
+    any duplicate identical elements have been removed.
+    - Ideal answers in format of one string have been converted to a list with
+    one element for consistency with cases where more than one golden ideal
+    answers are available. (i.e. "ideal_ans1" converted to ["ideal_ans1"])
+    - For yesno questions: All exact answers have been normalized to "yes" or
+    "no" (replacing "Yes", "YES" and "No")
+    - For factoid questions: The format of the exact answer was normalized to a
+    list of strings for each question, representing a set of synonyms
+    answering the question (i.e. [`ans1`, `syn11`, ... ]).
+    - For list questions: The format of the exact answer was normalized to a
+    list of lists. Each internal list represents one element of the answer
+    as a set of synonyms
+    (i.e. [[`ans1`, `syn11`, `syn12`], [`ans2`], [`ans3`, `syn31`] ...]).
+    - Empty elements, e.g. empty lists of documents have been removed.
+
+[1] 2251 questions : 619 factoid, 616 yesno, 531 summary, 485 list
+[2] The 48 deprecated question ids are : 52f8b2902059c6d71c000053,
+    52f11bf22059c6d71c000005, 52f77edb2059c6d71c000028, 52ed795098d0239505000032,
+    56d1a9baab2fed4a47000002, 52f7d3472059c6d71c00002f, 52fbe2bf2059c6d71c00006c,
+    52ec961098d023950500002a, 52e8e98298d0239505000020, 56cae5125795f9a73e000024,
+    530cefaaad0bf1360c000007, 530cefaaad0bf1360c000005, 52d63b2803868f1b0600003a,
+    530cefaaad0bf1360c00000a, 516425ff298dcd4e51000051, 55191149622b194345000010,
+    52fa70142059c6d71c000056, 52f77f4d2059c6d71c00002a, 52efc016c8da89891000001a,
+    52efc001c8da898910000019, 52f896ae2059c6d71c000045, 52eceada98d023950500002d,
+    52efc05cc8da89891000001c, 515e078e298dcd4e51000031, 52fe54252059c6d71c000079,
+    514217a6d24251bc05000005, 52d1389303868f1b06000032, 530cf4d5e2bfff940c000003,
+    52fc946d2059c6d71c000071, 52e8e99e98d0239505000021, 52ef7786c8da898910000015,
+    52d8494698d0239505000007, 530cf51d5610acba0c000001, 52f637972059c6d71c000025,
+    52e9f99798d0239505000025, 515de572298dcd4e51000021, 52fe4ad52059c6d71c000077,
+    52f65bf02059c6d71c000026, 52e8e9d298d0239505000022, 52fa74052059c6d71c00005a,
+    52ffbddf2059c6d71c00007d, 56bc932aac7ad1001900001c, 56c02883ef6e394741000017,
+    52d2b75403868f1b06000035, 52f118aa2059c6d71c000003, 52e929eb98d0239505000023,
+    532c12f2d6d3ac6a3400001d, 52d8466298d0239505000006'
+[3] The 48 questions resulting from merging with their pair have the
+    following ids: 5149aafcd24251bc05000045, 515db020298dcd4e51000011,
+    515db54c298dcd4e51000016, 51680a49298dcd4e51000062, 52b06a68f828ad283c000005,
+    52bf1aa503868f1b06000006, 52bf1af803868f1b06000008, 52bf1d6003868f1b0600000e,
+    52cb9b9b03868f1b0600002d, 52d2818403868f1b06000033, 52df887498d023950500000c,
+    52e0c9a298d0239505000010, 52e203bc98d0239505000011, 52e62bae98d0239505000015,
+    52e6c92598d0239505000019, 52e7bbf698d023950500001d, 52ea605098d0239505000028,
+    52ece29f98d023950500002c, 52ecf2dd98d023950500002e, 52ef7754c8da898910000014,
+    52f112bb2059c6d71c000002, 52f65f372059c6d71c000027, 52f77f752059c6d71c00002b,
+    52f77f892059c6d71c00002c, 52f89ee42059c6d71c00004d, 52f89f4f2059c6d71c00004e,
+    52f89fba2059c6d71c00004f, 52f89fc62059c6d71c000050, 52f89fd32059c6d71c000051,
+    52fa6ac72059c6d71c000055, 52fa73c62059c6d71c000058, 52fa73e82059c6d71c000059,
+    52fa74252059c6d71c00005b, 52fc8b772059c6d71c00006e, 52fc94572059c6d71c000070,
+    52fc94ae2059c6d71c000073, 52fc94db2059c6d71c000074, 52fe52702059c6d71c000078,
+    52fe58f82059c6d71c00007a, 530cefaaad0bf1360c000008, 530cefaaad0bf1360c000010,
+    533ba218fd9a95ea0d000007, 534bb147aeec6fbd07000014, 55167dec46478f2f2c00000a,
+    56c04412ef6e39474100001b, 56c1f01eef6e394741000046, 56c81fd15795f9a73e00000c,
+    587d016ed673c3eb14000002
+"""
+
+_BIOASQ_5B_DESCRIPTION = """\
+The data are intended to be used as training and development data for BioASQ 5,
+which will take place during 2017. There is one file containing the data:
+ - BioASQ-trainingDataset5b.json
+
+The file contains the data of the first four editions of the challenge: 1799
+questions with their relevant documents, snippets, concepts and rdf triples,
+exact and ideal answers.
+"""
+
+_BIOASQ_4B_DESCRIPTION = """\
+The data are intended to be used as training and development data for BioASQ 4,
+which will take place during 2016. There is one file containing the data:
+ - BioASQ-trainingDataset4b.json
+
+The file contains the data of the first three editions of the challenge: 1307
+questions with their relevant documents, snippets, concepts and rdf triples,
+exact and ideal answers from the first two editions and 497 questions with
+similar annotations from the third editions of the challenge.
+"""
+
+_BIOASQ_3B_DESCRIPTION = """No README provided."""
+
+_BIOASQ_2B_DESCRIPTION = """No README provided."""
+
+_BIOASQ_BLURB_DESCRIPTION = """The BioASQ corpus contains multiple question
+answering tasks annotated by biomedical experts, including yes/no, factoid, list,
+and summary questions. Pertaining to our objective of comparing neural language
+models, we focus on the the yes/no questions (Task 7b), and leave the inclusion
+of other tasks to future work. Each question is paired with a reference text
+containing multiple sentences from a PubMed abstract and a yes/no answer. We use
+the official train/dev/test split of 670/75/140 questions.
+
+See 'Domain-Specific Language Model Pretraining for Biomedical
+Natural Language Processing' """
+
+_DESCRIPTION = {
+    "bioasq_10b": _BIOASQ_10B_DESCRIPTION,
+    "bioasq_9b": _BIOASQ_9B_DESCRIPTION,
+    "bioasq_8b": _BIOASQ_8B_DESCRIPTION,
+    "bioasq_7b": _BIOASQ_7B_DESCRIPTION,
+    "bioasq_6b": _BIOASQ_6B_DESCRIPTION,
+    "bioasq_5b": _BIOASQ_5B_DESCRIPTION,
+    "bioasq_4b": _BIOASQ_4B_DESCRIPTION,
+    "bioasq_3b": _BIOASQ_3B_DESCRIPTION,
+    "bioasq_2b": _BIOASQ_2B_DESCRIPTION,
+    "bioasq_blurb": _BIOASQ_BLURB_DESCRIPTION,
+}
+
+_HOMEPAGE = "http://participants-area.bioasq.org/datasets/"
+
+# Data access reqires registering with BioASQ.
+# See http://participants-area.bioasq.org/accounts/register/
+_LICENSE = 'National Library of Medicine Terms and Conditions'
+
+_URLs = {
+    "bioasq_10b": ["BioASQ-training10b.zip", None],
+    "bioasq_9b": ["BioASQ-training9b.zip", "Task9BGoldenEnriched.zip"],
+    "bioasq_8b": ["BioASQ-training8b.zip", "Task8BGoldenEnriched.zip"],
+    "bioasq_7b": ["BioASQ-training7b.zip", "Task7BGoldenEnriched.zip"],
+    "bioasq_6b": ["BioASQ-training6b.zip", "Task6BGoldenEnriched.zip"],
+    "bioasq_5b": ["BioASQ-training5b.zip", "Task5BGoldenEnriched.zip"],
+    "bioasq_4b": ["BioASQ-training4b.zip", "Task4BGoldenEnriched.zip"],
+    "bioasq_3b": ["BioASQ-trainingDataset3b.zip", "Task3BGoldenEnriched.zip"],
+    "bioasq_2b": ["BioASQ-trainingDataset2b.zip", "Task2BGoldenEnriched.zip"],
+    "bioasq_blurb": ["BioASQ-training7b.zip", "Task7BGoldenEnriched.zip"],
+}
+
+# BLURB train and dev contain all yesno questions from the offical training split
+# test is all yesno question from the official test split
+_BLURB_SPLITS = {
+    "dev": {
+        "5313b049e3eabad021000013",
+        "553a8d78f321868558000003",
+        "5158a5b8d24251bc05000097",
+        "571e3d42bb137a4b0c000007",
+        "5175b97a8ed59a060a00002f",
+        "56c9e9d15795f9a73e00001d",
+        "56d19ffaab2fed4a47000001",
+        "518ccac0310faafe0800000b",
+        "56f12ca92ac5ed145900000e",
+        "51680a49298dcd4e51000062",
+        "5339ed7bd6d3ac6a34000060",
+        "516e5f33298dcd4e5100007e",
+        "5327139ad6d3ac6a3400000d",
+        "54e12ae3ae9738404b000004",
+        "5321b8579b2d7acc7e000008",
+        "514a4679d24251bc0500005b",
+        "54c12fd1f693c3b16b000001",
+        "52df887498d023950500000c",
+        "52f20d802059c6d71c00000a",
+        "532f0c4ed6d3ac6a3400002e",
+        "52b2f3b74003448f5500000c",
+        "52b2f1724003448f5500000b",
+        "515d9a42298dcd4e5100000d",
+        "5159b990d24251bc050000a3",
+        "54e12c30ae9738404b000005",
+        "553a6a9fbc4f83e82800001c",
+        "5509ec41c2af5d5b70000006",
+        "56cae40b5795f9a73e000022",
+        "51680b0e298dcd4e51000065",
+        "515df89e298dcd4e5100002f",
+        "54f49e56d0d681a040000004",
+        "571e3e2abb137a4b0c000008",
+        "515debe7298dcd4e51000026",
+        "56f6ab7009dd18d46b00000d",
+        "53302bced6d3ac6a34000039",
+        "5322de919b2d7acc7e000012",
+        "5709f212cf1c325851000020",
+        "5502abd1e9bde69634000008",
+        "516c220e298dcd4e51000071",
+        "5894597e7d9090f353000004",
+        "5895ec5e7d9090f353000015",
+        "58bbb8ae22d3005309000018",
+        "58bc58c302b8c60953000001",
+        "58c276bc02b8c60953000020",
+        "58c0825502b8c6095300001b",
+        "58ab1f6c9ef3c34033000002",
+        "58adbe999ef3c34033000005",
+        "58df3e408acda3452900002d",
+        "58dfec676fddd3e83e000006",
+        "58d8d0cc8acda34529000008",
+        "58b67fae22d3005309000009",
+        "58dbbbf08acda3452900001d",
+        "58dbba438acda3452900001c",
+        "58dbbdac8acda3452900001e",
+        "58dcbb8c8acda34529000021",
+        "5a468785966455904c00000d",
+        "5a70de5199e2c3af26000005",
+        "5a67a550b750ff4455000009",
+        "5a679875b750ff4455000004",
+        "5a7a44b4faa1ab7d2e000010",
+        "5a67ade5b750ff445500000c",
+        "5a8881118cb19eca6b000006",
+        "5a67b48cb750ff4455000010",
+        "5a679be1b750ff4455000005",
+        "5a7340962dc08e987e000017",
+        "5a737e233b9d13c70800000d",
+        "5a8dc57ffcd1d6a10c000025",
+        "5a6d186db750ff4455000031",
+        "5a70d43b99e2c3af26000003",
+        "5a70ec6899e2c3af2600000c",
+        "5a9ac4161d1251d03b000010",
+        "5a733d2a2dc08e987e000015",
+        "5a74acd80384be9551000006",
+        "5aa6800ad6d6b54f79000011",
+        "5a9d9ab94e03427e73000003",
+    }
+}
+
+_SUPPORTED_TASKS = [Tasks.QUESTION_ANSWERING]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class BioasqTaskBDataset(datasets.GeneratorBasedBuilder):
+    """
+    BioASQ Task B On Biomedical Semantic QA.
+    Creates configs for BioASQ2 through BioASQ10.
+    """
+
+    DEFAULT_CONFIG_NAME = "bioasq_9b_source"
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    # BioASQ2 through BioASQ10
+    BUILDER_CONFIGS = []
+    for version in range(2, 11):
+        BUILDER_CONFIGS.append(
+            BigBioConfig(
+                name=f"bioasq_{version}b_source",
+                version=SOURCE_VERSION,
+                description=f"bioasq{version} Task B source schema",
+                schema="source",
+                subset_id=f"bioasq_{version}b",
+            )
+        )
+
+        BUILDER_CONFIGS.append(
+            BigBioConfig(
+                name=f"bioasq_{version}b_bigbio_qa",
+                version=BIGBIO_VERSION,
+                description=f"bioasq{version} Task B in simplified BigBio schema",
+                schema="bigbio_qa",
+                subset_id=f"bioasq_{version}b",
+            )
+        )
+
+    # BLURB Benchmark config https://microsoft.github.io/BLURB/
+    BUILDER_CONFIGS.append(
+        BigBioConfig(
+            name=f"bioasq_blurb_bigbio_qa",
+            version=BIGBIO_VERSION,
+            description=f"BLURB benchmark in simplified BigBio schema",
+            schema="bigbio_qa",
+            subset_id=f"bioasq_blurb",
+        )
+    )
+
+    def _info(self):
+
+        # BioASQ Task B source schema
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "type": datasets.Value("string"),
+                    "body": datasets.Value("string"),
+                    "documents": datasets.Sequence(datasets.Value("string")),
+                    "concepts": datasets.Sequence(datasets.Value("string")),
+                    "ideal_answer": datasets.Sequence(datasets.Value("string")),
+                    "exact_answer": datasets.Sequence(datasets.Value("string")),
+                    "triples": [
+                        {
+                            "p": datasets.Value("string"),
+                            "s": datasets.Value("string"),
+                            "o": datasets.Value("string"),
+                        }
+                    ],
+                    "snippets": [
+                        {
+                            "offsetInBeginSection": datasets.Value("int32"),
+                            "offsetInEndSection": datasets.Value("int32"),
+                            "text": datasets.Value("string"),
+                            "beginSection": datasets.Value("string"),
+                            "endSection": datasets.Value("string"),
+                            "document": datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+        # simplified schema for QA tasks
+        elif self.config.schema == "bigbio_qa":
+            features = qa_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION[self.config.subset_id],
+            features=features,
+            supervised_keys=None,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _dump_gold_json(self, data_dir):
+        """
+        BioASQ test data is split into multiple records {9B1_golden.json,...,9B5_golden.json}
+        We combine these files into a single test set file 9Bx_golden.json
+        """
+        # BLURB is based on version 7
+        version = (
+            re.search(r"bioasq_([0-9]+)b", self.config.subset_id).group(1)
+            if "blurb" not in self.config.name
+            else "7"
+        )
+        gold_fpath = os.path.join(
+            data_dir, f"Task{version}BGoldenEnriched/bx_golden.json"
+        )
+
+        if not os.path.exists(gold_fpath):
+            # combine all gold json files
+            filelist = glob.glob(os.path.join(data_dir, "*/*.json"))
+            data = {"questions": []}
+            for fname in sorted(filelist):
+                with open(fname, "rt", encoding="utf-8") as file:
+                    data["questions"].extend(json.load(file)["questions"])
+            # dump gold to json
+            with open(gold_fpath, "wt", encoding="utf-8") as file:
+                json.dump(data, file, indent=2)
+
+        return f"Task{version}BGoldenEnriched/bx_golden.json"
+
+    def _blurb_split_generator(self, train_dir, test_dir):
+        """
+        Create splits for BLURB Benchmark
+        """
+        gold_fpath = self._dump_gold_json(test_dir)
+
+        # create train/dev splits from yesno questions
+        train_fpath = os.path.join(train_dir, "blurb_bioasq_train.json")
+        dev_fpath = os.path.join(train_dir, "blurb_bioasq_dev.json")
+
+        blurb_splits = {
+            "train": {"questions": []},
+            "dev": {"questions": []},
+            "test": {"questions": []},
+        }
+
+        if not os.path.exists(train_fpath):
+            data_fpath = os.path.join(train_dir, "BioASQ-training7b/trainining7b.json")
+            with open(data_fpath, "rt", encoding="utf-8") as file:
+                data = json.load(file)
+
+            for record in data["questions"]:
+                if record["type"] != "yesno":
+                    continue
+                if record["id"] in _BLURB_SPLITS["dev"]:
+                    blurb_splits["dev"]["questions"].append(record)
+                else:
+                    blurb_splits["train"]["questions"].append(record)
+
+            with open(train_fpath, "wt", encoding="utf-8") as file:
+                json.dump(blurb_splits["train"], file, indent=2)
+
+            with open(dev_fpath, "wt", encoding="utf-8") as file:
+                json.dump(blurb_splits["dev"], file, indent=2)
+
+        # create test split from yesno questions
+        with open(os.path.join(test_dir, gold_fpath), "rt", encoding="utf-8") as file:
+            data = json.load(file)
+
+        for record in data["questions"]:
+            if record["type"] != "yesno":
+                continue
+            blurb_splits["test"]["questions"].append(record)
+
+        test_fpath = os.path.join(test_dir, "blurb_bioasq_test.json")
+        with open(test_fpath, "wt", encoding="utf-8") as file:
+            json.dump(blurb_splits["test"], file, indent=2)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": train_fpath,
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": dev_fpath,
+                    "split": "dev",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": test_fpath,
+                    "split": "test",
+                },
+            ),
+        ]
+
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
+
+        train_dir, test_dir = dl_manager.download_and_extract(
+            [
+                os.path.join(self.config.data_dir, _url)
+                for _url in _URLs[self.config.subset_id]
+            ]
+        )
+        # create gold dump and get path
+        gold_fpath = self._dump_gold_json(test_dir)
+
+        # older versions of bioasq have different folder formats
+        train_fpaths = {
+            "bioasq_2b": "BioASQ_2013_TaskB/BioASQ-trainingDataset2b.json",
+            "bioasq_3b": "BioASQ-trainingDataset3b.json",
+            "bioasq_4b": "BioASQ-training4b/BioASQ-trainingDataset4b.json",
+            "bioasq_5b": "BioASQ-training5b/BioASQ-trainingDataset5b.json",
+            "bioasq_6b": "BioASQ-training6b/BioASQ-trainingDataset6b.json",
+            "bioasq_7b": "BioASQ-training7b/trainining7b.json",
+            "bioasq_8b": "training8b.json",  # HACK - this zipfile strips the dirname
+            "bioasq_9b": "BioASQ-training9b/training9b.json",
+            "bioasq_10b": "BioASQ-training10b/training10b.json",
+        }
+
+        # BLURB has custom train/dev/test splits based on Task 7B
+        if "blurb" in self.config.name:
+            return self._blurb_split_generator(train_dir, test_dir)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        train_dir, train_fpaths[self.config.subset_id]
+                    ),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(test_dir, gold_fpath),
+                    "split": "test",
+                },
+            ),
+        ]
+
+    def _get_exact_answer(self, record):
+        """The value exact_answer can be in different formats based on question type."""
+        if record["type"] == "yesno":
+            exact_answer = [record["exact_answer"]]
+        elif record["type"] == "summary":
+            exact_answer = []
+            # summary question types only have an ideal answer, so use that for bigbio
+            if self.config.schema == "bigbio_qa":
+                exact_answer = (
+                    record["ideal_answer"]
+                    if isinstance(record["ideal_answer"], list)
+                    else [record["ideal_answer"]]
+                )
+
+        elif record["type"] == "list":
+            exact_answer = record["exact_answer"]
+        elif record["type"] == "factoid":
+            # older version of bioasq sometimes represent this as as string
+            exact_answer = (
+                record["exact_answer"]
+                if isinstance(record["exact_answer"], list)
+                else [record["exact_answer"]]
+            )
+        return exact_answer
+
+    def _generate_examples(self, filepath, split):
+        """Yields examples as (key, example) tuples."""
+
+        if self.config.schema == "source":
+            with open(filepath, encoding="utf-8") as file:
+                data = json.load(file)
+                for i, record in enumerate(data["questions"]):
+                    yield i, {
+                        "id": record["id"],
+                        "type": record["type"],
+                        "body": record["body"],
+                        "documents": record["documents"],
+                        "concepts": record["concepts"] if "concepts" in record else [],
+                        "triples": record["triples"] if "triples" in record else [],
+                        "ideal_answer": record["ideal_answer"]
+                        if isinstance(record["ideal_answer"], list)
+                        else [record["ideal_answer"]],
+                        "exact_answer": self._get_exact_answer(record),
+                        "snippets": record["snippets"] if "snippets" in record else [],
+                    }
+
+        elif self.config.schema == "bigbio_qa":
+            # NOTE: Years 2014-2016 (BioASQ2-BioASQ4) have duplicate records
+            cache = set()
+            with open(filepath, encoding="utf-8") as file:
+                uid = 0
+                data = json.load(file)
+                for record in data["questions"]:
+                    # for questions that do not have snippets, skip
+                    if "snippets" not in record:
+                        continue
+                    for i, snippet in enumerate(record["snippets"]):
+                        key = f'{record["id"]}_{i}'
+                        # ignore duplicate records
+                        if key not in cache:
+                            cache.add(key)
+                            yield uid, {
+                                "id": key,
+                                "document_id": snippet["document"],
+                                "question_id": record["id"],
+                                "question": record["body"],
+                                "type": record["type"],
+                                "choices": [],
+                                "context": snippet["text"],
+                                "answer": self._get_exact_answer(record),
+                            }
+                            uid += 1

--- a/hub/hubscripts/bioasq_task_c_2017_hub.py
+++ b/hub/hubscripts/bioasq_task_c_2017_hub.py
@@ -1,0 +1,220 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import List
+
+import datasets
+
+from .bigbiohub import text.features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = True
+_CITATION = """\
+@article{nentidis-etal-2017-results,
+  title        = {Results of the fifth edition of the {B}io{ASQ} Challenge},
+  author       = {
+    Nentidis, Anastasios  and Bougiatiotis, Konstantinos  and Krithara,
+    Anastasia  and Paliouras, Georgios  and Kakadiaris, Ioannis
+  },
+  year         = 2007,
+  journal      = {},
+  volume       = {BioNLP 2017},
+  doi          = {10.18653/v1/W17-2306},
+  url          = {https://aclanthology.org/W17-2306},
+  biburl       = {},
+  bibsource    = {https://aclanthology.org/W17-2306}
+}
+
+"""
+
+_DATASETNAME = "bioasq_task_c_2017"
+_DISPLAYNAME = "BioASQ Task C 2017"
+
+_DESCRIPTION = """\
+The training data set for this task contains annotated biomedical articles
+published in PubMed and corresponding full text from PMC. By annotated is meant
+that GrantIDs and corresponding Grant Agencies have been identified in the full
+text of articles
+"""
+
+_HOMEPAGE = "http://participants-area.bioasq.org/general_information/Task5c/"
+
+_LICENSE = 'National Library of Medicine Terms and Conditions'
+
+# Website contains all data, but login required
+_URLS = {_DATASETNAME: "http://participants-area.bioasq.org/datasets/"}
+
+_SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+@dataclass
+class BioASQTaskC2017BigBioConfig(BigBioConfig):
+    schema: str = "source"
+    name: str = "bioasq_task_c_2017_source"
+    version: datasets.Version = datasets.Version(_SOURCE_VERSION)
+    description: str = "bioasq_task_c_2017 source schema"
+    subset_id: str = "bioasq_task_c_2017"
+
+
+class BioASQTaskC2017(datasets.GeneratorBasedBuilder):
+    """
+    BioASQ Task C Dataset for 2017
+    """
+
+    DEFAULT_CONFIG_NAME = "bioasq_task_c_2017_source"
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BioASQTaskC2017BigBioConfig(
+            name="bioasq_task_c_2017_source",
+            version=SOURCE_VERSION,
+            description="bioasq_task_c_2017 source schema",
+            schema="source",
+            subset_id="bioasq_task_c_2017",
+        ),
+        BioASQTaskC2017BigBioConfig(
+            name="bioasq_task_c_2017_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="bioasq_task_c_2017 BigBio schema",
+            schema="bigbio_text",
+            subset_id="bioasq_task_c_2017",
+        ),
+    ]
+
+    BUILDER_CONFIG_CLASS = BioASQTaskC2017BigBioConfig
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        # BioASQ Task C source schema
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "pmid": datasets.Value("string"),
+                    "pmcid": datasets.Value("string"),
+                    "grantList": [
+                        {
+                            "agency": datasets.Value("string"),
+                        }
+                    ],
+                    "text": datasets.Value("string"),
+                }
+            )
+
+        # For example bigbio_kb, bigbio_t2t
+        elif self.config.schema == "bigbio_text":
+            features = text.features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
+        else:
+            data_dir = self.config.data_dir
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "taskCTrainingData2017.json"),
+                    "filespath": os.path.join(data_dir, "Train_Text"),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "taskc_golden2.json"),
+                    "filespath": os.path.join(data_dir, "Final_Text"),
+                    "split": "test",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, filespath, split):
+
+        with open(filepath) as f:
+            task_data = json.load(f)
+
+        if self.config.schema == "source":
+            for article in task_data["articles"]:
+
+                with open(filespath + "/" + article["pmcid"] + ".xml") as f:
+                    text = f.read()
+                pmid = article["pmid"]
+
+                yield pmid, {
+                    "text": text,  # articles[pmid],
+                    "document_id": pmid,
+                    "id": str(pmid),
+                    "pmid": pmid,
+                    "pmcid": article["pmcid"],
+                    "grantList": [
+                        {"agency": grant["agency"]} for grant in article["grantList"]
+                    ],
+                }
+
+        elif self.config.schema == "bigbio_text":
+
+            for article in task_data["articles"]:
+
+                with open(filespath + "/" + article["pmcid"] + ".xml") as f:
+                    xml_string = f.read()
+
+                try:
+                    article_body = ET.fromstring(xml_string).find("./article/body")
+                except ET.ParseError:
+
+                    # PubMed XML might not contain namespace which results in parse error, add manually
+                    xml_string = xml_string.replace(
+                        "</pmc-articleset>",
+                        # xlink namespace
+                        '<article xmlns:xlink="http://www.w3.org/1999/xlink"'  # mml namespace
+                        ' xmlns:mml="http://www.w3.org/1998/Math/MathML"'
+                        ' article-type="research-article">',
+                    )
+                    xml_string = xml_string + "</article></pmc-articleset>"
+                    article_body = ET.fromstring(xml_string).find("./article/body")
+
+                text = ET.tostring(article_body, encoding="utf8", method="text")
+
+                yield article["pmid"], {
+                    "text": text,
+                    "id": str(article["pmid"]),
+                    "document_id": article["pmid"],
+                    "labels": [grant["agency"] for grant in article["grantList"]],
+                }

--- a/hub/hubscripts/bioinfer_hub.py
+++ b/hub/hubscripts/bioinfer_hub.py
@@ -1,0 +1,259 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The authors present BioInfer (Bio Information Extraction Resource), a new public
+resource providing an annotated corpus of biomedical English. We describe an
+annotation scheme capturing named entities and their relationships along with a
+dependency analysis of sentence syntax. We further present ontologies defining
+the types of entities and relationships annotated in the corpus. Currently, the
+corpus contains 1100 sentences from abstracts of biomedical research articles
+annotated for relationships, named entities, as well as syntactic dependencies.
+"""
+
+import os
+import xml.etree.ElementTree as ET
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{pyysalo2007bioinfer,
+  title        = {BioInfer: a corpus for information extraction in the biomedical domain},
+  author       = {
+    Pyysalo, Sampo and Ginter, Filip and Heimonen, Juho and Bj{\"o}rne, Jari
+    and Boberg, Jorma and J{\"a}rvinen, Jouni and Salakoski, Tapio
+  },
+  year         = 2007,
+  journal      = {BMC bioinformatics},
+  publisher    = {BioMed Central},
+  volume       = 8,
+  number       = 1,
+  pages        = {1--24}
+}
+"""
+
+_DATASETNAME = "bioinfer"
+_DISPLAYNAME = "BioInfer"
+
+_DESCRIPTION = """\
+A corpus targeted at protein, gene, and RNA relationships which serves as a
+resource for the development of information extraction systems and their
+components such as parsers and domain analyzers. Currently, the corpus contains
+1100 sentences from abstracts of biomedical research articles annotated for
+relationships, named entities, as well as syntactic dependencies.
+"""
+
+_HOMEPAGE = "https://github.com/metalrt/ppi-dataset"
+
+_LICENSE = 'Creative Commons Attribution 2.0 Generic'
+
+_URLS = {
+    _DATASETNAME: "https://github.com/metalrt/ppi-dataset/archive/refs/heads/master.zip",
+}
+
+_SUPPORTED_TASKS = [Tasks.RELATION_EXTRACTION, Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class BioinferDataset(datasets.GeneratorBasedBuilder):
+    """
+    1100 sentences from abstracts of biomedical research articles annotated
+    for relationships, named entities, as well as syntactic dependencies.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="bioinfer_source",
+            version=SOURCE_VERSION,
+            description="BioInfer source schema",
+            schema="source",
+            subset_id="bioinfer",
+        ),
+        BigBioConfig(
+            name="bioinfer_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="BioInfer BigBio schema",
+            schema="bigbio_kb",
+            subset_id="bioinfer",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "bioinfer_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "type": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "entities": [
+                        {
+                            "id": datasets.Value("string"),
+                            "offsets": [[datasets.Value("int32")]],
+                            "text": [datasets.Value("string")],
+                            "type": datasets.Value("string"),
+                            "normalized": [
+                                {
+                                    "db_name": datasets.Value("string"),
+                                    "db_id": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                    "relations": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arg1_id": datasets.Value("string"),
+                            "arg2_id": datasets.Value("string"),
+                            "normalized": [
+                                {
+                                    "db_name": datasets.Value("string"),
+                                    "db_id": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                }
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "ppi-dataset-master/csv_output/BioInfer-train.xml"
+                    ),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "ppi-dataset-master/csv_output/BioInfer-test.xml"
+                    ),
+                    "split": "test",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        tree = ET.parse(filepath)
+        root = tree.getroot()
+        if self.config.schema == "source":
+            for guid, sentence in enumerate(root.iter("sentence")):
+                example = self._create_example(sentence)
+                example["text"] = sentence.attrib["text"]
+                example["type"] = "Sentence"
+                yield guid, example
+
+        elif self.config.schema == "bigbio_kb":
+            for guid, sentence in enumerate(root.iter("sentence")):
+                example = self._create_example(sentence)
+                example["passages"] = [
+                    {
+                        "id": f"{sentence.attrib['id']}__text",
+                        "type": "Sentence",
+                        "text": [sentence.attrib["text"]],
+                        "offsets": [(0, len(sentence.attrib["text"]))],
+                    }
+                ]
+                example["events"] = []
+                example["coreferences"] = []
+                example["id"] = guid
+                yield guid, example
+
+    def _create_example(self, sentence):
+        example = {}
+        example["document_id"] = sentence.attrib["id"]
+        example["entities"] = []
+        example["relations"] = []
+        for tag in sentence:
+            if tag.tag == "entity":
+                example["entities"].append(self._add_entity(tag))
+            elif tag.tag == "interaction":
+                example["relations"].append(self._add_interaction(tag))
+            else:
+                raise ValueError(f"unknown tags: {tag.tag}")
+        return example
+
+    @staticmethod
+    def _add_entity(entity):
+        offsets = [
+            [int(o) for o in offset.split("-")]
+            for offset in entity.attrib["charOffset"].split(",")
+        ]
+        # For multiple offsets, split entity text accordingly
+        if len(offsets) > 1:
+            text = []
+            i = 0
+            for start, end in offsets:
+                chunk_len = end - start
+                text.append(entity.attrib["text"][i : chunk_len + i])
+                i += chunk_len
+                while (
+                    i < len(entity.attrib["text"]) and entity.attrib["text"][i] == " "
+                ):
+                    i += 1
+        else:
+            text = [entity.attrib["text"]]
+        return {
+            "id": entity.attrib["id"],
+            "offsets": offsets,
+            "text": text,
+            "type": entity.attrib["type"],
+            "normalized": {},
+        }
+
+    @staticmethod
+    def _add_interaction(interaction):
+        return {
+            "id": interaction.attrib["id"],
+            "type": interaction.attrib["type"],
+            "arg1_id": interaction.attrib["e1"],
+            "arg2_id": interaction.attrib["e2"],
+            "normalized": {},
+        }

--- a/hub/hubscripts/biology_how_why_corpus_hub.py
+++ b/hub/hubscripts/biology_how_why_corpus_hub.py
@@ -1,0 +1,205 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This dataset consists of 185 "how" and 193 "why" biology questions authored by a domain expert, with one or more gold 
+answer passages identified in an undergraduate textbook. The expert was not constrained in any way during the 
+annotation process, so gold answers might be smaller than a paragraph or span multiple paragraphs. This dataset was 
+used for the question-answering system described in the paper “Discourse Complements Lexical Semantics for Non-factoid 
+Answer Reranking” (ACL 2014).
+"""
+
+import os
+import xml.dom.minidom as xml
+from itertools import chain, count
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import qa_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@inproceedings{jansen-etal-2014-discourse,
+    title = "Discourse Complements Lexical Semantics for Non-factoid Answer Reranking",
+    author = "Jansen, Peter  and
+      Surdeanu, Mihai  and
+      Clark, Peter",
+    booktitle = "Proceedings of the 52nd Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
+    month = jun,
+    year = "2014",
+    address = "Baltimore, Maryland",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/P14-1092",
+    doi = "10.3115/v1/P14-1092",
+    pages = "977--986",
+}
+"""
+
+_DATASETNAME = "biology_how_why_corpus"
+_DISPLAYNAME = "BiologyHowWhyCorpus"
+
+_DESCRIPTION = """\
+This dataset consists of 185 "how" and 193 "why" biology questions authored by a domain expert, with one or more gold 
+answer passages identified in an undergraduate textbook. The expert was not constrained in any way during the 
+annotation process, so gold answers might be smaller than a paragraph or span multiple paragraphs. This dataset was 
+used for the question-answering system described in the paper “Discourse Complements Lexical Semantics for Non-factoid 
+Answer Reranking” (ACL 2014).
+"""
+
+_HOMEPAGE = "https://allenai.org/data/biology-how-why-corpus"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: "https://ai2-public-datasets.s3.amazonaws.com/biology-how-why-corpus/BiologyHowWhyCorpus.tar",
+}
+
+_SUPPORTED_TASKS = [Tasks.QUESTION_ANSWERING]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class BiologyHowWhyCorpusDataset(datasets.GeneratorBasedBuilder):
+    """This dataset consists of 185 "how" and 193 "why" biology questions."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="biology_how_why_corpus_source",
+            version=SOURCE_VERSION,
+            description="Biology How Why Corpus source schema",
+            schema="source",
+            subset_id="biology_how_why_corpus",
+        ),
+        BigBioConfig(
+            name="biology_how_why_corpus_bigbio_qa",
+            version=BIGBIO_VERSION,
+            description="Biology How Why Corpus BigBio schema",
+            schema="bigbio_qa",
+            subset_id="biology_how_why_corpus",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "biology_how_why_corpus_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "text": datasets.Value("string"),
+                    "type": datasets.Value("string"),
+                    "answers": [
+                        {
+                            "justification": datasets.Value("string"),
+                            "docid": datasets.Value("string"),
+                            "sentences": datasets.Sequence(datasets.Value("int32")),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_qa":
+            features = qa_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "how_path": os.path.join(
+                        data_dir, "BiologyHowWhyCorpus", "GoldStandardVulcanHOW.all.xml"
+                    ),
+                    "why_path": os.path.join(
+                        data_dir, "BiologyHowWhyCorpus", "GoldStandardVulcanWHY.all.xml"
+                    ),
+                },
+            ),
+        ]
+
+    def _generate_examples(self, how_path: str, why_path: str) -> Tuple[int, Dict]:
+
+        uid = count(0)
+
+        if self.config.schema == "source":
+            for question in chain(
+                self._parse_questions(how_path, "how"),
+                self._parse_questions(why_path, "why"),
+            ):
+                yield next(uid), question
+
+        elif self.config.schema == "bigbio_qa":
+            for question in chain(
+                self._parse_questions(how_path, "how"),
+                self._parse_questions(why_path, "why"),
+            ):
+                for answer in question["answers"]:
+                    id = next(uid)
+                    yield id, {
+                        "id": id,
+                        "question_id": next(uid),
+                        "document_id": answer["docid"],
+                        "question": question["text"],
+                        "type": question["type"],
+                        "choices": [],
+                        "context": "",
+                        "answer": [answer["justification"]],
+                    }
+
+    def _parse_questions(self, path: str, type: str):
+        collection = xml.parse(path).documentElement
+        questions = collection.getElementsByTagName("question")
+        for question in questions:
+            text = question.getElementsByTagName("text")[0].childNodes[0].data
+            answers = question.getElementsByTagName("answer")
+            answers_ = []
+            for answer in answers:
+                justification = (
+                    answer.getElementsByTagName("justification")[0].childNodes[0].data
+                )
+                docid = answer.getElementsByTagName("docid")[0].childNodes[0].data
+                sentences = (
+                    answer.getElementsByTagName("sentences")[0]
+                    .childNodes[0]
+                    .data.split(", ")
+                )
+                answers_.append(
+                    {
+                        "justification": justification,
+                        "docid": docid,
+                        "sentences": sentences,
+                    }
+                )
+            yield {"text": text, "type": type, "answers": answers_}

--- a/hub/hubscripts/biomrc_hub.py
+++ b/hub/hubscripts/biomrc_hub.py
@@ -1,0 +1,267 @@
+# coding=utf-8
+# Copyright 2020 The TensorFlow Datasets Authors and the HuggingFace Datasets Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+We introduce BIOMRC, a large-scale cloze-style biomedical MRC dataset. Care was taken to reduce noise, compared to the
+previous BIOREAD dataset of Pappas et al. (2018). Experiments show that simple heuristics do not perform well on the
+new dataset and that two neural MRC models that had been tested on BIOREAD perform much better on BIOMRC, indicating
+that the new dataset is indeed less noisy or at least that its task is more feasible. Non-expert human performance is
+also higher on the new dataset compared to BIOREAD, and biomedical experts perform even better. We also introduce a new
+BERT-based MRC model, the best version of which substantially outperforms all other methods tested, reaching or
+surpassing the accuracy of biomedical experts in some experiments. We make the new dataset available in three different
+sizes, also releasing our code, and providing a leaderboard.
+"""
+
+import itertools as it
+import json
+
+import datasets
+
+from .bigbiohub import qa_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{pappas-etal-2020-biomrc,
+    title = "{B}io{MRC}: A Dataset for Biomedical Machine Reading Comprehension",
+    author = "Pappas, Dimitris  and
+      Stavropoulos, Petros  and
+      Androutsopoulos, Ion  and
+      McDonald, Ryan",
+    booktitle = "Proceedings of the 19th SIGBioMed Workshop on Biomedical Language Processing",
+    month = jul,
+    year = "2020",
+    address = "Online",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/2020.bionlp-1.15",
+    pages = "140--149",
+}
+"""
+
+_DATASETNAME = "biomrc"
+_DISPLAYNAME = "BIOMRC"
+
+_DESCRIPTION = """\
+We introduce BIOMRC, a large-scale cloze-style biomedical MRC dataset. Care was taken to reduce noise, compared to the
+previous BIOREAD dataset of Pappas et al. (2018). Experiments show that simple heuristics do not perform well on the
+new dataset and that two neural MRC models that had been tested on BIOREAD perform much better on BIOMRC, indicating
+that the new dataset is indeed less noisy or at least that its task is more feasible. Non-expert human performance is
+also higher on the new dataset compared to BIOREAD, and biomedical experts perform even better. We also introduce a new
+BERT-based MRC model, the best version of which substantially outperforms all other methods tested, reaching or
+surpassing the accuracy of biomedical experts in some experiments. We make the new dataset available in three different
+sizes, also releasing our code, and providing a leaderboard.
+"""
+
+_HOMEPAGE = "https://github.com/PetrosStav/BioMRC_code"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    "large": {
+        "A": {
+            "train": "https://archive.org/download/biomrc_dataset/biomrc_large/dataset_train.json.gz",
+            "val": "https://archive.org/download/biomrc_dataset/biomrc_large/dataset_val.json.gz",
+            "test": "https://archive.org/download/biomrc_dataset/biomrc_large/dataset_test.json.gz",
+        },
+        "B": {
+            "train": "https://archive.org/download/biomrc_dataset/biomrc_large/dataset_train_B.json.gz",
+            "val": "https://archive.org/download/biomrc_dataset/biomrc_large/dataset_val_B.json.gz",
+            "test": "https://archive.org/download/biomrc_dataset/biomrc_large/dataset_test_B.json.gz",
+        },
+    },
+    "small": {
+        "A": {
+            "train": "https://archive.org/download/biomrc_dataset/biomrc_small/dataset_train_small.json.gz",
+            "val": "https://archive.org/download/biomrc_dataset/biomrc_small/dataset_val_small.json.gz",
+            "test": "https://archive.org/download/biomrc_dataset/biomrc_small/dataset_test_small.json.gz",
+        },
+        "B": {
+            "train": "https://archive.org/download/biomrc_dataset/biomrc_small/dataset_train_small_B.json.gz",
+            "val": "https://archive.org/download/biomrc_dataset/biomrc_small/dataset_val_small_B.json.gz",
+            "test": "https://archive.org/download/biomrc_dataset/biomrc_small/dataset_test_small_B.json.gz",
+        },
+    },
+    "tiny": {
+        "A": {
+            "test": "https://archive.org/download/biomrc_dataset/biomrc_tiny/dataset_tiny.json.gz"
+        },
+        "B": {
+            "test": "https://archive.org/download/biomrc_dataset/biomrc_tiny/dataset_tiny_B.json.gz"
+        },
+    },
+}
+
+_SUPPORTED_TASKS = [Tasks.QUESTION_ANSWERING]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class BiomrcDataset(datasets.GeneratorBasedBuilder):
+    """BioMRC: A Dataset for Biomedical Machine Reading Comprehension"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = []
+
+    for biomrc_setting in ["A", "B"]:
+        for biomrc_version in ["large", "small", "tiny"]:
+            subset_id = f"biomrc_{biomrc_version}_{biomrc_setting}"
+            BUILDER_CONFIGS.append(
+                BigBioConfig(
+                    name=f"{subset_id}_source",
+                    version=SOURCE_VERSION,
+                    description=f"BioMRC Version {biomrc_version} Setting {biomrc_setting} source schema",
+                    schema="source",
+                    subset_id=subset_id,
+                )
+            )
+            BUILDER_CONFIGS.append(
+                BigBioConfig(
+                    name=f"{subset_id}_bigbio_qa",
+                    version=BIGBIO_VERSION,
+                    description=f"BioMRC Version {biomrc_version} Setting {biomrc_setting} BigBio schema",
+                    schema="bigbio_qa",
+                    subset_id=subset_id,
+                )
+            )
+
+    DEFAULT_CONFIG_NAME = "biomrc_large_B_source"
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "abstract": datasets.Value("string"),
+                    "title": datasets.Value("string"),
+                    "entities_list": datasets.features.Sequence(
+                        {
+                            "pseudoidentifier": datasets.Value("string"),
+                            "identifier": datasets.Value("string"),
+                            "synonyms": datasets.Value("string"),
+                        }
+                    ),
+                    "answer": {
+                        "pseudoidentifier": datasets.Value("string"),
+                        "identifier": datasets.Value("string"),
+                        "synonyms": datasets.Value("string"),
+                    },
+                }
+            )
+        elif self.config.schema == "bigbio_qa":
+            features = qa_features
+        else:
+            raise NotImplementedError()
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+
+        _, version, setting = self.config.subset_id.split("_")
+        downloaded_files = dl_manager.download_and_extract(_URLS[version][setting])
+
+        if version == "tiny":
+            return [
+                datasets.SplitGenerator(
+                    name=datasets.Split.TRAIN,
+                    gen_kwargs={"filepath": downloaded_files["test"]},
+                ),
+            ]
+        else:
+            return [
+                datasets.SplitGenerator(
+                    name=datasets.Split.TRAIN,
+                    gen_kwargs={"filepath": downloaded_files["train"]},
+                ),
+                datasets.SplitGenerator(
+                    name=datasets.Split.VALIDATION,
+                    gen_kwargs={"filepath": downloaded_files["val"]},
+                ),
+                datasets.SplitGenerator(
+                    name=datasets.Split.TEST,
+                    gen_kwargs={"filepath": downloaded_files["test"]},
+                ),
+            ]
+
+    def _generate_examples(self, filepath):
+        """Yields examples as (key, example) tuples."""
+
+        if self.config.schema == "source":
+            with open(filepath, encoding="utf-8") as fp:
+                biomrc = json.load(fp)
+                for _id, (ab, ti, el, an) in enumerate(
+                    zip(
+                        biomrc["abstracts"],
+                        biomrc["titles"],
+                        biomrc["entities_list"],
+                        biomrc["answers"],
+                    )
+                ):
+                    el = [self._parse_dict_from_entity(entity) for entity in el]
+                    an = self._parse_dict_from_entity(an)
+                    yield _id, {
+                        "abstract": ab,
+                        "title": ti,
+                        "entities_list": el,
+                        "answer": an,
+                    }
+        elif self.config.schema == "bigbio_qa":
+            with open(filepath, encoding="utf-8") as fp:
+                uid = it.count(0)
+                biomrc = json.load(fp)
+                for _id, (ab, ti, el, an) in enumerate(
+                    zip(
+                        biomrc["abstracts"],
+                        biomrc["titles"],
+                        biomrc["entities_list"],
+                        biomrc["answers"],
+                    )
+                ):
+                    # remove info such as code, label, synonyms from answer and choices
+                    # f.e. @entity1 :: ('9606', 'Species') :: ['patients', 'patient']"
+                    example = {
+                        "id": next(uid),
+                        "question_id": next(uid),
+                        "document_id": next(uid),
+                        "question": ti,
+                        "type": "multiple_choice",
+                        "choices": [x.split(" :: ")[0] for x in el],
+                        "context": ab,
+                        "answer": [an.split(" :: ")[0]],
+                    }
+                    yield _id, example
+
+    def _parse_dict_from_entity(self, entity):
+        if "::" in entity:
+            pseudoidentifier, identifier, synonyms = entity.split(" :: ")
+            return {
+                "pseudoidentifier": pseudoidentifier,
+                "identifier": identifier,
+                "synonyms": synonyms,
+            }
+        else:
+            return {"pseudoidentifier": entity, "identifier": "", "synonyms": ""}

--- a/hub/hubscripts/bionlp_shared_task_2009_hub.py
+++ b/hub/hubscripts/bionlp_shared_task_2009_hub.py
@@ -1,0 +1,231 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pathlib import Path
+from typing import Dict, List
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{kim-etal-2009-overview,
+    title = "Overview of {B}io{NLP}{'}09 Shared Task on Event Extraction",
+    author = "Kim, Jin-Dong  and
+      Ohta, Tomoko  and
+      Pyysalo, Sampo  and
+      Kano, Yoshinobu  and
+      Tsujii, Jun{'}ichi",
+    booktitle = "Proceedings of the {B}io{NLP} 2009 Workshop Companion Volume for Shared Task",
+    month = jun,
+    year = "2009",
+    address = "Boulder, Colorado",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/W09-1401",
+    pages = "1--9",
+}
+"""
+
+_DATASETNAME = "bionlp_shared_task_2009"
+_DISPLAYNAME = "BioNLP 2009"
+
+_DESCRIPTION = """\
+The BioNLP Shared Task 2009 was organized by GENIA Project and its corpora were curated based
+on the annotations of the publicly available GENIA Event corpus and an unreleased (blind) section
+of the GENIA Event corpus annotations, used for evaluation.
+"""
+
+_HOMEPAGE = "http://www.geniaproject.org/shared-tasks/bionlp-shared-task-2009"
+
+_LICENSE = 'GENIA Project License for Annotated Corpora'
+
+_URL_BASE = "http://www.nactem.ac.uk/GENIA/current/Shared-tasks/BioNLP-ST-2009/"
+_URLS = {
+    _DATASETNAME: {
+        "train": _URL_BASE + "bionlp09_shared_task_training_data_rev2.tar.gz",
+        "test": _URL_BASE
+        + "bionlp09_shared_task_test_data_without_gold_annotation.tar.gz",
+        "dev": _URL_BASE + "bionlp09_shared_task_development_data_rev1.tar.gz",
+    },
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.EVENT_EXTRACTION,
+    Tasks.COREFERENCE_RESOLUTION,
+]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+# https://2011.bionlp-st.org/bionlp-shared-task-2011/genia-event-extraction-genia
+
+
+class BioNLPSharedTask2009(datasets.GeneratorBasedBuilder):
+    """TODO: Short description of my dataset."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="bionlp_shared_task_2009_source",
+            version=SOURCE_VERSION,
+            description="bionlp_shared_task_2009 source schema",
+            schema="source",
+            subset_id="bionlp_shared_task_2009",
+        ),
+        BigBioConfig(
+            name="bionlp_shared_task_2009_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="bionlp_shared_task_2009 BigBio schema",
+            schema="bigbio_kb",
+            subset_id="bionlp_shared_task_2009",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "bionlp_shared_task_2009_source"
+
+    _ROLE_MAPPING = {
+        "Theme2": "Theme",
+        "Theme3": "Theme",
+        "Theme4": "Theme",
+        "Site2": "Site",
+    }
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [
+                        {
+                            "id": datasets.Value("string"),
+                            "offsets": [[datasets.Value("int64")]],
+                            "text": [datasets.Value("string")],
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [
+                        {
+                            "arguments": [
+                                {
+                                    "ref_id": datasets.Value("string"),
+                                    "role": datasets.Value("string"),
+                                }
+                            ],
+                            "id": datasets.Value("string"),
+                            "trigger": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "relations": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arg1_id": datasets.Value("string"),
+                            "arg2_id": datasets.Value("string"),
+                            "normalized": [
+                                {
+                                    "db_name": datasets.Value("string"),
+                                    "db_id": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                    "equivalences": [datasets.Value("string")],
+                    "attributes": [datasets.Value("string")],
+                    "normalizations": [datasets.Value("string")],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        urls = _URLS[_DATASETNAME]
+        data_dir_train = dl_manager.download_and_extract(urls["train"])
+        data_dir_test = dl_manager.download_and_extract(urls["test"])
+        data_dir_dev = dl_manager.download_and_extract(urls["dev"])
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_dir_train,
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": data_dir_test,
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": data_dir_dev,
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _standardize_arguments_roles(self, kb_example: Dict) -> Dict:
+
+        for event in kb_example["events"]:
+            for argument in event["arguments"]:
+                role = argument["role"]
+                argument["role"] = self._ROLE_MAPPING.get(role, role)
+
+        return kb_example
+
+    def _generate_examples(self, filepath, split):
+
+        filepath = Path(filepath)
+        txt_files: List[Path] = [
+            file for file in filepath.iterdir() if file.suffix == ".txt"
+        ]
+
+        if self.config.schema == "source":
+            for i, file in enumerate(txt_files):
+                brat_content = parse_brat_file(file)
+                yield i, brat_content
+
+        elif self.config.schema == "bigbio_kb":
+            for i, file in enumerate(txt_files):
+                brat_content = parse_brat_file(file)
+                kb_example = brat_parse_to_bigbio_kb(brat_content)
+                kb_example = self._standardize_arguments_roles(kb_example)
+                kb_example["id"] = kb_example["document_id"]
+                yield i, kb_example

--- a/hub/hubscripts/bionlp_st_2011_epi_hub.py
+++ b/hub/hubscripts/bionlp_st_2011_epi_hub.py
@@ -1,0 +1,240 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pathlib import Path
+from typing import List
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "bionlp_st_2011_epi"
+_DISPLAYNAME = "BioNLP 2011 EPI"
+
+_SOURCE_VIEW_NAME = "source"
+_UNIFIED_VIEW_NAME = "bigbio"
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{ohta-etal-2011-overview,
+    title = "Overview of the Epigenetics and Post-translational
+    Modifications ({EPI}) task of {B}io{NLP} Shared Task 2011",
+    author = "Ohta, Tomoko  and
+      Pyysalo, Sampo  and
+      Tsujii, Jun{'}ichi",
+    booktitle = "Proceedings of {B}io{NLP} Shared Task 2011 Workshop",
+    month = jun,
+    year = "2011",
+    address = "Portland, Oregon, USA",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/W11-1803",
+    pages = "16--25",
+}
+"""
+
+_DESCRIPTION = """\
+The dataset of the Epigenetics and Post-translational Modifications (EPI) task
+of BioNLP Shared Task 2011.
+"""
+
+_HOMEPAGE = "https://github.com/openbiocorpora/bionlp-st-2011-epi"
+
+_LICENSE = 'GENIA Project License for Annotated Corpora'
+
+_URLs = {
+    "source": "https://github.com/openbiocorpora/bionlp-st-2011-epi/archive/refs/heads/master.zip",
+    "bigbio_kb": "https://github.com/openbiocorpora/bionlp-st-2011-epi/archive/refs/heads/master.zip",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.EVENT_EXTRACTION,
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.COREFERENCE_RESOLUTION,
+]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class bionlp_st_2011_epi(datasets.GeneratorBasedBuilder):
+    """The dataset of the Epigenetics and Post-translational Modifications (EPI) task
+    of BioNLP Shared Task 2011."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="bionlp_st_2011_epi_source",
+            version=SOURCE_VERSION,
+            description="bionlp_st_2011_epi source schema",
+            schema="source",
+            subset_id="bionlp_st_2011_epi",
+        ),
+        BigBioConfig(
+            name="bionlp_st_2011_epi_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="bionlp_st_2011_epi BigBio schema",
+            schema="bigbio_kb",
+            subset_id="bionlp_st_2011_epi",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "bionlp_st_2011_epi_source"
+
+    def _info(self):
+        """
+        - `features` defines the schema of the parsed data set. The schema depends on the
+        chosen `config`: If it is `_SOURCE_VIEW_NAME` the schema is the schema of the
+        original data. If `config` is `_UNIFIED_VIEW_NAME`, then the schema is the
+        canonical KB-task schema defined in `biomedical/schemas/kb.py`.
+        """
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "trigger": datasets.Value(
+                                "string"
+                            ),  # refers to the text_bound_annotation of the trigger,
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arguments": datasets.Sequence(
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "attributes": [  # M or A lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value(
+                                "string"
+                            ),  # Name of the resource, e.g. "Wikipedia"
+                            "cuid": datasets.Value(
+                                "string"
+                            ),  # ID in the resource, e.g. 534366
+                            "text": datasets.Value(
+                                "string"
+                            ),  # Human readable description/name of the entity, e.g. "Barack Obama"
+                        }
+                    ],
+                },
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+
+        my_urls = _URLs[self.config.schema]
+        data_dir = Path(dl_manager.download_and_extract(my_urls))
+        data_files = {
+            "train": data_dir
+            / f"bionlp-st-2011-epi-master"
+            / "original-data"
+            / "train",
+            "dev": data_dir / f"bionlp-st-2011-epi-master" / "original-data" / "devel",
+            "test": data_dir / f"bionlp-st-2011-epi-master" / "original-data" / "test",
+        }
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"data_files": data_files["train"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"data_files": data_files["dev"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"data_files": data_files["test"]},
+            ),
+        ]
+
+    def _generate_examples(self, data_files: Path):
+        if self.config.schema == "source":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.parse_brat_file(txt_file)
+                example["id"] = str(guid)
+                yield guid, example
+        elif self.config.schema == "bigbio_kb":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.brat_parse_to_bigbio_kb(
+                    parsing.parse_brat_file(txt_file)
+                )
+                example["id"] = str(guid)
+                yield guid, example
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/hub/hubscripts/bionlp_st_2011_ge_hub.py
+++ b/hub/hubscripts/bionlp_st_2011_ge_hub.py
@@ -1,0 +1,264 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Dict, List
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "bionlp_st_2011_ge"
+_DISPLAYNAME = "BioNLP 2011 GE"
+
+_SOURCE_VIEW_NAME = "source"
+_UNIFIED_VIEW_NAME = "bigbio"
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{10.5555/2107691.2107693,
+author = {Kim, Jin-Dong and Wang, Yue and Takagi, Toshihisa and Yonezawa, Akinori},
+title = {Overview of Genia Event Task in BioNLP Shared Task 2011},
+year = {2011},
+isbn = {9781937284091},
+publisher = {Association for Computational Linguistics},
+address = {USA},
+abstract = {The Genia event task, a bio-molecular event extraction task,
+is arranged as one of the main tasks of BioNLP Shared Task 2011.
+As its second time to be arranged for community-wide focused
+efforts, it aimed to measure the advance of the community since 2009,
+and to evaluate generalization of the technology to full text papers.
+After a 3-month system development period, 15 teams submitted their
+performance results on test cases. The results show the community has
+made a significant advancement in terms of both performance improvement
+and generalization.},
+booktitle = {Proceedings of the BioNLP Shared Task 2011 Workshop},
+pages = {7–15},
+numpages = {9},
+location = {Portland, Oregon},
+series = {BioNLP Shared Task '11}
+}
+"""
+
+_DESCRIPTION = """\
+The BioNLP-ST GE task has been promoting development of fine-grained information extraction (IE) from biomedical
+documents, since 2009. Particularly, it has focused on the domain of NFkB as a model domain of Biomedical IE.
+The GENIA task aims at extracting events occurring upon genes or gene products, which are typed as "Protein"
+without differentiating genes from gene products. Other types of physical entities, e.g. cells, cell components,
+are not differentiated from each other, and their type is given as "Entity".
+"""
+
+_HOMEPAGE = "https://sites.google.com/site/bionlpst/bionlp-shared-task-2011/genia-event-extraction-genia"
+
+_LICENSE = 'Creative Commons Attribution 3.0 Unported'
+
+_URLs = {
+    "source": "https://github.com/openbiocorpora/bionlp-st-2011-ge/archive/refs/heads/master.zip",
+    "bigbio_kb": "https://github.com/openbiocorpora/bionlp-st-2011-ge/archive/refs/heads/master.zip",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.EVENT_EXTRACTION,
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.COREFERENCE_RESOLUTION,
+]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class bionlp_st_2011_ge(datasets.GeneratorBasedBuilder):
+    """The BioNLP-ST GE task has been promoting development of fine-grained information extraction (IE) from biomedical
+    documents, since 2009. Particularly, it has focused on the domain of NFkB as a model domain of Biomedical IE"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="bionlp_st_2011_ge_source",
+            version=SOURCE_VERSION,
+            description="bionlp_st_2011_ge source schema",
+            schema="source",
+            subset_id="bionlp_st_2011_ge",
+        ),
+        BigBioConfig(
+            name="bionlp_st_2011_ge_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="bionlp_st_2011_ge BigBio schema",
+            schema="bigbio_kb",
+            subset_id="bionlp_st_2011_ge",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "bionlp_st_2011_ge_source"
+
+    _ROLE_MAPPING = {
+        "Theme2": "Theme",
+        "Theme3": "Theme",
+        "Theme4": "Theme",
+        "Site2": "Site",
+    }
+
+    def _info(self):
+        """
+        - `features` defines the schema of the parsed data set. The schema depends on the
+        chosen `config`: If it is `_SOURCE_VIEW_NAME` the schema is the schema of the
+        original data. If `config` is `_UNIFIED_VIEW_NAME`, then the schema is the
+        canonical KB-task schema defined in `biomedical/schemas/kb.py`.
+        """
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "trigger": datasets.Value(
+                                "string"
+                            ),  # refers to the text_bound_annotation of the trigger,
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arguments": datasets.Sequence(
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "attributes": [  # M or A lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value(
+                                "string"
+                            ),  # Name of the resource, e.g. "Wikipedia"
+                            "cuid": datasets.Value(
+                                "string"
+                            ),  # ID in the resource, e.g. 534366
+                            "text": datasets.Value(
+                                "string"
+                            ),  # Human readable description/name of the entity, e.g. "Barack Obama"
+                        }
+                    ],
+                },
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+
+        my_urls = _URLs[self.config.schema]
+        data_dir = Path(dl_manager.download_and_extract(my_urls))
+        data_files = {
+            "train": data_dir / f"bionlp-st-2011-ge-master" / "original-data" / "train",
+            "dev": data_dir / f"bionlp-st-2011-ge-master" / "original-data" / "devel",
+            "test": data_dir / f"bionlp-st-2011-ge-master" / "original-data" / "test",
+        }
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"data_files": data_files["train"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"data_files": data_files["dev"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"data_files": data_files["test"]},
+            ),
+        ]
+
+    def _standardize_arguments_roles(self, kb_example: Dict) -> Dict:
+
+        for event in kb_example["events"]:
+            for argument in event["arguments"]:
+                role = argument["role"]
+                argument["role"] = self._ROLE_MAPPING.get(role, role)
+
+        return kb_example
+
+    def _generate_examples(self, data_files: Path):
+        if self.config.schema == "source":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.parse_brat_file(txt_file)
+                example["id"] = str(guid)
+                yield guid, example
+        elif self.config.schema == "bigbio_kb":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.brat_parse_to_bigbio_kb(
+                    parsing.parse_brat_file(txt_file)
+                )
+                example = self._standardize_arguments_roles(example)
+                example["id"] = str(guid)
+                yield guid, example
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/hub/hubscripts/bionlp_st_2011_id_hub.py
+++ b/hub/hubscripts/bionlp_st_2011_id_hub.py
@@ -1,0 +1,258 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Dict, List
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "bionlp_st_2011_id"
+_DISPLAYNAME = "BioNLP 2011 ID"
+
+_SOURCE_VIEW_NAME = "source"
+_UNIFIED_VIEW_NAME = "bigbio"
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{pyysalo-etal-2011-overview,
+    title = "Overview of the Infectious Diseases ({ID}) task of {B}io{NLP} Shared Task 2011",
+    author = "Pyysalo, Sampo  and
+      Ohta, Tomoko  and
+      Rak, Rafal  and
+      Sullivan, Dan  and
+      Mao, Chunhong  and
+      Wang, Chunxia  and
+      Sobral, Bruno  and
+      Tsujii, Jun{'}ichi  and
+      Ananiadou, Sophia",
+    booktitle = "Proceedings of {B}io{NLP} Shared Task 2011 Workshop",
+    month = jun,
+    year = "2011",
+    address = "Portland, Oregon, USA",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/W11-1804",
+    pages = "26--35",
+}
+"""
+
+_DESCRIPTION = """\
+The dataset of the Infectious Diseases (ID) task of
+BioNLP Shared Task 2011.
+"""
+
+_HOMEPAGE = "https://github.com/openbiocorpora/bionlp-st-2011-id"
+
+_LICENSE = 'GENIA Project License for Annotated Corpora'
+
+_URLs = {
+    "source": "https://github.com/openbiocorpora/bionlp-st-2011-id/archive/refs/heads/master.zip",
+    "bigbio_kb": "https://github.com/openbiocorpora/bionlp-st-2011-id/archive/refs/heads/master.zip",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.EVENT_EXTRACTION,
+    Tasks.COREFERENCE_RESOLUTION,
+    Tasks.NAMED_ENTITY_RECOGNITION,
+]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class bionlp_st_2011_id(datasets.GeneratorBasedBuilder):
+    """The dataset of the Infectious Diseases (ID) task of
+    BioNLP Shared Task 2011."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="bionlp_st_2011_id_source",
+            version=SOURCE_VERSION,
+            description="bionlp_st_2011_id source schema",
+            schema="source",
+            subset_id="bionlp_st_2011_id",
+        ),
+        BigBioConfig(
+            name="bionlp_st_2011_id_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="bionlp_st_2011_id BigBio schema",
+            schema="bigbio_kb",
+            subset_id="bionlp_st_2011_id",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "bionlp_st_2011_id_source"
+
+    _ROLE_MAPPING = {
+        "Theme1": "Theme",
+        "Theme2": "Theme",
+        "Site1": "Site",
+        "Site2": "Site",
+    }
+
+    def _info(self):
+        """
+        - `features` defines the schema of the parsed data set. The schema depends on the
+        chosen `config`: If it is `_SOURCE_VIEW_NAME` the schema is the schema of the
+        original data. If `config` is `_UNIFIED_VIEW_NAME`, then the schema is the
+        canonical KB-task schema defined in `biomedical/schemas/kb.py`.
+        """
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "trigger": datasets.Value(
+                                "string"
+                            ),  # refers to the text_bound_annotation of the trigger,
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arguments": datasets.Sequence(
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "attributes": [  # M or A lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value(
+                                "string"
+                            ),  # Name of the resource, e.g. "Wikipedia"
+                            "cuid": datasets.Value(
+                                "string"
+                            ),  # ID in the resource, e.g. 534366
+                            "text": datasets.Value(
+                                "string"
+                            ),  # Human readable description/name of the entity, e.g. "Barack Obama"
+                        }
+                    ],
+                },
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+
+        my_urls = _URLs[self.config.schema]
+        data_dir = Path(dl_manager.download_and_extract(my_urls))
+        data_files = {
+            "train": data_dir / f"bionlp-st-2011-id-master" / "original-data" / "train",
+            "dev": data_dir / f"bionlp-st-2011-id-master" / "original-data" / "devel",
+            "test": data_dir / f"bionlp-st-2011-id-master" / "original-data" / "test",
+        }
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"data_files": data_files["train"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"data_files": data_files["dev"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"data_files": data_files["test"]},
+            ),
+        ]
+
+    def _standardize_arguments_roles(self, kb_example: Dict) -> Dict:
+
+        for event in kb_example["events"]:
+            for argument in event["arguments"]:
+                role = argument["role"]
+                argument["role"] = self._ROLE_MAPPING.get(role, role)
+
+        return kb_example
+
+    def _generate_examples(self, data_files: Path):
+        if self.config.schema == "source":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.parse_brat_file(txt_file)
+                example["id"] = str(guid)
+                yield guid, example
+        elif self.config.schema == "bigbio_kb":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.brat_parse_to_bigbio_kb(
+                    parsing.parse_brat_file(txt_file)
+                )
+                example = self._standardize_arguments_roles(example)
+                example["id"] = str(guid)
+                yield guid, example
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/hub/hubscripts/bionlp_st_2011_rel_hub.py
+++ b/hub/hubscripts/bionlp_st_2011_rel_hub.py
@@ -1,0 +1,250 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import List
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "bionlp_st_2011_rel"
+_DISPLAYNAME = "BioNLP 2011 REL"
+
+_SOURCE_VIEW_NAME = "source"
+_UNIFIED_VIEW_NAME = "bigbio"
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{10.5555/2107691.2107703,
+author = {Pyysalo, Sampo and Ohta, Tomoko and Tsujii, Jun'ichi},
+title = {Overview of the Entity Relations (REL) Supporting Task of BioNLP Shared Task 2011},
+year = {2011},
+isbn = {9781937284091},
+publisher = {Association for Computational Linguistics},
+address = {USA},
+abstract = {This paper presents the Entity Relations (REL) task,
+a supporting task of the BioNLP Shared Task 2011. The task concerns
+the extraction of two types of part-of relations between a gene/protein
+and an associated entity. Four teams submitted final results for
+the REL task, with the highest-performing system achieving 57.7%
+F-score. While experiments suggest use of the data can help improve
+event extraction performance, the task data has so far received only
+limited use in support of event extraction. The REL task continues
+as an open challenge, with all resources available from the shared
+task website.},
+booktitle = {Proceedings of the BioNLP Shared Task 2011 Workshop},
+pages = {83–88},
+numpages = {6},
+location = {Portland, Oregon},
+series = {BioNLP Shared Task '11}
+}
+"""
+
+_DESCRIPTION = """\
+The Entity Relations (REL) task is a supporting task of the BioNLP Shared Task 2011.
+The task concerns the extraction of two types of part-of relations between a
+gene/protein and an associated entity.
+"""
+
+_HOMEPAGE = "https://github.com/openbiocorpora/bionlp-st-2011-rel"
+
+_LICENSE = 'GENIA Project License for Annotated Corpora'
+
+_URLs = {
+    "source": "https://github.com/openbiocorpora/bionlp-st-2011-rel/archive/refs/heads/master.zip",
+    "bigbio_kb": "https://github.com/openbiocorpora/bionlp-st-2011-rel/archive/refs/heads/master.zip",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.RELATION_EXTRACTION,
+    Tasks.COREFERENCE_RESOLUTION,
+]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class bionlp_st_2011_rel(datasets.GeneratorBasedBuilder):
+    """The Entity Relations (REL) task is a supporting task of the BioNLP Shared Task 2011."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="bionlp_st_2011_rel_source",
+            version=SOURCE_VERSION,
+            description="bionlp_st_2011_rel source schema",
+            schema="source",
+            subset_id="bionlp_st_2011_rel",
+        ),
+        BigBioConfig(
+            name="bionlp_st_2011_rel_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="bionlp_st_2011_rel BigBio schema",
+            schema="bigbio_kb",
+            subset_id="bionlp_st_2011_rel",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "bionlp_st_2011_rel_source"
+
+    _FILE_SUFFIX = [".a1", ".rel", ".ann"]
+
+    def _info(self):
+        """
+        - `features` defines the schema of the parsed data set. The schema depends on the
+        chosen `config`: If it is `_SOURCE_VIEW_NAME` the schema is the schema of the
+        original data. If `config` is `_UNIFIED_VIEW_NAME`, then the schema is the
+        canonical KB-task schema defined in `biomedical/schemas/kb.py`.
+        """
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "trigger": datasets.Value(
+                                "string"
+                            ),  # refers to the text_bound_annotation of the trigger,
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arguments": datasets.Sequence(
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "attributes": [  # M or A lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value(
+                                "string"
+                            ),  # Name of the resource, e.g. "Wikipedia"
+                            "cuid": datasets.Value(
+                                "string"
+                            ),  # ID in the resource, e.g. 534366
+                            "text": datasets.Value(
+                                "string"
+                            ),  # Human readable description/name of the entity, e.g. "Barack Obama"
+                        }
+                    ],
+                },
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+
+        my_urls = _URLs[self.config.schema]
+        data_dir = Path(dl_manager.download_and_extract(my_urls))
+        data_files = {
+            "train": data_dir
+            / f"bionlp-st-2011-rel-master"
+            / "original-data"
+            / "train",
+            "dev": data_dir / f"bionlp-st-2011-rel-master" / "original-data" / "devel",
+            "test": data_dir / f"bionlp-st-2011-rel-master" / "original-data" / "test",
+        }
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"data_files": data_files["train"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"data_files": data_files["dev"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"data_files": data_files["test"]},
+            ),
+        ]
+
+    def _generate_examples(self, data_files: Path):
+        if self.config.schema == "source":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.parse_brat_file(txt_file, self._FILE_SUFFIX)
+                example["id"] = str(guid)
+                yield guid, example
+        elif self.config.schema == "bigbio_kb":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.brat_parse_to_bigbio_kb(
+                    parsing.parse_brat_file(txt_file, self._FILE_SUFFIX)
+                )
+                example["id"] = str(guid)
+                yield guid, example
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/hub/hubscripts/bionlp_st_2013_cg_hub.py
+++ b/hub/hubscripts/bionlp_st_2013_cg_hub.py
@@ -1,0 +1,268 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Dict, List
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "bionlp_st_2013_cg"
+_DISPLAYNAME = "BioNLP 2013 CG"
+
+_UNIFIED_VIEW_NAME = "bigbio"
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{pyysalo-etal-2013-overview,
+    title = "Overview of the Cancer Genetics ({CG}) task of {B}io{NLP} Shared Task 2013",
+    author = "Pyysalo, Sampo  and
+      Ohta, Tomoko  and
+      Ananiadou, Sophia",
+    booktitle = "Proceedings of the {B}io{NLP} Shared Task 2013 Workshop",
+    month = aug,
+    year = "2013",
+    address = "Sofia, Bulgaria",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/W13-2008",
+    pages = "58--66",
+}
+"""
+
+_DESCRIPTION = """\
+the Cancer Genetics (CG) is a event extraction task and a main task of the BioNLP Shared Task (ST) 2013.
+The CG task is an information extraction task targeting the recognition of events in text,
+represented as structured n-ary associations of given physical entities. In addition to
+addressing the cancer domain, the CG task is differentiated from previous event extraction
+tasks in the BioNLP ST series in addressing a wide range of pathological processes and multiple
+levels of biological organization, ranging from the molecular through the cellular and organ
+levels up to whole organisms. Final test set submissions were accepted from six teams
+"""
+
+_HOMEPAGE = "https://github.com/openbiocorpora/bionlp-st-2013-cg"
+
+_LICENSE = 'GENIA Project License for Annotated Corpora'
+
+_URLs = {
+    "bionlp_st_2013_cg": "https://github.com/openbiocorpora/bionlp-st-2013-cg/archive/refs/heads/master.zip",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.EVENT_EXTRACTION,
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.COREFERENCE_RESOLUTION,
+]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class bionlp_st_2013_cg(datasets.GeneratorBasedBuilder):
+    """the Cancer Genetics (CG) is a event extraction task
+    and a main task of the BioNLP Shared Task (ST) 2013."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="bionlp_st_2013_cg_source",
+            version=SOURCE_VERSION,
+            description="bionlp_st_2013 source schema",
+            schema="source",
+            subset_id="bionlp_st_2013_pc",
+        ),
+        BigBioConfig(
+            name="bionlp_st_2013_cg_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="bionlp_st_2013_cg BigBio schema",
+            schema="bigbio_kb",
+            subset_id="bionlp_st_2013_pc",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "bionlp_st_2013_cg_source"
+
+    _ROLE_MAPPING = {
+        "Theme2": "Theme",
+        "Theme3": "Theme",
+        "Theme4": "Theme",
+        "Theme5": "Theme",
+        "Theme6": "Theme",
+        "Instrument2": "Instrument",
+        "Instrument3": "Instrument",
+        "Participant2": "Participant",
+        "Participant3": "Participant",
+        "Participant4": "Participant",
+        "Cause2": "Cause",
+    }
+
+    def _info(self):
+        """
+        - `features` defines the schema of the parsed data set. The schema depends on the
+        chosen `config`: If it is `_SOURCE_VIEW_NAME` the schema is the schema of the
+        original data. If `config` is `_UNIFIED_VIEW_NAME`, then the schema is the
+        canonical KB-task schema defined in `biomedical/schemas/kb.py`.
+        """
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "trigger": datasets.Value(
+                                "string"
+                            ),  # refers to the text_bound_annotation of the trigger,
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arguments": datasets.Sequence(
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "attributes": [  # M or A lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value(
+                                "string"
+                            ),  # Name of the resource, e.g. "Wikipedia"
+                            "cuid": datasets.Value(
+                                "string"
+                            ),  # ID in the resource, e.g. 534366
+                            "text": datasets.Value(
+                                "string"
+                            ),  # Human readable description/name of the entity, e.g. "Barack Obama"
+                        }
+                    ],
+                },
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+        return datasets.DatasetInfo(
+            # This is the description that will appear on the datasets page.
+            description=_DESCRIPTION,
+            features=features,
+            # If there's a common (input, target) tuple from the features, uncomment supervised_keys line below and
+            # specify them. They'll be used if as_supervised=True in builder.as_dataset.
+            # This is not applicable for MLEE.
+            # supervised_keys=("sentence", "label"),
+            # Homepage of the dataset for documentation
+            homepage=_HOMEPAGE,
+            # License for the dataset if available
+            license=str(_LICENSE),
+            # Citation for the dataset
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+        my_urls = _URLs[_DATASETNAME]
+        data_dir = Path(dl_manager.download_and_extract(my_urls))
+        data_files = {
+            "train": data_dir / f"bionlp-st-2013-cg-master" / "original-data" / "train",
+            "dev": data_dir / f"bionlp-st-2013-cg-master" / "original-data" / "devel",
+            "test": data_dir / f"bionlp-st-2013-cg-master" / "original-data" / "test",
+        }
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"data_files": data_files["train"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"data_files": data_files["dev"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"data_files": data_files["test"]},
+            ),
+        ]
+
+    def _standardize_arguments_roles(self, kb_example: Dict) -> Dict:
+
+        for event in kb_example["events"]:
+            for argument in event["arguments"]:
+                role = argument["role"]
+                argument["role"] = self._ROLE_MAPPING.get(role, role)
+
+        return kb_example
+
+    def _generate_examples(self, data_files: Path):
+        if self.config.schema == "source":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.parse_brat_file(txt_file)
+                example["id"] = str(guid)
+                yield guid, example
+        elif self.config.schema == "bigbio_kb":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.brat_parse_to_bigbio_kb(
+                    parsing.parse_brat_file(txt_file)
+                )
+                example = self._standardize_arguments_roles(example)
+                example["id"] = str(guid)
+                yield guid, example
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/hub/hubscripts/bionlp_st_2013_ge_hub.py
+++ b/hub/hubscripts/bionlp_st_2013_ge_hub.py
@@ -1,0 +1,238 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import List
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "bionlp_st_2013_ge"
+_DISPLAYNAME = "BioNLP 2013 GE"
+
+_SOURCE_VIEW_NAME = "source"
+_UNIFIED_VIEW_NAME = "bigbio"
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{kim-etal-2013-genia,
+    title = "The {G}enia Event Extraction Shared Task, 2013 Edition - Overview",
+    author = "Kim, Jin-Dong  and
+      Wang, Yue  and
+      Yasunori, Yamamoto",
+    booktitle = "Proceedings of the {B}io{NLP} Shared Task 2013 Workshop",
+    month = aug,
+    year = "2013",
+    address = "Sofia, Bulgaria",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/W13-2002",
+    pages = "8--15",
+}
+"""
+
+_DESCRIPTION = """\
+The BioNLP-ST GE task has been promoting development of fine-grained
+information extraction (IE) from biomedical
+documents, since 2009. Particularly, it has focused on the domain of
+NFkB as a model domain of Biomedical IE
+"""
+
+_HOMEPAGE = "https://github.com/openbiocorpora/bionlp-st-2013-ge"
+
+_LICENSE = 'GENIA Project License for Annotated Corpora'
+
+_URLs = {
+    "source": "https://github.com/openbiocorpora/bionlp-st-2013-ge/archive/refs/heads/master.zip",
+    "bigbio_kb": "https://github.com/openbiocorpora/bionlp-st-2013-ge/archive/refs/heads/master.zip",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.EVENT_EXTRACTION,
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.RELATION_EXTRACTION,
+    Tasks.COREFERENCE_RESOLUTION,
+]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class bionlp_st_2013_ge(datasets.GeneratorBasedBuilder):
+    """The BioNLP-ST GE task has been promoting development of fine-grained information extraction (IE) from biomedical
+    documents, since 2009. Particularly, it has focused on the domain of NFkB as a model domain of Biomedical IE"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="bionlp_st_2013_ge_source",
+            version=SOURCE_VERSION,
+            description="bionlp_st_2013_ge source schema",
+            schema="source",
+            subset_id="bionlp_st_2013_ge",
+        ),
+        BigBioConfig(
+            name="bionlp_st_2013_ge_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="bionlp_st_2013_ge BigBio schema",
+            schema="bigbio_kb",
+            subset_id="bionlp_st_2013_ge",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "bionlp_st_2013_ge_source"
+
+    def _info(self):
+        """
+        - `features` defines the schema of the parsed data set. The schema depends on the
+        chosen `config`: If it is `_SOURCE_VIEW_NAME` the schema is the schema of the
+        original data. If `config` is `_UNIFIED_VIEW_NAME`, then the schema is the
+        canonical KB-task schema defined in `biomedical/schemas/kb.py`.
+        """
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "trigger": datasets.Value(
+                                "string"
+                            ),  # refers to the text_bound_annotation of the trigger,
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arguments": datasets.Sequence(
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "attributes": [  # M or A lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value(
+                                "string"
+                            ),  # Name of the resource, e.g. "Wikipedia"
+                            "cuid": datasets.Value(
+                                "string"
+                            ),  # ID in the resource, e.g. 534366
+                            "text": datasets.Value(
+                                "string"
+                            ),  # Human readable description/name of the entity, e.g. "Barack Obama"
+                        }
+                    ],
+                },
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+
+        my_urls = _URLs[self.config.schema]
+        data_dir = Path(dl_manager.download_and_extract(my_urls))
+        data_files = {
+            "train": data_dir / f"bionlp-st-2013-ge-master" / "original-data" / "train",
+            "dev": data_dir / f"bionlp-st-2013-ge-master" / "original-data" / "devel",
+            "test": data_dir / f"bionlp-st-2013-ge-master" / "original-data" / "test",
+        }
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"data_files": data_files["train"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"data_files": data_files["dev"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"data_files": data_files["test"]},
+            ),
+        ]
+
+    def _generate_examples(self, data_files: Path):
+        if self.config.schema == "source":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.parse_brat_file(txt_file)
+                example["id"] = str(guid)
+                yield guid, example
+        elif self.config.schema == "bigbio_kb":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.brat_parse_to_bigbio_kb(
+                    parsing.parse_brat_file(txt_file)
+                )
+                example["id"] = str(guid)
+                yield guid, example
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/hub/hubscripts/bionlp_st_2013_gro_hub.py
+++ b/hub/hubscripts/bionlp_st_2013_gro_hub.py
@@ -1,0 +1,240 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pathlib import Path
+from typing import List
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "bionlp_st_2013_gro"
+_DISPLAYNAME = "BioNLP 2013 GRO"
+
+_SOURCE_VIEW_NAME = "source"
+_UNIFIED_VIEW_NAME = "bigbio"
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{kim-etal-2013-gro,
+    title = "{GRO} Task: Populating the Gene Regulation Ontology with events and relations",
+    author = "Kim, Jung-jae  and
+      Han, Xu  and
+      Lee, Vivian  and
+      Rebholz-Schuhmann, Dietrich",
+    booktitle = "Proceedings of the {B}io{NLP} Shared Task 2013 Workshop",
+    month = aug,
+    year = "2013",
+    address = "Sofia, Bulgaria",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/W13-2007",
+    pages = "50--57",
+}
+"""
+
+_DESCRIPTION = """\
+GRO Task: Populating the Gene Regulation Ontology with events and
+relations. A data set from the bio NLP shared tasks competition from 2013
+"""
+
+_HOMEPAGE = "https://github.com/openbiocorpora/bionlp-st-2013-gro"
+
+_LICENSE = 'GENIA Project License for Annotated Corpora'
+
+_URLs = {
+    "source": "https://github.com/openbiocorpora/bionlp-st-2013-gro/archive/refs/heads/master.zip",
+    "bigbio_kb": "https://github.com/openbiocorpora/bionlp-st-2013-gro/archive/refs/heads/master.zip",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.EVENT_EXTRACTION,
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.RELATION_EXTRACTION,
+]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class bionlp_st_2013_gro(datasets.GeneratorBasedBuilder):
+    """GRO Task: Populating the Gene Regulation Ontology with events and
+    relations. A data set from the bio NLP shared tasks competition from 2013"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="bionlp_st_2013_gro_source",
+            version=SOURCE_VERSION,
+            description="bionlp_st_2013_gro source schema",
+            schema="source",
+            subset_id="bionlp_st_2013_gro",
+        ),
+        BigBioConfig(
+            name="bionlp_st_2013_gro_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="bionlp_st_2013_gro BigBio schema",
+            schema="bigbio_kb",
+            subset_id="bionlp_st_2013_gro",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "bionlp_st_2013_gro_source"
+
+    def _info(self):
+        """
+        - `features` defines the schema of the parsed data set. The schema depends on the
+        chosen `config`: If it is `_SOURCE_VIEW_NAME` the schema is the schema of the
+        original data. If `config` is `_UNIFIED_VIEW_NAME`, then the schema is the
+        canonical KB-task schema defined in `biomedical/schemas/kb.py`.
+        """
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "trigger": datasets.Value(
+                                "string"
+                            ),  # refers to the text_bound_annotation of the trigger,
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arguments": datasets.Sequence(
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "attributes": [  # M or A lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value(
+                                "string"
+                            ),  # Name of the resource, e.g. "Wikipedia"
+                            "cuid": datasets.Value(
+                                "string"
+                            ),  # ID in the resource, e.g. 534366
+                            "text": datasets.Value(
+                                "string"
+                            ),  # Human readable description/name of the entity, e.g. "Barack Obama"
+                        }
+                    ],
+                },
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+
+        my_urls = _URLs[self.config.schema]
+        data_dir = Path(dl_manager.download_and_extract(my_urls))
+        data_files = {
+            "train": data_dir
+            / f"bionlp-st-2013-gro-master"
+            / "original-data"
+            / "train",
+            "dev": data_dir / f"bionlp-st-2013-gro-master" / "original-data" / "devel",
+            "test": data_dir / f"bionlp-st-2013-gro-master" / "original-data" / "test",
+        }
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"data_files": data_files["train"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"data_files": data_files["dev"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"data_files": data_files["test"]},
+            ),
+        ]
+
+    def _generate_examples(self, data_files: Path):
+        if self.config.schema == "source":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.parse_brat_file(txt_file)
+                example["id"] = str(guid)
+                yield guid, example
+        elif self.config.schema == "bigbio_kb":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.brat_parse_to_bigbio_kb(
+                    parsing.parse_brat_file(txt_file)
+                )
+                example["id"] = str(guid)
+                yield guid, example
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/hub/hubscripts/bionlp_st_2013_pc_hub.py
+++ b/hub/hubscripts/bionlp_st_2013_pc_hub.py
@@ -1,0 +1,273 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Dict, List
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "bionlp_st_2013_pc"
+_DISPLAYNAME = "BioNLP 2013 PC"
+
+_UNIFIED_VIEW_NAME = "bigbio"
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{ohta-etal-2013-overview,
+    title = "Overview of the Pathway Curation ({PC}) task of {B}io{NLP} Shared Task 2013",
+    author = "Ohta, Tomoko  and
+      Pyysalo, Sampo  and
+      Rak, Rafal  and
+      Rowley, Andrew  and
+      Chun, Hong-Woo  and
+      Jung, Sung-Jae  and
+      Choi, Sung-Pil  and
+      Ananiadou, Sophia  and
+      Tsujii, Jun{'}ichi",
+    booktitle = "Proceedings of the {B}io{NLP} Shared Task 2013 Workshop",
+    month = aug,
+    year = "2013",
+    address = "Sofia, Bulgaria",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/W13-2009",
+    pages = "67--75",
+}
+"""
+
+_DESCRIPTION = """\
+the Pathway Curation (PC) task is a main event extraction task of the BioNLP shared task (ST) 2013.
+The PC task concerns the automatic extraction of biomolecular reactions from text.
+The task setting, representation and semantics are defined with respect to pathway
+model standards and ontologies (SBML, BioPAX, SBO) and documents selected by relevance
+to specific model reactions. Two BioNLP ST 2013 participants successfully completed
+the PC task. The highest achieved F-score, 52.8%, indicates that event extraction is
+a promising approach to supporting pathway curation efforts.
+"""
+
+_HOMEPAGE = "https://github.com/openbiocorpora/bionlp-st-2013-pc"
+
+_LICENSE = 'GENIA Project License for Annotated Corpora'
+
+_URLs = {
+    "bionlp_st_2013_pc": "https://github.com/openbiocorpora/bionlp-st-2013-pc/archive/refs/heads/master.zip",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.EVENT_EXTRACTION,
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.COREFERENCE_RESOLUTION,
+]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class bionlp_st_2013_pc(datasets.GeneratorBasedBuilder):
+    """the Pathway Curation (PC) task is a main event extraction task of the BioNLP shared task (ST) 2013."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="bionlp_st_2013_pc_source",
+            version=SOURCE_VERSION,
+            description="bionlp_st_2013 source schema",
+            schema="source",
+            subset_id="bionlp_st_2013_pc",
+        ),
+        BigBioConfig(
+            name="bionlp_st_2013_pc_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="bionlp_st_2013_pc BigBio schema",
+            schema="bigbio_kb",
+            subset_id="bionlp_st_2013_pc",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "bionlp_st_2013_pc_source"
+
+    _ROLE_MAPPING = {
+        "Theme2": "Theme",
+        "Theme3": "Theme",
+        "Theme4": "Theme",
+        "Participant2": "Participant",
+        "Participant3": "Participant",
+        "Participant4": "Participant",
+        "Participant5": "Participant",
+        "Product2": "Product",
+        "Product3": "Product",
+        "Product4": "Product",
+    }
+
+    def _info(self):
+        """
+        - `features` defines the schema of the parsed data set. The schema depends on the
+        chosen `config`: If it is `_SOURCE_VIEW_NAME` the schema is the schema of the
+        original data. If `config` is `_UNIFIED_VIEW_NAME`, then the schema is the
+        canonical KB-task schema defined in `biomedical/schemas/kb.py`.
+        """
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "trigger": datasets.Value(
+                                "string"
+                            ),  # refers to the text_bound_annotation of the trigger,
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arguments": datasets.Sequence(
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "attributes": [  # M or A lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value(
+                                "string"
+                            ),  # Name of the resource, e.g. "Wikipedia"
+                            "cuid": datasets.Value(
+                                "string"
+                            ),  # ID in the resource, e.g. 534366
+                            "text": datasets.Value(
+                                "string"
+                            ),  # Human readable description/name of the entity, e.g. "Barack Obama"
+                        }
+                    ],
+                },
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            # This is the description that will appear on the datasets page.
+            description=_DESCRIPTION,
+            features=features,
+            # If there's a common (input, target) tuple from the features, uncomment supervised_keys line below and
+            # specify them. They'll be used if as_supervised=True in builder.as_dataset.
+            # This is not applicable for MLEE.
+            # supervised_keys=("sentence", "label"),
+            # Homepage of the dataset for documentation
+            homepage=_HOMEPAGE,
+            # License for the dataset if available
+            license=str(_LICENSE),
+            # Citation for the dataset
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+        my_urls = _URLs[_DATASETNAME]
+        data_dir = Path(dl_manager.download_and_extract(my_urls))
+        data_files = {
+            "train": data_dir / f"bionlp-st-2013-pc-master" / "original-data" / "train",
+            "dev": data_dir / f"bionlp-st-2013-pc-master" / "original-data" / "devel",
+            "test": data_dir / f"bionlp-st-2013-pc-master" / "original-data" / "test",
+        }
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"data_files": data_files["train"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"data_files": data_files["dev"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"data_files": data_files["test"]},
+            ),
+        ]
+
+    def _standardize_arguments_roles(self, kb_example: Dict) -> Dict:
+
+        for event in kb_example["events"]:
+            for argument in event["arguments"]:
+                role = argument["role"]
+                argument["role"] = self._ROLE_MAPPING.get(role, role)
+
+        return kb_example
+
+    def _generate_examples(self, data_files: Path):
+        if self.config.schema == "source":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.parse_brat_file(txt_file)
+                example["id"] = str(guid)
+                yield guid, example
+        elif self.config.schema == "bigbio_kb":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.brat_parse_to_bigbio_kb(
+                    parsing.parse_brat_file(txt_file)
+                )
+                example = self._standardize_arguments_roles(example)
+                example["id"] = str(guid)
+                yield guid, example
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/hub/hubscripts/bionlp_st_2019_bb_hub.py
+++ b/hub/hubscripts/bionlp_st_2019_bb_hub.py
@@ -1,0 +1,594 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Dict, List
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "bionlp_st_2019_bb"
+_DISPLAYNAME = "BioNLP 2019 BB"
+
+_SOURCE_VIEW_NAME = "source"
+_UNIFIED_VIEW_NAME = "bigbio"
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{bossy-etal-2019-bacteria,
+    title = "Bacteria Biotope at {B}io{NLP} Open Shared Tasks 2019",
+    author = "Bossy, Robert  and
+      Del{\'e}ger, Louise  and
+      Chaix, Estelle  and
+      Ba, Mouhamadou  and
+      N{\'e}dellec, Claire",
+    booktitle = "Proceedings of The 5th Workshop on BioNLP Open Shared Tasks",
+    month = nov,
+    year = "2019",
+    address = "Hong Kong, China",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/D19-5719",
+    doi = "10.18653/v1/D19-5719",
+    pages = "121--131",
+    abstract = "This paper presents the fourth edition of the Bacteria
+    Biotope task at BioNLP Open Shared Tasks 2019. The task focuses on
+    the extraction of the locations and phenotypes of microorganisms
+    from PubMed abstracts and full-text excerpts, and the characterization
+    of these entities with respect to reference knowledge sources (NCBI
+    taxonomy, OntoBiotope ontology). The task is motivated by the importance
+    of the knowledge on biodiversity for fundamental research and applications
+    in microbiology. The paper describes the different proposed subtasks, the
+    corpus characteristics, and the challenge organization. We also provide an
+    analysis of the results obtained by participants, and inspect the evolution
+    of the results since the last edition in 2016.",
+}
+"""
+
+_DESCRIPTION = """\
+The task focuses on the extraction of the locations and phenotypes of
+microorganisms from PubMed abstracts and full-text excerpts, and the
+characterization of these entities with respect to reference knowledge
+sources (NCBI taxonomy, OntoBiotope ontology). The task is motivated by
+the importance of the knowledge on biodiversity for fundamental research
+and applications in microbiology.
+
+"""
+
+_HOMEPAGE = "https://sites.google.com/view/bb-2019/dataset"
+
+_LICENSE = 'License information unavailable'
+
+_URLs = {
+    "source": {
+        "norm": {
+            "train": "https://drive.google.com/uc?export=download&id=1aXbshxgytZ1Dhbmw7OULPFarPO1FbcM3",
+            "dev": "https://drive.google.com/uc?export=download&id=14jRZWF8VeluEYrV9EybV3LeGm4q5nH6s",
+            "test": "https://drive.google.com/uc?export=download&id=1BPDCFTVMmIlOowYA-DkeNNFjwTfHYPG6",
+        },
+        "norm+ner": {
+            "train": "https://drive.google.com/uc?export=download&id=1yKxBPMej8EYdVeU4QS1xquFfXM76F-2K",
+            "dev": "https://drive.google.com/uc?export=download&id=1Xk7h9bax533QWclO3Ur7aS07OATBF_bG",
+            "test": "https://drive.google.com/uc?export=download&id=1Cb5hQIPS3LIeUL-UWdqyWfKB52xUz9cp",
+        },
+        "rel": {
+            "train": "https://drive.google.com/uc?export=download&id=1gnc-ScNpssC3qrA7cVox4Iei7i96sYqC",
+            "dev": "https://drive.google.com/uc?export=download&id=1wJM9XOfmvIBcX23t9bzQX5fLZwWQJIwS",
+            "test": "https://drive.google.com/uc?export=download&id=1smhKA4LEPK5UJEyBLseq0mBaT9REUevu",
+        },
+        "rel+ner": {
+            "train": "https://drive.google.com/uc?export=download&id=1CPx9NxTPQbygqMtxw3d0hNFajhecqgss",
+            "dev": "https://drive.google.com/uc?export=download&id=1lVyCCuAJ5TmmTDz4S0dISBNiWGR745_7",
+            "test": "https://drive.google.com/uc?export=download&id=1uE8oY5m-7mSA-W-e6vownnAVV97IwHhA",
+        },
+        "kb": {
+            "train": "https://drive.google.com/uc?export=download&id=1Iuce3T_IArXWBbIJ7RXb_STaPnWKQBN-",
+            "dev": "https://drive.google.com/uc?export=download&id=14yON_Tc9dm8esWYDVxL-krw23sgTCcdL",
+            "test": "https://drive.google.com/uc?export=download&id=1wVqI_t9mirGUk71BkwkcKJv0VNGyaHDs",
+        },
+        "kb+ner": {
+            "train": "https://drive.google.com/uc?export=download&id=1WMl9eD4OZXq8zkkmHp3hSEvAqaAVui6L",
+            "dev": "https://drive.google.com/uc?export=download&id=1oOfOfjIfg1XnesXwaKvSDfqgnchuximG",
+            "test": "https://drive.google.com/uc?export=download&id=1_dRbgpGJUBCfF-iN2qOAgOBRvYmE7byW",
+        },
+    },
+    "bigbio_kb": {
+        "kb+ner": {
+            "train": "https://drive.google.com/uc?export=download&id=1WMl9eD4OZXq8zkkmHp3hSEvAqaAVui6L",
+            "dev": "https://drive.google.com/uc?export=download&id=1oOfOfjIfg1XnesXwaKvSDfqgnchuximG",
+            "test": "https://drive.google.com/uc?export=download&id=1_dRbgpGJUBCfF-iN2qOAgOBRvYmE7byW",
+        },
+    },
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.NAMED_ENTITY_DISAMBIGUATION,
+    Tasks.RELATION_EXTRACTION,
+]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class bionlp_st_2019_bb(datasets.GeneratorBasedBuilder):
+    """This dataset is the fourth edition of the Bacteria
+    Biotope task at BioNLP Open Shared Tasks 2019"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="bionlp_st_2019_bb_norm_source",
+            version=SOURCE_VERSION,
+            description="bionlp_st_2019_bb entity normalization source schema",
+            schema="source",
+            subset_id="bionlp_st_2019_bb",
+        ),
+        BigBioConfig(
+            name="bionlp_st_2019_bb_norm+ner_source",
+            version=SOURCE_VERSION,
+            description="bionlp_st_2019_bb entity recognition and normalization source schema",
+            schema="source",
+            subset_id="bionlp_st_2019_bb",
+        ),
+        BigBioConfig(
+            name="bionlp_st_2019_bb_rel_source",
+            version=SOURCE_VERSION,
+            description="bionlp_st_2019_bb relation extraction source schema",
+            schema="source",
+            subset_id="bionlp_st_2019_bb",
+        ),
+        BigBioConfig(
+            name="bionlp_st_2019_bb_rel+ner_source",
+            version=SOURCE_VERSION,
+            description="bionlp_st_2019_bb entity recognition and relation extraction source schema",
+            schema="source",
+            subset_id="bionlp_st_2019_bb",
+        ),
+        BigBioConfig(
+            name="bionlp_st_2019_bb_kb_source",
+            version=SOURCE_VERSION,
+            description="bionlp_st_2019_bb entity normalization and relation extraction source schema",
+            schema="source",
+            subset_id="bionlp_st_2019_bb",
+        ),
+        BigBioConfig(
+            name="bionlp_st_2019_bb_kb+ner_source",
+            version=SOURCE_VERSION,
+            description="bionlp_st_2019_bb entity recognition and normalization and relation extraction source schema",
+            schema="source",
+            subset_id="bionlp_st_2019_bb",
+        ),
+        BigBioConfig(
+            name="bionlp_st_2019_bb_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="bionlp_st_2019_bb BigBio schema",
+            schema="bigbio_kb",
+            subset_id="bionlp_st_2019_bb",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "bionlp_st_2019_bb_kb+ner_source"
+
+    def _info(self):
+        """
+        - `features` defines the schema of the parsed data set. The schema depends on the
+        chosen `config`: If it is `_SOURCE_VIEW_NAME` the schema is the schema of the
+        original data. If `config` is `_UNIFIED_VIEW_NAME`, then the schema is the
+        canonical KB-task schema defined in `biomedical/schemas/kb.py`.
+        """
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "trigger": datasets.Value(
+                                "string"
+                            ),  # refers to the text_bound_annotation of the trigger,
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arguments": datasets.Sequence(
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "attributes": [  # M or A lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value(
+                                "string"
+                            ),  # Name of the resource, e.g. "Wikipedia"
+                            "cuid": datasets.Value(
+                                "string"
+                            ),  # ID in the resource, e.g. 534366
+                        }
+                    ],
+                },
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+        version = self.config.name.split("_")[-2]
+        if version == "bigbio":
+            version = "kb+ner"
+        my_urls = _URLs[self.config.schema][version]
+        data_files = {
+            "train": Path(dl_manager.download_and_extract(my_urls["train"]))
+            / f"BioNLP-OST-2019_BB-{version}_train",
+            "dev": Path(dl_manager.download_and_extract(my_urls["dev"]))
+            / f"BioNLP-OST-2019_BB-{version}_dev",
+            "test": Path(dl_manager.download_and_extract(my_urls["test"]))
+            / f"BioNLP-OST-2019_BB-{version}_test",
+        }
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"data_files": data_files["train"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"data_files": data_files["dev"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"data_files": data_files["test"]},
+            ),
+        ]
+
+    def _generate_examples(self, data_files: Path):
+        if self.config.schema == "source":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = self.parse_brat_file(txt_file)
+                example["id"] = str(guid)
+                yield guid, example
+        elif self.config.schema == "bigbio_kb":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.brat_parse_to_bigbio_kb(
+                    self.parse_brat_file(txt_file)
+                )
+                example["id"] = str(guid)
+                yield guid, example
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")
+
+    def parse_brat_file(
+        self,
+        txt_file: Path,
+        annotation_file_suffixes: List[str] = None,
+        parse_notes: bool = False,
+    ) -> Dict:
+        """
+        Parse a brat file into the schema defined below.
+        `txt_file` should be the path to the brat '.txt' file you want to parse, e.g. 'data/1234.txt'
+        Assumes that the annotations are contained in one or more of the corresponding '.a1', '.a2' or '.ann' files,
+        e.g. 'data/1234.ann' or 'data/1234.a1' and 'data/1234.a2'.
+
+        Will include annotator notes, when `parse_notes == True`.
+
+        brat_features = datasets.Features(
+            {
+                "id": datasets.Value("string"),
+                "document_id": datasets.Value("string"),
+                "text": datasets.Value("string"),
+                "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                    {
+                        "offsets": datasets.Sequence([datasets.Value("int32")]),
+                        "text": datasets.Sequence(datasets.Value("string")),
+                        "type": datasets.Value("string"),
+                        "id": datasets.Value("string"),
+                    }
+                ],
+                "events": [  # E line in brat
+                    {
+                        "trigger": datasets.Value(
+                            "string"
+                        ),  # refers to the text_bound_annotation of the trigger,
+                        "id": datasets.Value("string"),
+                        "type": datasets.Value("string"),
+                        "arguments": datasets.Sequence(
+                            {
+                                "role": datasets.Value("string"),
+                                "ref_id": datasets.Value("string"),
+                            }
+                        ),
+                    }
+                ],
+                "relations": [  # R line in brat
+                    {
+                        "id": datasets.Value("string"),
+                        "head": {
+                            "ref_id": datasets.Value("string"),
+                            "role": datasets.Value("string"),
+                        },
+                        "tail": {
+                            "ref_id": datasets.Value("string"),
+                            "role": datasets.Value("string"),
+                        },
+                        "type": datasets.Value("string"),
+                    }
+                ],
+                "equivalences": [  # Equiv line in brat
+                    {
+                        "id": datasets.Value("string"),
+                        "ref_ids": datasets.Sequence(datasets.Value("string")),
+                    }
+                ],
+                "attributes": [  # M or A lines in brat
+                    {
+                        "id": datasets.Value("string"),
+                        "type": datasets.Value("string"),
+                        "ref_id": datasets.Value("string"),
+                        "value": datasets.Value("string"),
+                    }
+                ],
+                "normalizations": [  # N lines in brat
+                    {
+                        "id": datasets.Value("string"),
+                        "type": datasets.Value("string"),
+                        "ref_id": datasets.Value("string"),
+                        "resource_name": datasets.Value(
+                            "string"
+                        ),  # Name of the resource, e.g. "Wikipedia"
+                        "cuid": datasets.Value(
+                            "string"
+                        ),  # ID in the resource, e.g. 534366
+                        "text": datasets.Value(
+                            "string"
+                        ),  # Human readable description/name of the entity, e.g. "Barack Obama"
+                    }
+                ],
+                ### OPTIONAL: Only included when `parse_notes == True`
+                "notes": [  # # lines in brat
+                    {
+                        "id": datasets.Value("string"),
+                        "type": datasets.Value("string"),
+                        "ref_id": datasets.Value("string"),
+                        "text": datasets.Value("string"),
+                    }
+                ],
+            },
+            )
+        """
+
+        example = {}
+        example["document_id"] = txt_file.with_suffix("").name
+        with txt_file.open(encoding="utf-8") as f:
+            if self.config.schema == "bigbio_kb":
+                example["text"] = f.read().replace("\u00A0", " ").replace("\n", " ")
+            else:
+                example["text"] = f.read()
+
+        # If no specific suffixes of the to-be-read annotation files are given - take standard suffixes
+        # for event extraction
+        if annotation_file_suffixes is None:
+            annotation_file_suffixes = [".a1", ".a2", ".ann"]
+
+        if len(annotation_file_suffixes) == 0:
+            raise AssertionError(
+                "At least one suffix for the to-be-read annotation files should be given!"
+            )
+
+        ann_lines = []
+        for suffix in annotation_file_suffixes:
+            annotation_file = txt_file.with_suffix(suffix)
+            if annotation_file.exists():
+                with annotation_file.open(encoding="utf8") as f:
+                    ann_lines.extend(f.readlines())
+
+        example["text_bound_annotations"] = []
+        example["events"] = []
+        example["relations"] = []
+        example["equivalences"] = []
+        example["attributes"] = []
+        example["normalizations"] = []
+
+        if parse_notes:
+            example["notes"] = []
+
+        for line in ann_lines:
+            line = line.strip()
+            if not line:
+                continue
+
+            if line.startswith("T"):  # Text bound
+                ann = {}
+                fields = line.split("\t")
+                ann["id"] = fields[0]
+                ann["type"] = fields[1].split()[0]
+                if ann["type"] in ["Title", "Paragraph"]:
+                    continue
+                ann["offsets"] = []
+                span_str = parsing.remove_prefix(fields[1], (ann["type"] + " "))
+                text = fields[2]
+                for span in span_str.split(";"):
+                    start, end = span.split()
+                    ann["offsets"].append([int(start), int(end)])
+
+                # Heuristically split text of discontiguous entities into chunks
+                ann["text"] = []
+                if len(ann["offsets"]) > 1:
+                    i = 0
+                    for start, end in ann["offsets"]:
+                        chunk_len = end - start
+                        if self.config.schema == "bigbio_kb":
+                            ann["text"].append(
+                                text[i : chunk_len + i].replace("\u00A0", " ")
+                            )
+                        else:
+                            ann["text"].append(text[i : chunk_len + i])
+                        i += chunk_len
+                        while i < len(text) and text[i] == " ":
+                            i += 1
+                else:
+                    if self.config.schema == "bigbio_kb":
+                        ann["text"] = [text.replace("\u00A0", " ")]
+                    else:
+                        ann["text"] = [text]
+
+                example["text_bound_annotations"].append(ann)
+
+            elif line.startswith("E"):
+                ann = {}
+                fields = line.split("\t")
+
+                ann["id"] = fields[0]
+
+                ann["type"], ann["trigger"] = fields[1].split()[0].split(":")
+
+                ann["arguments"] = []
+                for role_ref_id in fields[1].split()[1:]:
+                    argument = {
+                        "role": (role_ref_id.split(":"))[0],
+                        "ref_id": (role_ref_id.split(":"))[1],
+                    }
+                    ann["arguments"].append(argument)
+
+                example["events"].append(ann)
+
+            elif line.startswith("R"):
+                ann = {}
+                fields = line.split("\t")
+
+                ann["id"] = fields[0]
+                ann["type"] = fields[1].split()[0]
+
+                ann["head"] = {
+                    "role": fields[1].split()[1].split(":")[0],
+                    "ref_id": fields[1].split()[1].split(":")[1],
+                }
+                ann["tail"] = {
+                    "role": fields[1].split()[2].split(":")[0],
+                    "ref_id": fields[1].split()[2].split(":")[1],
+                }
+
+                example["relations"].append(ann)
+
+            # '*' seems to be the legacy way to mark equivalences,
+            # but I couldn't find any info on the current way
+            # this might have to be adapted dependent on the brat version
+            # of the annotation
+            elif line.startswith("*"):
+                ann = {}
+                fields = line.split("\t")
+
+                ann["id"] = fields[0]
+                ann["ref_ids"] = fields[1].split()[1:]
+
+                example["equivalences"].append(ann)
+
+            elif line.startswith("A") or line.startswith("M"):
+                ann = {}
+                fields = line.split("\t")
+
+                ann["id"] = fields[0]
+
+                info = fields[1].split()
+                ann["type"] = info[0]
+                ann["ref_id"] = info[1]
+
+                if len(info) > 2:
+                    ann["value"] = info[2]
+                else:
+                    ann["value"] = ""
+
+                example["attributes"].append(ann)
+
+            elif line.startswith("N"):
+                ann = {}
+                fields = line.split("\t")
+
+                ann["id"] = fields[0]
+
+                info = fields[1].split()
+
+                ann["ref_id"] = info[1].split(":")[-1]
+                ann["resource_name"] = info[0]
+                ann["cuid"] = "".join(info[2].split(":")[1:])
+                example["normalizations"].append(ann)
+
+            elif parse_notes and line.startswith("#"):
+                ann = {}
+                fields = line.split("\t")
+
+                ann["id"] = fields[0]
+                ann["text"] = fields[2]
+
+                info = fields[1].split()
+
+                ann["type"] = info[0]
+                ann["ref_id"] = info[1]
+                example["notes"].append(ann)
+        return example

--- a/hub/hubscripts/biored_hub.py
+++ b/hub/hubscripts/biored_hub.py
@@ -1,0 +1,323 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Relation Extraction corpus with multiple entity types (e.g., gene/protein,
+disease, chemical) and relation pairs (e.g., gene-disease; chemical-chemical),
+on a set of 600 PubMed articles
+"""
+
+import itertools
+import os
+from typing import Dict, List, Tuple
+
+import datasets
+from bioc import pubtator
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{DBLP:journals/corr/abs-2204-04263,
+  author    = {Ling Luo and
+               Po{-}Ting Lai and
+               Chih{-}Hsuan Wei and
+               Cecilia N. Arighi and
+               Zhiyong Lu},
+  title     = {BioRED: {A} Comprehensive Biomedical Relation Extraction Dataset},
+  journal   = {CoRR},
+  volume    = {abs/2204.04263},
+  year      = {2022},
+  url       = {https://doi.org/10.48550/arXiv.2204.04263},
+  doi       = {10.48550/arXiv.2204.04263},
+  eprinttype = {arXiv},
+  eprint    = {2204.04263},
+  timestamp = {Wed, 11 May 2022 15:24:37 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-2204-04263.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+"""
+
+_DATASETNAME = "biored"
+_DISPLAYNAME = "BioRED"
+
+_DESCRIPTION = """\
+Relation Extraction corpus with multiple entity types (e.g., gene/protein,
+disease, chemical) and relation pairs (e.g., gene-disease; chemical-chemical),
+on a set of 600 PubMed articles
+"""
+
+_HOMEPAGE = "https://ftp.ncbi.nlm.nih.gov/pub/lu/BioRED/"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: "https://ftp.ncbi.nlm.nih.gov/pub/lu/BioRED/BIORED.zip",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+logger = datasets.utils.logging.get_logger(__name__)
+
+
+class BioredDataset(datasets.GeneratorBasedBuilder):
+    """Relation Extraction corpus with multiple entity types (e.g., gene/protein, disease, chemical) and relation pairs (e.g., gene-disease; chemical-chemical), on a set of 600 PubMed articles"""
+
+    # For bigbio_kb, this dataset uses a naming convention as
+    # uid_[title/abstract/relation/entity_id]_[entity/relation_uid]
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name=_DATASETNAME + "_source",
+            version=SOURCE_VERSION,
+            description=_DATASETNAME + " source schema",
+            schema="source",
+            subset_id=_DATASETNAME,
+        ),
+        BigBioConfig(
+            name=_DATASETNAME + "_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description=_DATASETNAME + " BigBio schema",
+            schema="bigbio_kb",
+            subset_id=_DATASETNAME,
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = _DATASETNAME + "_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+
+            features = datasets.Features(
+                {
+                    "pmid": datasets.Value("string"),
+                    "passages": [
+                        {
+                            "type": datasets.Value("string"),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                        }
+                    ],
+                    "entities": [
+                        {
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "concept_id": datasets.Value("string"),
+                            "semantic_type_id": datasets.Sequence(
+                                datasets.Value("string")
+                            ),
+                        }
+                    ],
+                    "relations": [
+                        {
+                            "novel": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "concept_1": datasets.Value("string"),
+                            "concept_2": datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "BioRED", "Train.PubTator"),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "BioRED", "Test.PubTator"),
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "BioRED", "Dev.PubTator"),
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        if self.config.schema == "source":
+            with open(filepath, "r", encoding="utf8") as fstream:
+                for raw_document in self.generate_raw_docs(fstream):
+                    document = self.parse_raw_doc(raw_document)
+                    yield document["pmid"], document
+
+        elif self.config.schema == "bigbio_kb":
+            with open(filepath, "r", encoding="utf8") as fstream:
+                uid = itertools.count(0)
+                for raw_document in self.generate_raw_docs(fstream):
+                    entities_in_doc = dict()
+                    document = self.parse_raw_doc(raw_document)
+                    pmid = document.pop("pmid")
+                    document["id"] = str(next(uid))
+                    document["document_id"] = pmid
+                    entities_ = []
+                    relations_ = []
+                    for entity in document["entities"]:
+                        temp_id = document["id"] + "_" + str(entity["concept_id"])
+                        curr_entity_count = entities_in_doc.get(temp_id, 0)
+                        entities_.append(
+                            {
+                                "id": temp_id + "_" + str(curr_entity_count),
+                                "type": entity["semantic_type_id"],
+                                "text": entity["text"],
+                                "normalized": [],
+                                "offsets": entity["offsets"],
+                            }
+                        )
+                        entities_in_doc[temp_id] = curr_entity_count + 1
+                    rel_uid = itertools.count(0)
+                    for relation in document["relations"]:
+                        relations_.append(
+                            {
+                                "id": document["id"]
+                                + "_relation_"
+                                + str(next(rel_uid)),
+                                "type": relation["type"],
+                                "arg1_id": document["id"]
+                                + "_"
+                                + str(relation["concept_1"])
+                                + "_0",
+                                "arg2_id": document["id"]
+                                + "_"
+                                + str(relation["concept_2"])
+                                + "_0",
+                                "normalized": [],
+                            }
+                        )
+                    for passage in document["passages"]:
+                        passage["id"] = document["id"] + "_" + passage["type"]
+                    document["entities"] = entities_
+                    document["relations"] = relations_
+                    document["events"] = []
+                    document["coreferences"] = []
+                    yield document["document_id"], document
+
+    def generate_raw_docs(self, fstream):
+        """
+        Given a filestream, this function yields documents from it
+        """
+        raw_document = []
+        for line in fstream:
+            if line.strip():
+                raw_document.append(line.strip())
+            elif raw_document:
+                yield raw_document
+                raw_document = []
+        if raw_document:
+            yield raw_document
+
+    def parse_raw_doc(self, raw_doc):
+        pmid, _, title = raw_doc[0].split("|")
+        pmid = int(pmid)
+        _, _, abstract = raw_doc[1].split("|")
+        passages = [
+            {"type": "title", "text": [title], "offsets": [[0, len(title)]]},
+            {
+                "type": "abstract",
+                "text": [abstract],
+                "offsets": [[len(title) + 1, len(title) + len(abstract) + 1]],
+            },
+        ]
+        entities = []
+        relations = []
+        for line in raw_doc[2:]:
+            mentions = line.split("\t")
+            (_pmid, _type_ind, *rest) = mentions
+            if _type_ind in [
+                "Positive_Correlation",
+                "Association",
+                "Negative_Correlation",
+                "Bind",
+                "Conversion",
+                "Cotreatment",
+                "Cause",
+                "Comparison",
+                "Drug_Interaction",
+            ]:
+                # Relations handled here
+                relation_type = _type_ind
+                concept_1, concept_2, novel = rest
+                relation = {
+                    "type": relation_type,
+                    "concept_1": concept_1,
+                    "concept_2": concept_2,
+                    "novel": novel,
+                }
+                relations.append(relation)
+            elif _type_ind.isnumeric():
+                # Entities handled here
+                start_idx = _type_ind
+                end_idx, mention, semantic_type_id, entity_ids = rest
+                entity = [
+                    {
+                        "offsets": [[int(start_idx), int(end_idx)]],
+                        "text": [mention],
+                        "semantic_type_id": semantic_type_id.split(","),
+                        "concept_id": entity_id,
+                    }
+                    for entity_id in entity_ids.split(",")
+                ]
+                entities.extend(entity)
+            else:
+                logger.warn(
+                    f"Skipping annotation in Document ID: {_pmid}. Unexpected format"
+                )
+        return {
+            "pmid": pmid,
+            "passages": passages,
+            "entities": entities,
+            "relations": relations,
+        }

--- a/hub/hubscripts/biorelex_hub.py
+++ b/hub/hubscripts/biorelex_hub.py
@@ -1,0 +1,416 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+BioRelEx is a biological relation extraction dataset. Version 1.0 contains 2010
+annotated sentences that describe binding interactions between various
+biological entities (proteins, chemicals, etc.). 1405 sentences are for
+training, another 201 sentences are for validation. They are publicly available
+at https://github.com/YerevaNN/BioRelEx/releases. Another 404 sentences are for
+testing which are kept private for at this Codalab competition
+https://competitions.codalab.org/competitions/20468. All sentences contain words
+"bind", "bound" or "binding". For every sentence we provide: 1) Complete
+annotations of all biological entities that appear in the sentence 2) Entity
+types (32 types) and grounding information for most of the proteins and families
+(links to uniprot, interpro and other databases) 3) Coreference between entities
+in the same sentence (e.g. abbreviations and synonyms) 4) Binding interactions
+between the annotated entities 5) Binding interaction types: positive, negative
+(A does not bind B) and neutral (A may bind to B)
+"""
+
+import itertools as it
+import json
+from collections import defaultdict
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+# TODO: Add BibTeX citation
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{khachatrian2019biorelex,
+    title = "{B}io{R}el{E}x 1.0: Biological Relation Extraction Benchmark",
+    author = "Khachatrian, Hrant  and
+      Nersisyan, Lilit  and
+      Hambardzumyan, Karen  and
+      Galstyan, Tigran  and
+      Hakobyan, Anna  and
+      Arakelyan, Arsen  and
+      Rzhetsky, Andrey  and
+      Galstyan, Aram",
+    booktitle = "Proceedings of the 18th BioNLP Workshop and Shared Task",
+    month = aug,
+    year = "2019",
+    address = "Florence, Italy",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/W19-5019",
+    doi = "10.18653/v1/W19-5019",
+    pages = "176--190"
+}
+"""
+
+_DATASETNAME = "biorelex"
+_DISPLAYNAME = "BioRelEx"
+
+_DESCRIPTION = """\
+BioRelEx is a biological relation extraction dataset. Version 1.0 contains 2010
+annotated sentences that describe binding interactions between various
+biological entities (proteins, chemicals, etc.). 1405 sentences are for
+training, another 201 sentences are for validation. They are publicly available
+at https://github.com/YerevaNN/BioRelEx/releases. Another 404 sentences are for
+testing which are kept private for at this Codalab competition
+https://competitions.codalab.org/competitions/20468. All sentences contain words
+"bind", "bound" or "binding". For every sentence we provide: 1) Complete
+annotations of all biological entities that appear in the sentence 2) Entity
+types (32 types) and grounding information for most of the proteins and families
+(links to uniprot, interpro and other databases) 3) Coreference between entities
+in the same sentence (e.g. abbreviations and synonyms) 4) Binding interactions
+between the annotated entities 5) Binding interaction types: positive, negative
+(A does not bind B) and neutral (A may bind to B)"""
+
+_HOMEPAGE = "https://github.com/YerevaNN/BioRelEx"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: {
+        "train": "https://github.com/YerevaNN/BioRelEx/releases/download/1.0alpha7/1.0alpha7.train.json",
+        "dev": "https://github.com/YerevaNN/BioRelEx/releases/download/1.0alpha7/1.0alpha7.dev.json",
+    },
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.NAMED_ENTITY_DISAMBIGUATION,
+    Tasks.RELATION_EXTRACTION,
+    Tasks.COREFERENCE_RESOLUTION,
+]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class BioRelExDataset(datasets.GeneratorBasedBuilder):
+    """BioRelEx is a biological relation extraction dataset."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="biorelex_source",
+            version=SOURCE_VERSION,
+            description="BioRelEx source schema",
+            schema="source",
+            subset_id="biorelex",
+        ),
+        BigBioConfig(
+            name="biorelex_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="BioRelEx BigBio schema",
+            schema="bigbio_kb",
+            subset_id="biorelex",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "biorelex_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "paperid": datasets.Value("string"),
+                    "interactions": [
+                        {
+                            "participants": datasets.Sequence(datasets.Value("int32")),
+                            "type": datasets.Value("string"),
+                            "implicit": datasets.Value("bool"),
+                            "label": datasets.Value("int32"),
+                        }
+                    ],
+                    "url": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "entities": [
+                        {
+                            "is_state": datasets.Value("bool"),
+                            "label": datasets.Value("string"),
+                            "names": [
+                                {
+                                    "text": datasets.Value("string"),
+                                    "is_mentioned": datasets.Value("bool"),
+                                    "mentions": datasets.Sequence(
+                                        [datasets.Value("int32")]
+                                    ),
+                                }
+                            ],
+                            "grounding": [
+                                {
+                                    "comment": datasets.Value("string"),
+                                    "entrez_gene": datasets.Value("string"),
+                                    "source": datasets.Value("string"),
+                                    "link": datasets.Value("string"),
+                                    "hgnc_symbol": datasets.Value("string"),
+                                    "organism": datasets.Value("string"),
+                                }
+                            ],
+                            "is_mentioned": datasets.Value("bool"),
+                            "is_mutant": datasets.Value("bool"),
+                        }
+                    ],
+                    "_line_": datasets.Value("int32"),
+                    "id": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_dir["train"],
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": data_dir["dev"],
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        with open(filepath, "r", encoding="utf8") as f:
+            data = json.load(f)
+        data = self._prep(data)
+
+        if self.config.schema == "source":
+            for key, example in enumerate(data):
+                yield key, example
+
+        elif self.config.schema == "bigbio_kb":
+            for key, example in enumerate(data):
+                example_ = self._source_to_kb(example)
+                yield key, example_
+
+    def _prep(self, data):
+        for example in data:
+            for entity in example["entities"]:
+                entity["names"] = self._json_dict_to_list(entity["names"], "text")
+                if entity["grounding"] is None:
+                    entity["grounding"] = []
+                else:
+                    entity["grounding"] = [entity["grounding"]]
+        return data
+
+    def _json_dict_to_list(self, json, new_key):
+        list_ = []
+        for key, values in json.items():
+            assert isinstance(values, dict), "Child element is not a dict"
+            assert new_key not in values, "New key already in values"
+            values[new_key] = key
+            list_.append(values)
+        return list_
+
+    def _source_to_kb(self, example):
+        example_id = example["id"]
+        entities_, corefs_, ref_id_map = self._get_entities(
+            example_id, example["entities"]
+        )
+        relations_ = self._get_relations(
+            example_id, ref_id_map, example["interactions"]
+        )
+
+        document_ = {
+            "id": example_id,
+            "document_id": example["paperid"],
+            "passages": [
+                {
+                    "id": example_id + ".sent",
+                    "type": "sentence",
+                    "text": [example["text"]],
+                    "offsets": [[0, len(example["text"])]],
+                }
+            ],
+            "entities": entities_,
+            "coreferences": corefs_,
+            "relations": relations_,
+            "events": [],
+        }
+        return document_
+
+    def _get_entities(self, example_id, entities):
+        entities_ = []
+        corefs_ = []
+
+        eid = it.count(0)
+        cid = it.count(0)
+        # dictionary mapping the original ref ids (indexes of entities) for relations
+        org_rel_ref_id_2_kb_entity_id = defaultdict(list)
+
+        for relation_ref_id, entity in enumerate(entities):
+
+            # get normalization for entities
+            normalized_ = self._get_normalizations(entity)
+
+            # create entity for each synonym
+            coref_eids_ = []
+            for names in entity["names"]:
+                for id, mention in enumerate(names["mentions"]):
+                    entity_id = example_id + ".ent" + str(next(eid)) + "_" + str(id)
+                    org_rel_ref_id_2_kb_entity_id[relation_ref_id].append(entity_id)
+                    coref_eids_.append(entity_id)
+                    entities_.append(
+                        {
+                            "id": entity_id,
+                            "type": entity["label"],
+                            "text": [names["text"]],
+                            "offsets": [mention],
+                            "normalized": normalized_,
+                        }
+                    )
+
+            # create coreferences
+            coref_id = example_id + ".coref" + str(next(cid))
+            corefs_.append(
+                {
+                    "id": coref_id,
+                    "entity_ids": coref_eids_,
+                }
+            )
+        return entities_, corefs_, org_rel_ref_id_2_kb_entity_id
+
+    def _get_normalizations(self, entity):
+        normalized_ = []
+        if entity["grounding"]:
+            assert len(entity["grounding"]) == 1
+            if entity["grounding"][0]["entrez_gene"] != "NA":
+                normalized_.append(
+                    {
+                        "db_name": "NCBI gene",
+                        "db_id": entity["grounding"][0]["entrez_gene"],
+                    }
+                )
+            if entity["grounding"][0]["hgnc_symbol"] != "NA":
+                normalized_.append(
+                    {"db_name": "hgnc", "db_id": entity["grounding"][0]["hgnc_symbol"]}
+                )
+
+            # maybe parse some other ids?
+            source = entity["grounding"][0]["source"]
+            if (
+                source != "NCBI gene"
+                and source != "https://www.genenames.org/data/genegroup/"
+            ):  # NCBI gene is same as entrez
+                normalized_.append(
+                    self._parse_id_from_link(
+                        entity["grounding"][0]["link"], entity["grounding"][0]["source"]
+                    )
+                )
+        return normalized_
+
+    def _get_relations(self, example_id, org_rel_ref_id_2_kb_entity_id, interactions):
+        rid = it.count(0)
+        relations_ = []
+        for interaction in interactions:
+            rel_id = example_id + ".rel" + str(next(rid))
+            assert len(interaction["participants"]) == 2
+
+            subjects = org_rel_ref_id_2_kb_entity_id[interaction["participants"][0]]
+            objects = org_rel_ref_id_2_kb_entity_id[interaction["participants"][1]]
+
+            for s in subjects:
+                for o in objects:
+                    relations_.append(
+                        {
+                            "id": rel_id + "s" + s + ".o" + o,
+                            "type": interaction["type"],
+                            "arg1_id": s,
+                            "arg2_id": o,
+                            "normalized": [],
+                        }
+                    )
+        return relations_
+
+    def _parse_id_from_link(self, link, source):
+        source_template_map = {
+            "uniprot": ["https://www.uniprot.org/uniprot/"],
+            "pubchem:compound": ["https://pubchem.ncbi.nlm.nih.gov/compound/"],
+            "pubchem:substance": ["https://pubchem.ncbi.nlm.nih.gov/substance/"],
+            "pfam": ["https://pfam.xfam.org/family/", "http://pfam.xfam.org/family/"],
+            "interpro": [
+                "http://www.ebi.ac.uk/interpro/entry/",
+                "https://www.ebi.ac.uk/interpro/entry/",
+            ],
+            "DrugBank": ["https://www.drugbank.ca/drugs/"],
+        }
+
+        # fix exceptions manually
+        if source == "https://enzyme.expasy.org/EC/2.5.1.18" and link == source:
+            return {"db_name": "intenz", "db_id": "2.5.1.18"}
+        elif (
+            source == "https://www.genome.jp/kegg-bin/show_pathway?map=ko04120"
+            and link == source
+        ):
+            return {"db_name": "kegg", "db_id": "ko04120"}
+        elif (
+            source == "https://www.genome.jp/dbget-bin/www_bget?enzyme+2.7.11.1"
+            and link == source
+        ):
+            return {"db_name": "intenz", "db_id": "2.7.11.1"}
+        elif (
+            source == "http://www.chemspider.com/Chemical-Structure.7995676.html"
+            and link == source
+        ):
+            return {"db_name": "chemspider", "db_id": "7995676"}
+        elif source == "intenz":
+            id = link.split("=")[0]
+            return {"db_name": source, "db_id": id}
+        else:
+            link_templates = source_template_map[source]
+            for template in link_templates:
+                if link.startswith(template):
+                    id = link.replace(template, "")
+                    id = id.split("?")[0]
+                    assert "/" not in id
+                    return {"db_name": source, "db_id": id}
+
+            assert (
+                False
+            ), f"No template found for {link}, choices: {repr(link_templates)}"

--- a/hub/hubscripts/bioscope_hub.py
+++ b/hub/hubscripts/bioscope_hub.py
@@ -1,0 +1,332 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+BioScope
+---
+The corpus consists of three parts, namely medical free texts, biological full
+papers and biological scientific abstracts. The dataset contains annotations at
+the token level for negative and speculative keywords and at the sentence level
+for their linguistic scope. The annotation process was carried out by two
+independent linguist annotators and a chief linguist - also responsible for
+setting up the annotation guidelines - who resolved cases where the annotators
+disagreed. The resulting corpus consists of more than 20.000 sentences that were
+considered for annotation and over 10% of them actually contain one (or more)
+linguistic annotation suggesting negation or uncertainty.
+"""
+
+import os
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{vincze2008bioscope,
+  title={The BioScope corpus: biomedical texts annotated for uncertainty, negation and their scopes},
+  author={Vincze, Veronika and Szarvas, Gy{\"o}rgy and Farkas, Rich{\'a}rd and M{\'o}ra, Gy{\"o}rgy and Csirik, J{\'a}nos},
+  journal={BMC bioinformatics},
+  volume={9},
+  number={11},
+  pages={1--9},
+  year={2008},
+  publisher={BioMed Central}
+}
+"""
+
+_DATASETNAME = "bioscope"
+_DISPLAYNAME = "BioScope"
+
+
+_DESCRIPTION = """\
+The BioScope corpus consists of medical and biological texts annotated for
+negation, speculation and their linguistic scope. This was done to allow a
+comparison between the development of systems for negation/hedge detection and
+scope resolution. The BioScope corpus was annotated by two independent linguists
+following the guidelines written by our linguist expert before the annotation of
+the corpus was initiated.
+"""
+
+_HOMEPAGE = "https://rgai.inf.u-szeged.hu/node/105"
+
+_LICENSE = 'Creative Commons Attribution 2.0 Generic'
+
+_URLS = {
+    _DATASETNAME: "https://rgai.sed.hu/sites/rgai.sed.hu/files/bioscope.zip",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class BioscopeDataset(datasets.GeneratorBasedBuilder):
+    """The BioScope corpus consists of medical and biological texts annotated for negation, speculation and their linguistic scope."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="bioscope_source",
+            version=SOURCE_VERSION,
+            description="bioscope source schema",
+            schema="source",
+            subset_id="bioscope",
+        ),
+        BigBioConfig(
+            name="bioscope_abstracts_source",
+            version=SOURCE_VERSION,
+            description="bioscope source schema",
+            schema="source",
+            subset_id="bioscope_abstracts",
+        ),
+        BigBioConfig(
+            name="bioscope_papers_source",
+            version=SOURCE_VERSION,
+            description="bioscope source schema",
+            schema="source",
+            subset_id="bioscope_papers",
+        ),
+        BigBioConfig(
+            name="bioscope_medical_texts_source",
+            version=SOURCE_VERSION,
+            description="bioscope source schema",
+            schema="source",
+            subset_id="bioscope_medical_texts",
+        ),
+        BigBioConfig(
+            name="bioscope_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="bioscope BigBio schema",
+            schema="bigbio_kb",
+            subset_id="bioscope",
+        ),
+        BigBioConfig(
+            name="bioscope_abstracts_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="bioscope BigBio schema",
+            schema="bigbio_kb",
+            subset_id="bioscope_abstracts",
+        ),
+        BigBioConfig(
+            name="bioscope_papers_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="bioscope BigBio schema",
+            schema="bigbio_kb",
+            subset_id="bioscope_papers",
+        ),
+        BigBioConfig(
+            name="bioscope_medical_texts_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="bioscope BigBio schema",
+            schema="bigbio_kb",
+            subset_id="bioscope_medical_texts",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "bioscope_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "document_type": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "entities": [
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                            "normalized": [
+                                {
+                                    "db_name": datasets.Value("string"),
+                                    "db_id": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "data_files": data_dir,
+                },
+            )
+        ]
+
+    def _generate_examples(self, data_files: Path) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        sentences = self._load_sentences(data_files)
+        if self.config.schema == "source":
+            for guid, sentence_tuple in enumerate(sentences):
+                document_type, sentence = sentence_tuple
+                example = self._create_example(sentence_tuple)
+                example["document_type"] = f"{document_type}_{sentence.attrib['id']}"
+                example["text"] = "".join(sentence_tuple[1].itertext())
+                yield guid, example
+
+        elif self.config.schema == "bigbio_kb":
+            for guid, sentence_tuple in enumerate(sentences):
+                document_type, sentence = sentence_tuple
+                example = self._create_example(sentence_tuple)
+                example["id"] = guid
+                example["passages"] = [
+                    {
+                        "id": f"{document_type}_{sentence.attrib['id']}",
+                        "type": document_type,
+                        "text": ["".join(sentence.itertext())],
+                        "offsets": [(0, len("".join(sentence.itertext())))],
+                    }
+                ]
+                example["events"] = []
+                example["coreferences"] = []
+                example["relations"] = []
+                yield guid, example
+
+    def _load_sentences(self, data_files: Path) -> List:
+        """
+        Returns a list of tuples (Document type, iterator from dataset)
+        """
+        if self.config.subset_id.__contains__("abstracts"):
+            sentences = self._concat_iterators(
+                (
+                    "Abstract",
+                    ET.parse(os.path.join(data_files, "abstracts.xml"))
+                    .getroot()
+                    .iter("sentence"),
+                )
+            )
+        elif self.config.subset_id.__contains__("papers"):
+            sentences = self._concat_iterators(
+                (
+                    "Paper",
+                    ET.parse(os.path.join(data_files, "full_papers.xml"))
+                    .getroot()
+                    .iter("sentence"),
+                )
+            )
+        elif self.config.subset_id.__contains__("medical_texts"):
+            sentences = self._concat_iterators(
+                (
+                    "Medical text",
+                    ET.parse(
+                        os.path.join(
+                            data_files, "clinical_merger/clinical_records_anon.xml"
+                        )
+                    )
+                    .getroot()
+                    .iter("sentence"),
+                )
+            )
+        else:
+            abstracts = (
+                ET.parse(os.path.join(data_files, "abstracts.xml"))
+                .getroot()
+                .iter("sentence")
+            )
+            papers = (
+                ET.parse(os.path.join(data_files, "full_papers.xml"))
+                .getroot()
+                .iter("sentence")
+            )
+            medical_texts = (
+                ET.parse(
+                    os.path.join(
+                        data_files, "clinical_merger/clinical_records_anon.xml"
+                    )
+                )
+                .getroot()
+                .iter("sentence")
+            )
+            sentences = self._concat_iterators(
+                ("Abstract", abstracts),
+                ("Paper", papers),
+                ("Medical text", medical_texts),
+            )
+        return sentences
+
+    @staticmethod
+    def _concat_iterators(*iterator_tuple):
+        for document_type, iterator in iterator_tuple:
+            for element in iterator:
+                yield document_type, element
+
+    def _create_example(self, sentence_tuple):
+        document_type, sentence = sentence_tuple
+        document_type_prefix = document_type[0]
+
+        example = {}
+        example["document_id"] = f"{document_type_prefix}_{sentence.attrib['id']}"
+        example["entities"] = self._extract_entities(sentence, document_type_prefix)
+        return example
+
+    def _extract_entities(self, sentence, document_type_prefix):
+        text = "".join(sentence.itertext())
+        entities = []
+        xcopes = dict([(xcope.attrib["id"], xcope) for xcope in sentence.iter("xcope")])
+        cues = dict([(cue.attrib["ref"], cue) for cue in sentence.iter("cue")])
+        for idx, xcope in xcopes.items():
+            # X2.140.2 has no annotation in raw data
+            if cues.get(idx) is None:
+                continue
+            entities.append(
+                {
+                    "id": f"{document_type_prefix}_{idx}",
+                    "type": cues.get(idx).attrib["type"],
+                    "text": ["".join(xcope.itertext())],
+                    "offsets": self._extract_offsets(
+                        text=text, entity_text="".join(xcope.itertext())
+                    ),
+                    "normalized": [],
+                }
+            )
+        return entities
+
+    def _extract_offsets(self, text, entity_text):
+        return [(text.find(entity_text), text.find(entity_text) + len(entity_text))]

--- a/hub/hubscripts/biosses_hub.py
+++ b/hub/hubscripts/biosses_hub.py
@@ -1,0 +1,307 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+BioSSES computes similarity of biomedical sentences by utilizing WordNet as the
+general domain ontology and UMLS as the biomedical domain specific ontology.
+The original paper outlines the approaches with respect to using annotator
+score as golden standard. Source view will return all annotator score
+individually whereas the Bigbio view will return the mean of the annotator
+score.
+
+Note: The original files are Word documents, compressed using RAR. This data
+loader uses a version that privides the same data in text format.
+"""
+import datasets
+import pandas as pd
+
+from .bigbiohub import pairs_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "biosses"
+_DISPLAYNAME = "BIOSSES"
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """
+@article{souganciouglu2017biosses,
+  title={BIOSSES: a semantic sentence similarity estimation system for the biomedical domain},
+  author={Soğancıoğlu, Gizem, Hakime Öztürk, and Arzucan Özgür},
+  journal={Bioinformatics},
+  volume={33},
+  number={14},
+  pages={i49--i58},
+  year={2017},
+  publisher={Oxford University Press}
+}
+"""
+
+_DESCRIPTION = """
+BioSSES computes similarity of biomedical sentences by utilizing WordNet as the
+general domain ontology and UMLS as the biomedical domain specific ontology.
+The original paper outlines the approaches with respect to using annotator
+score as golden standard. Source view will return all annotator score
+individually whereas the Bigbio view will return the mean of the annotator
+score.
+"""
+
+_HOMEPAGE = "https://tabilab.cmpe.boun.edu.tr/BIOSSES/DataSet.html"
+
+_LICENSE = 'GNU General Public License v3.0 only'
+
+_URLs = {
+    "source": "https://huggingface.co/datasets/bigscience-biomedical/biosses/raw/main/annotation_pairs_scores.tsv",
+    "bigbio_pairs": "https://huggingface.co/datasets/bigscience-biomedical/biosses/raw/main/annotation_pairs_scores.tsv",
+}
+
+_SUPPORTED_TASKS = [Tasks.SEMANTIC_SIMILARITY]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+# The BIOSSES dataset does not provide canonical train/dev/test splits.
+# However the BLUE and BLURB datasets use the following split definitions.
+# see https://github.com/bigscience-workshop/biomedical/issues/664
+
+TRAIN_INDEXES = [
+    78,
+    45,
+    35,
+    50,
+    27,
+    13,
+    87,
+    1,
+    58,
+    99,
+    55,
+    74,
+    66,
+    39,
+    44,
+    18,
+    84,
+    76,
+    19,
+    10,
+    75,
+    46,
+    15,
+    86,
+    60,
+    14,
+    51,
+    79,
+    29,
+    34,
+    94,
+    28,
+    62,
+    42,
+    21,
+    30,
+    11,
+    53,
+    6,
+    12,
+    26,
+    48,
+    31,
+    32,
+    77,
+    37,
+    95,
+    85,
+    36,
+    56,
+    43,
+    61,
+    16,
+    5,
+    67,
+    65,
+    54,
+    3,
+    73,
+    98,
+    17,
+    4,
+    92,
+    93,
+]
+DEV_INDEXES = [
+    88,
+    82,
+    8,
+    63,
+    47,
+    68,
+    40,
+    90,
+    100,
+    24,
+    41,
+    91,
+    80,
+    9,
+    72,
+    2,
+]
+TEST_INDEXES = [
+    59,
+    96,
+    70,
+    22,
+    81,
+    38,
+    57,
+    23,
+    33,
+    89,
+    69,
+    49,
+    7,
+    71,
+    97,
+    25,
+    83,
+    64,
+    52,
+    20,
+]
+
+
+class BiossesDataset(datasets.GeneratorBasedBuilder):
+    """BIOSSES : Biomedical Semantic Similarity Estimation System"""
+
+    DEFAULT_CONFIG_NAME = "biosses_source"
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="biosses_source",
+            version=SOURCE_VERSION,
+            description="BIOSSES source schema",
+            schema="source",
+            subset_id="biosses",
+        ),
+        BigBioConfig(
+            name="biosses_bigbio_pairs",
+            version=BIGBIO_VERSION,
+            description="BIOSSES simplified BigBio schema",
+            schema="bigbio_pairs",
+            subset_id="biosses",
+        ),
+    ]
+
+    def _info(self):
+
+        if self.config.name == "biosses_source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("int64"),
+                    "document_id": datasets.Value("int64"),
+                    "text_1": datasets.Value("string"),
+                    "text_2": datasets.Value("string"),
+                    "annotator_a": datasets.Value("int64"),
+                    "annotator_b": datasets.Value("int64"),
+                    "annotator_c": datasets.Value("int64"),
+                    "annotator_d": datasets.Value("int64"),
+                    "annotator_e": datasets.Value("int64"),
+                }
+            )
+        elif self.config.name == "biosses_bigbio_pairs":
+            features = pairs_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            supervised_keys=None,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+
+        my_urls = _URLs[self.config.schema]
+        dl_dir = dl_manager.download_and_extract(my_urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": dl_dir,
+                    "split": "train",
+                    "indexes": TRAIN_INDEXES,
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": dl_dir,
+                    "split": "validation",
+                    "indexes": DEV_INDEXES,
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": dl_dir,
+                    "split": "test",
+                    "indexes": TEST_INDEXES,
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split, indexes):
+
+        df = pd.read_csv(filepath, sep="\t", encoding="utf-8")
+        df = df[df["sentence_id"].isin(indexes)]
+
+        if self.config.schema == "source":
+            for uid, row in df.iterrows():
+                yield uid, {
+                    "id": uid,
+                    "document_id": row["sentence_id"],
+                    "text_1": row["sentence_1"],
+                    "text_2": row["sentence_2"],
+                    "annotator_a": row["annotator_a"],
+                    "annotator_b": row["annotator_b"],
+                    "annotator_c": row["annotator_c"],
+                    "annotator_d": row["annotator_d"],
+                    "annotator_e": row["annotator_e"],
+                }
+
+        elif self.config.schema == "bigbio_pairs":
+            for uid, row in df.iterrows():
+                yield uid, {
+                    "id": uid,
+                    "document_id": row["sentence_id"],
+                    "text_1": row["sentence_1"],
+                    "text_2": row["sentence_2"],
+                    "label": str(
+                        (
+                            row["annotator_a"]
+                            + row["annotator_b"]
+                            + row["annotator_c"]
+                            + row["annotator_d"]
+                            + row["annotator_e"]
+                        )
+                        / 5
+                    ),
+                }

--- a/hub/hubscripts/cantemist_hub.py
+++ b/hub/hubscripts/cantemist_hub.py
@@ -1,0 +1,370 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A dataset loading script for the CANTEMIST corpus.
+
+The CANTEMIST datset is collection of 1301 oncological clinical case reports 
+written in Spanish, with tumor morphology mentions manually annotated and 
+mapped by clinical experts to a controlled terminology. Every tumor morphology 
+mention is linked to an eCIE-O code (the Spanish equivalent of ICD-O).
+"""
+
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['Spanish']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@article{miranda2020named,
+  title={Named Entity Recognition, Concept Normalization and Clinical Coding: Overview of the Cantemist Track for Cancer Text Mining in Spanish, Corpus, Guidelines, Methods and Results.},
+  author={Miranda-Escalada, Antonio and Farr{\'e}, Eul{\`a}lia and Krallinger, Martin},
+  journal={IberLEF@ SEPLN},
+  pages={303--323},
+  year={2020}
+}
+"""
+
+_DATASETNAME = "cantemist"
+_DISPLAYNAME = "CANTEMIST"
+
+_DESCRIPTION = """\
+Collection of 1301 oncological clinical case reports written in Spanish, with tumor morphology mentions \
+manually annotated and mapped by clinical experts to a controlled terminology. Every tumor morphology \
+mention is linked to an eCIE-O code (the Spanish equivalent of ICD-O).
+
+The original dataset is distributed in Brat format, and was randomly sampled into 3 subsets. \
+The training, development and test sets contain 501, 500 and 300 documents each, respectively.
+
+This dataset was designed for the CANcer TExt Mining Shared Task, sponsored by Plan-TL. \
+The task is divided in 3 subtasks: CANTEMIST-NER, CANTEMIST_NORM and CANTEMIST-CODING.
+
+CANTEMIST-NER track: requires finding automatically tumor morphology mentions. All tumor morphology \
+mentions are defined by their corresponding character offsets in UTF-8 plain text medical documents. 
+
+CANTEMIST-NORM track: clinical concept normalization or named entity normalization task that requires \
+to return all tumor morphology entity mentions together with their corresponding eCIE-O-3.1 codes \
+i.e. finding and normalizing tumor morphology mentions.
+
+CANTEMIST-CODING track: requires returning for each of document a ranked list of its corresponding ICD-O-3 \
+codes. This it is essentially a sort of indexing or multi-label classification task or oncology clinical coding. 
+
+For further information, please visit https://temu.bsc.es/cantemist or send an email to encargo-pln-life@bsc.es
+"""
+
+_HOMEPAGE = "https://temu.bsc.es/cantemist/?p=4338"
+
+_LICENSE = 'Creative Commons Attribution 4.0 International'
+
+_URLS = {
+    "cantemist": "https://zenodo.org/record/3978041/files/cantemist.zip?download=1",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.NAMED_ENTITY_DISAMBIGUATION,
+    Tasks.TEXT_CLASSIFICATION,
+]
+
+_SOURCE_VERSION = "1.6.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class CantemistDataset(datasets.GeneratorBasedBuilder):
+    """Manually annotated collection of oncological clinical case reports written in Spanish."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="cantemist_source",
+            version=SOURCE_VERSION,
+            description="CANTEMIST source schema",
+            schema="source",
+            subset_id="cantemist",
+        ),
+        BigBioConfig(
+            name="cantemist_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="CANTEMIST BigBio schema for the NER and NED tasks",
+            schema="bigbio_kb",
+            subset_id="subtracks_1_2",
+        ),
+        BigBioConfig(
+            name="cantemist_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="CANTEMIST BigBio schema for the CODING task",
+            schema="bigbio_text",
+            subset_id="subtrack_3",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "cantemist_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "labels": [datasets.Value("string")],  # subtrack 3 codes
+                    "text_bound_annotations": [  # T line in brat
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "trigger": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arguments": datasets.Sequence(
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "attributes": [  # M or A lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value("string"),
+                            "cuid": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                        }
+                    ],
+                    "notes": [  # # lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                        }
+                    ],
+                },
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        elif self.config.schema == "bigbio_text":
+            features = text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """
+        Downloads/extracts the data to generate the train, validation and test splits.
+
+        Each split is created by instantiating a `datasets.SplitGenerator`, which will
+        call `this._generate_examples` with the keyword arguments in `gen_kwargs`.
+        """
+
+        data_dir = dl_manager.download_and_extract(_URLS["cantemist"])
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepaths": {
+                        "task1": Path(
+                            os.path.join(data_dir, "train-set/cantemist-ner")
+                        ),
+                        "task2": Path(
+                            os.path.join(data_dir, "train-set/cantemist-norm")
+                        ),
+                        "task3": Path(
+                            os.path.join(data_dir, "train-set/cantemist-coding")
+                        ),
+                    },
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepaths": {
+                        "task1": Path(os.path.join(data_dir, "test-set/cantemist-ner")),
+                        "task2": Path(
+                            os.path.join(data_dir, "test-set/cantemist-norm")
+                        ),
+                        "task3": Path(
+                            os.path.join(data_dir, "test-set/cantemist-coding")
+                        ),
+                    },
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepaths": {
+                        "task1_set1": Path(
+                            os.path.join(data_dir, "dev-set1/cantemist-ner")
+                        ),
+                        "task1_set2": Path(
+                            os.path.join(data_dir, "dev-set2/cantemist-ner")
+                        ),
+                        "task2_set1": Path(
+                            os.path.join(data_dir, "dev-set1/cantemist-norm")
+                        ),
+                        "task2_set2": Path(
+                            os.path.join(data_dir, "dev-set2/cantemist-norm")
+                        ),
+                        "task3_set1": Path(
+                            os.path.join(data_dir, "dev-set1/cantemist-coding")
+                        ),
+                        "task3_set2": Path(
+                            os.path.join(data_dir, "dev-set2/cantemist-coding")
+                        ),
+                    },
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepaths, split: str) -> Tuple[int, Dict]:
+        """
+        This method handles input defined in _split_generators to yield (key, example) tuples from the dataset.
+        Method parameters are unpacked from `gen_kwargs` as given in `_split_generators`.
+        """
+
+        if split != "dev":
+            txt_files_task1 = list(filepaths["task1"].glob("*txt"))
+            txt_files_task2 = list(filepaths["task2"].glob("*txt"))
+            tsv_file_task3 = Path(
+                os.path.join(filepaths["task3"], f"{split}-coding.tsv")
+            )
+            task3_df = pd.read_csv(tsv_file_task3, sep="\t", header=None)
+        else:
+            txt_files_task1, txt_files_task2, dfs = [], [], []
+            for i in range(1, 3):
+                txt_files_task1 += list(filepaths[f"task1_set{i}"].glob("*txt"))
+                txt_files_task2 += list(filepaths[f"task2_set{i}"].glob("*txt"))
+                tsv_file_task3 = Path(
+                    os.path.join(filepaths[f"task3_set{i}"], f"{split}{i}-coding.tsv")
+                )
+                df = pd.read_csv(tsv_file_task3, sep="\t", header=0)
+                dfs.append(df)
+            task3_df = pd.concat(dfs)
+
+        if self.config.schema == "source" or self.config.schema == "bigbio_text":
+            task3_dict = {}
+            for idx, row in task3_df.iterrows():
+                file, code = row[0], row[1]
+                if file not in task3_dict:
+                    task3_dict[file] = [code]
+                else:
+                    task3_dict[file] += [code]
+
+        if self.config.schema == "source":
+            for guid, txt_file in enumerate(txt_files_task2):
+                example = parsing.parse_brat_file(txt_file, parse_notes=True)
+                if example["document_id"] in task3_dict:
+                    example["labels"] = task3_dict[example["document_id"]]
+                else:
+                    example[
+                        "labels"
+                    ] = (
+                        []
+                    )  # few cases where subtrack 3 has no codes for the current document
+                example["id"] = str(guid)
+                yield guid, example
+
+        elif self.config.schema == "bigbio_kb":
+            for guid, txt_file in enumerate(txt_files_task2):
+                parsed_brat = parsing.parse_brat_file(txt_file, parse_notes=True)
+                example = parsing.brat_parse_to_bigbio_kb(parsed_brat)
+                example["id"] = str(guid)
+                for i in range(0, len(example["entities"])):
+                    normalized_dict = {
+                        "db_id": parsed_brat["notes"][i]["text"],
+                        "db_name": "eCIE-O-3.1",
+                    }
+                    example["entities"][i]["normalized"].append(normalized_dict)
+                yield guid, example
+
+        elif self.config.schema == "bigbio_text":
+            for guid, txt_file in enumerate(txt_files_task1):
+                parsed_brat = parsing.parse_brat_file(txt_file, parse_notes=False)
+                if parsed_brat["document_id"] in task3_dict:
+                    labels = task3_dict[parsed_brat["document_id"]]
+                else:
+                    labels = (
+                        []
+                    )  # few cases where subtrack 3 has no codes for the current document
+                example = {
+                    "id": str(guid),
+                    "document_id": parsed_brat["document_id"],
+                    "text": parsed_brat["text"],
+                    "labels": labels,
+                }
+                yield guid, example
+
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/hub/hubscripts/cas_hub.py
+++ b/hub/hubscripts/cas_hub.py
@@ -1,0 +1,261 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import datasets
+import numpy as np
+import pandas as pd
+
+from .bigbiohub import text_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['French']
+_PUBMED = False
+_LOCAL = True
+_CITATION = """\
+@inproceedings{grabar-etal-2018-cas,
+  title        = {{CAS}: {F}rench Corpus with Clinical Cases},
+  author       = {Grabar, Natalia  and Claveau, Vincent  and Dalloux, Cl{\'e}ment},
+  year         = 2018,
+  month        = oct,
+  booktitle    = {
+    Proceedings of the Ninth International Workshop on Health Text Mining and
+    Information Analysis
+  },
+  publisher    = {Association for Computational Linguistics},
+  address      = {Brussels, Belgium},
+  pages        = {122--128},
+  doi          = {10.18653/v1/W18-5614},
+  url          = {https://aclanthology.org/W18-5614},
+  abstract     = {
+    Textual corpora are extremely important for various NLP applications as
+    they provide information necessary for creating, setting and testing these
+    applications and the corresponding tools. They are also crucial for
+    designing reliable methods and reproducible results. Yet, in some areas,
+    such as the medical area, due to confidentiality or to ethical reasons, it
+    is complicated and even impossible to access textual data representative of
+    those produced in these areas. We propose the CAS corpus built with
+    clinical cases, such as they are reported in the published scientific
+    literature in French. We describe this corpus, currently containing over
+    397,000 word occurrences, and the existing linguistic and semantic
+    annotations.
+  }
+}"""
+
+_DATASETNAME = "cas"
+_DISPLAYNAME = "CAS"
+
+_DESCRIPTION = """\
+We manually annotated two corpora from the biomedical field. The ESSAI corpus \
+contains clinical trial protocols in French. They were mainly obtained from the \
+National Cancer Institute The typical protocol consists of two parts: the \
+summary of the trial, which indicates the purpose of the trial and the methods \
+applied; and a detailed description of the trial with the inclusion and \
+exclusion criteria. The CAS corpus contains clinical cases published in \
+scientific literature and training material. They are published in different \
+journals from French-speaking countries (France, Belgium, Switzerland, Canada, \
+African countries, tropical countries) and are related to various medical \
+specialties (cardiology, urology, oncology, obstetrics, pulmonology, \
+gastro-enterology). The purpose of clinical cases is to describe clinical \
+situations of patients. Hence, their content is close to the content of clinical \
+narratives (description of diagnoses, treatments or procedures, evolution, \
+family history, expected audience, etc.). In clinical cases, the negation is \
+frequently used for describing the patient signs, symptoms, and diagnosis. \
+Speculation is present as well but less frequently.
+
+This version only contain the annotated CAS corpus
+"""
+
+_HOMEPAGE = "https://clementdalloux.fr/?page_id=28"
+
+_LICENSE = 'Data User Agreement'
+
+_URLS = {
+    "cas_source": "",
+    "cas_bigbio_text": "",
+    "cas_bigbio_kb": "",
+}
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+_SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
+
+
+class CAS(datasets.GeneratorBasedBuilder):
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    DEFAULT_CONFIG_NAME = "cas_source"
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="cas_source",
+            version=SOURCE_VERSION,
+            description="CAS source schema",
+            schema="source",
+            subset_id="cas",
+        ),
+        BigBioConfig(
+            name="cas_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="CAS simplified BigBio schema for negation/speculation classification",
+            schema="bigbio_text",
+            subset_id="cas",
+        ),
+        BigBioConfig(
+            name="cas_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="CAS simplified BigBio schema for part-of-speech-tagging",
+            schema="bigbio_kb",
+            subset_id="cas",
+        ),
+    ]
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": [datasets.Value("string")],
+                    "lemmas": [datasets.Value("string")],
+                    "POS_tags": [datasets.Value("string")],
+                    "labels": [datasets.Value("string")],
+                }
+            )
+        elif self.config.schema == "bigbio_text":
+            features = text_features
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            supervised_keys=None,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
+        else:
+            data_dir = self.config.data_dir
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"datadir": data_dir},
+            ),
+        ]
+
+    def _generate_examples(self, datadir):
+        key = 0
+        for file in ["CAS_neg.txt", "CAS_spec.txt"]:
+            filepath = os.path.join(datadir, file)
+            label = "negation" if "neg" in file else "speculation"
+            id_docs = []
+            id_words = []
+            words = []
+            lemmas = []
+            POS_tags = []
+
+            with open(filepath) as f:
+                for line in f.readlines():
+                    line_content = line.split("\t")
+                    if len(line_content) > 1:
+                        id_docs.append(line_content[0])
+                        id_words.append(line_content[1])
+                        words.append(line_content[2])
+                        lemmas.append(line_content[3])
+                        POS_tags.append(line_content[4])
+
+            dic = {
+                "id_docs": np.array(list(map(int, id_docs))),
+                "id_words": id_words,
+                "words": words,
+                "lemmas": lemmas,
+                "POS_tags": POS_tags,
+            }
+            if self.config.schema == "source":
+                for doc_id in set(dic["id_docs"]):
+                    idces = np.argwhere(dic["id_docs"] == doc_id)[:, 0]
+                    text = [dic["words"][id] for id in idces]
+                    text_lemmas = [dic["lemmas"][id] for id in idces]
+                    POS_tags_ = [dic["POS_tags"][id] for id in idces]
+                    yield key, {
+                        "id": key,
+                        "document_id": doc_id,
+                        "text": text,
+                        "lemmas": text_lemmas,
+                        "POS_tags": POS_tags_,
+                        "labels": [label],
+                    }
+                    key += 1
+            elif self.config.schema == "bigbio_text":
+                for doc_id in set(dic["id_docs"]):
+                    idces = np.argwhere(dic["id_docs"] == doc_id)[:, 0]
+                    text = " ".join([dic["words"][id] for id in idces])
+                    yield key, {
+                        "id": key,
+                        "document_id": doc_id,
+                        "text": text,
+                        "labels": [label],
+                    }
+                    key += 1
+            elif self.config.schema == "bigbio_kb":
+                for doc_id in set(dic["id_docs"]):
+                    idces = np.argwhere(dic["id_docs"] == doc_id)[:, 0]
+                    text = [dic["words"][id] for id in idces]
+                    POS_tags_ = [dic["POS_tags"][id] for id in idces]
+
+                    data = {
+                        "id": str(key),
+                        "document_id": doc_id,
+                        "passages": [],
+                        "entities": [],
+                        "relations": [],
+                        "events": [],
+                        "coreferences": [],
+                    }
+                    key += 1
+
+                    data["passages"] = [
+                        {
+                            "id": str(key + i),
+                            "type": "sentence",
+                            "text": [text[i]],
+                            "offsets": [[i, i + 1]],
+                        }
+                        for i in range(len(text))
+                    ]
+                    key += len(text)
+
+                    for i in range(len(text)):
+                        entity = {
+                            "id": key,
+                            "type": "POS_tag",
+                            "text": [POS_tags_[i]],
+                            "offsets": [[i, i + 1]],
+                            "normalized": [],
+                        }
+                        data["entities"].append(entity)
+                        key += 1
+
+                    yield key, data

--- a/hub/hubscripts/cellfinder_hub.py
+++ b/hub/hubscripts/cellfinder_hub.py
@@ -1,0 +1,277 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+The CellFinder project aims to create a stem cell data repository by linking
+information from existing public databases and by performing text mining on the
+research literature. The first version of the corpus is composed of 10 full text
+documents containing more than 2,100 sentences, 65,000 tokens and 5,200
+annotations for entities. The corpus has been annotated with six types of
+entities (anatomical parts, cell components, cell lines, cell types,
+genes/protein and species) with an overall inter-annotator agreement around 80%.
+
+See: https://www.informatik.hu-berlin.de/de/forschung/gebiete/wbi/resources/cellfinder/
+"""
+from pathlib import Path
+from typing import Dict, Iterator, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{neves2012annotating,
+  title        = {Annotating and evaluating text for stem cell research},
+  author       = {Neves, Mariana and Damaschun, Alexander and Kurtz, Andreas and Leser, Ulf},
+  year         = 2012,
+  booktitle    = {
+    Proceedings of the Third Workshop on Building and Evaluation Resources for
+    Biomedical Text Mining\ (BioTxtM 2012) at Language Resources and Evaluation
+    (LREC). Istanbul, Turkey
+  },
+  pages        = {16--23},
+  organization = {Citeseer}
+}
+"""
+
+_DATASETNAME = "cellfinder"
+_DISPLAYNAME = "CellFinder"
+
+_DESCRIPTION = """\
+The CellFinder project aims to create a stem cell data repository by linking \
+information from existing public databases and by performing text mining on the \
+research literature. The first version of the corpus is composed of 10 full text \
+documents containing more than 2,100 sentences, 65,000 tokens and 5,200 \
+annotations for entities. The corpus has been annotated with six types of \
+entities (anatomical parts, cell components, cell lines, cell types, \
+genes/protein and species) with an overall inter-annotator agreement around 80%.
+
+See: https://www.informatik.hu-berlin.de/de/forschung/gebiete/wbi/resources/cellfinder/
+"""
+
+_HOMEPAGE = (
+    "https://www.informatik.hu-berlin.de/de/forschung/gebiete/wbi/resources/cellfinder/"
+)
+_LICENSE = 'Creative Commons Attribution Share Alike 3.0 Unported'
+
+_SOURCE_URL = (
+    "https://www.informatik.hu-berlin.de/de/forschung/gebiete/wbi/resources/cellfinder/"
+)
+_URLS = {
+    _DATASETNAME: _SOURCE_URL + "cellfinder1_brat.tar.gz",
+    _DATASETNAME + "_splits": _SOURCE_URL + "cellfinder1_brat_sections.tar.gz",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class CellFinderDataset(datasets.GeneratorBasedBuilder):
+    """The CellFinder corpus."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="cellfinder_source",
+            version=SOURCE_VERSION,
+            description="CellFinder source schema",
+            schema="source",
+            subset_id="cellfinder",
+        ),
+        BigBioConfig(
+            name="cellfinder_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="CellFinder BigBio schema",
+            schema="bigbio_kb",
+            subset_id="cellfinder",
+        ),
+        BigBioConfig(
+            name="cellfinder_splits_source",
+            version=SOURCE_VERSION,
+            description="CellFinder source schema",
+            schema="source",
+            subset_id="cellfinder_splits",
+        ),
+        BigBioConfig(
+            name="cellfinder_splits_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="CellFinder BigBio schema",
+            schema="bigbio_kb",
+            subset_id="cellfinder_splits",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "cellfinder_source"
+    SPLIT_TO_IDS = {
+        "train": [16316465, 17381551, 17389645, 18162134, 18286199],
+        "test": [15971941, 16623949, 16672070, 17288595, 17967047],
+    }
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "type": datasets.Value("string"),
+                    "entities": [
+                        {
+                            "entity_id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        urls = _URLS[_DATASETNAME]
+        if self.config.subset_id.endswith("_splits"):
+            urls = _URLS[_DATASETNAME + "_splits"]
+
+        data_dir = Path(dl_manager.download_and_extract(urls))
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"data_dir": data_dir, "split": "train"},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"data_dir": data_dir, "split": "test"},
+            ),
+        ]
+
+    def _is_to_exclude(self, file: Path) -> bool:
+
+        to_exclude = False
+
+        if (
+            file.name.startswith("._")
+            or file.name.endswith(".ann")
+            or file.name == "LICENSE"
+        ):
+            to_exclude = True
+
+        return to_exclude
+
+    def _not_in_split(self, file: Path, split: str) -> bool:
+
+        to_exclude = False
+
+        # SKIP files according to split
+        if self.config.subset_id.endswith("_splits"):
+            file_id = file.stem.split("_")[0]
+        else:
+            file_id = file.stem
+
+        if int(file_id) not in self.SPLIT_TO_IDS[split]:
+            to_exclude = True
+
+        return to_exclude
+
+    def _generate_examples(
+        self, data_dir: Path, split: str
+    ) -> Iterator[Tuple[str, Dict]]:
+        if self.config.schema == "source":
+            for file in data_dir.iterdir():
+
+                # Ignore hidden files and annotation files - we just consider the brat text files
+                if self._is_to_exclude(file=file):
+                    continue
+
+                if self._not_in_split(file=file, split=split):
+                    continue
+
+                # Read brat annotations for the given text file and convert example to the source format
+                brat_example = parsing.parse_brat_file(file)
+                source_example = self._to_source_example(file, brat_example)
+
+                yield source_example["document_id"], source_example
+
+        elif self.config.schema == "bigbio_kb":
+            for file in data_dir.iterdir():
+
+                # Ignore hidden files and annotation files - we just consider the brat text files
+                if self._is_to_exclude(file=file):
+                    continue
+
+                if self._not_in_split(file=file, split=split):
+                    continue
+
+                # Read brat annotations for the given text file and convert example to the BigBio-KB format
+                brat_example = parsing.parse_brat_file(file)
+                kb_example = parsing.brat_parse_to_bigbio_kb(brat_example)
+                kb_example["id"] = kb_example["document_id"]
+
+                # Fix text type annotation for the converted example
+                kb_example["passages"][0]["type"] = self.get_text_type(file)
+
+                yield kb_example["id"], kb_example
+
+    def _to_source_example(self, input_file: Path, brat_example: Dict) -> Dict:
+        """
+        Converts an example extracted using the default brat parsing logic to the source format
+        of the given corpus.
+        """
+        text_type = self.get_text_type(input_file)
+        source_example = {
+            "document_id": brat_example["document_id"],
+            "text": brat_example["text"],
+            "type": text_type,
+        }
+
+        id_prefix = brat_example["document_id"] + "_"
+
+        source_example["entities"] = []
+        for entity_annotation in brat_example["text_bound_annotations"]:
+            entity_ann = entity_annotation.copy()
+
+            entity_ann["entity_id"] = id_prefix + entity_ann["id"]
+            entity_ann.pop("id")
+
+            source_example["entities"].append(entity_ann)
+
+        return source_example
+
+    def get_text_type(self, input_file: Path) -> str:
+        """
+        Exctracts section name from filename, if absent return full_text
+        """
+
+        name_parts = str(input_file.stem).split("_")
+        if len(name_parts) == 3:
+            return name_parts[2]
+        return "full_text"

--- a/hub/hubscripts/chebi_nactem_hub.py
+++ b/hub/hubscripts/chebi_nactem_hub.py
@@ -1,0 +1,237 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{Shardlow2018,
+  title        = {
+    A New Corpus to Support Text Mining for the Curation of Metabolites in the
+    {ChEBI} Database
+  },
+  author       = {
+    Shardlow, M J and Nguyen, N and Owen, G and O'Donovan, C and Leach, A and
+    McNaught, J and Turner, S and Ananiadou, S
+  },
+  year         = 2018,
+  month        = may,
+  booktitle    = {
+    Proceedings of the Eleventh International Conference on Language Resources
+    and Evaluation ({LREC} 2018)
+  },
+  location     = {Miyazaki, Japan},
+  pages        = {280--285},
+  conference   = {
+    Eleventh International Conference on Language Resources and Evaluation
+    (LREC 2018)
+  },
+  language     = {en}
+}
+"""
+
+_DATASETNAME = "chebi_nactem"
+_DISPLAYNAME = "CHEBI Corpus"
+
+_DESCRIPTION = """\
+The ChEBI corpus contains 199 annotated abstracts and 100 annotated full papers.
+All documents in the corpus have been annotated for named entities and relations
+between these. In total, our corpus provides over 15000 named entity annotations
+and over 6,000 relations between entities.
+"""
+
+_HOMEPAGE = "http://www.nactem.ac.uk/chebi"
+
+_LICENSE = 'Creative Commons Attribution 4.0 International'
+
+_URLS = {
+    _DATASETNAME: "http://www.nactem.ac.uk/chebi/ChEBI.zip",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class ChebiNactemDatasset(datasets.GeneratorBasedBuilder):
+    """Chemical Entities of Biological Interest (ChEBI) corpus."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = []
+    for subset_id in ["abstr_ann1", "abstr_ann2", "fullpaper"]:
+        BUILDER_CONFIGS += [
+            BigBioConfig(
+                name=f"chebi_nactem_{subset_id}_source",
+                version=SOURCE_VERSION,
+                description="chebi_nactem source schema",
+                schema="source",
+                subset_id=f"chebi_nactem_{subset_id}",
+            ),
+            BigBioConfig(
+                name=f"chebi_nactem_{subset_id}_bigbio_kb",
+                version=BIGBIO_VERSION,
+                description="chebi_nactem BigBio schema",
+                schema="bigbio_kb",
+                subset_id=f"chebi_nactem_{subset_id}",
+            ),
+        ]
+
+    DEFAULT_CONFIG_NAME = "chebi_nactem_fullpaper_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "entities": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                        }
+                    ],
+                    "relations": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arg1": datasets.Value("string"),
+                            "arg2": datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+        else:
+            raise NotImplementedError(self.config.schema)
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        subset_paths = {
+            "chebi_nactem_abstr_ann1": "ChEBI/abstracts/Annotator1",
+            "chebi_nactem_abstr_ann2": "ChEBI/abstracts/Annotator2",
+            "chebi_nactem_fullpaper": "ChEBI/fullpapers",
+        }
+
+        subset_dir = Path(data_dir) / subset_paths[self.config.subset_id]
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "data_dir": subset_dir,
+                },
+            )
+        ]
+
+    def _generate_examples(self, data_dir: Path) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        def uid_gen():
+            _uid = 0
+            while True:
+                yield str(_uid)
+                _uid += 1
+
+        uid = iter(uid_gen())
+
+        txt_files = (f for f in os.listdir(data_dir) if f.endswith(".txt"))
+        for idx, file_name in enumerate(txt_files):
+
+            brat_file = data_dir / file_name
+            contents = parse_brat_file(brat_file)
+
+            if self.config.schema == "source":
+                yield idx, {
+                    "document_id": contents["document_id"],
+                    "text": contents["text"],
+                    "entities": contents["text_bound_annotations"],
+                    "relations": [
+                        {
+                            "id": relation["id"],
+                            "type": relation["type"],
+                            "arg1": relation["head"]["ref_id"],
+                            "arg2": relation["tail"]["ref_id"],
+                        }
+                        for relation in contents["relations"]
+                    ],
+                }
+
+            elif self.config.schema == "bigbio_kb":
+                yield idx, {
+                    "id": next(uid),
+                    "document_id": contents["document_id"],
+                    "passages": [
+                        {
+                            "id": next(uid),
+                            "type": "",
+                            "text": [contents["text"]],
+                            "offsets": [(0, len(contents["text"]))],
+                        }
+                    ],
+                    "entities": [
+                        {
+                            "id": f"{idx}_{entity['id']}",
+                            "type": entity["type"],
+                            "offsets": entity["offsets"],
+                            "text": entity["text"],
+                            "normalized": [],
+                        }
+                        for entity in contents["text_bound_annotations"]
+                    ],
+                    "events": [],
+                    "coreferences": [],
+                    "relations": [
+                        {
+                            "id": f"{idx}_{relation['id']}",
+                            "type": relation["type"],
+                            "arg1_id": f"{idx}_{relation['head']['ref_id']}",
+                            "arg2_id": f"{idx}_{relation['tail']['ref_id']}",
+                            "normalized": [],
+                        }
+                        for relation in contents["relations"]
+                    ],
+                }
+            else:
+                raise NotImplementedError(self.config.schema)

--- a/hub/hubscripts/chemdner_hub.py
+++ b/hub/hubscripts/chemdner_hub.py
@@ -1,0 +1,417 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+from typing import Dict, Iterator, List, Tuple
+
+import bioc
+import datasets
+from bioc import biocxml
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{Krallinger2015,
+  title        = {The CHEMDNER corpus of chemicals and drugs and its annotation principles},
+  author       = {
+    Krallinger, Martin and Rabal, Obdulia and Leitner, Florian and Vazquez,
+    Miguel and Salgado, David and Lu, Zhiyong and Leaman, Robert and Lu, Yanan
+    and Ji, Donghong and Lowe, Daniel M. and Sayle, Roger A. and
+    Batista-Navarro, Riza Theresa and Rak, Rafal and Huber, Torsten and
+    Rockt{\"a}schel, Tim and Matos, S{\'e}rgio and Campos, David and Tang,
+    Buzhou and Xu, Hua and Munkhdalai, Tsendsuren and Ryu, Keun Ho and Ramanan,
+    S. V. and Nathan, Senthil and {\v{Z}}itnik, Slavko and Bajec, Marko and
+    Weber, Lutz and Irmer, Matthias and Akhondi, Saber A. and Kors, Jan A. and
+    Xu, Shuo and An, Xin and Sikdar, Utpal Kumar and Ekbal, Asif and Yoshioka,
+    Masaharu and Dieb, Thaer M. and Choi, Miji and Verspoor, Karin and Khabsa,
+    Madian and Giles, C. Lee and Liu, Hongfang and Ravikumar, Komandur
+    Elayavilli and Lamurias, Andre and Couto, Francisco M. and Dai, Hong-Jie
+    and Tsai, Richard Tzong-Han and Ata, Caglar and Can, Tolga and Usi{\'e},
+    Anabel and Alves, Rui and Segura-Bedmar, Isabel and Mart{\'i}nez, Paloma
+    and Oyarzabal, Julen and Valencia, Alfonso
+  },
+  year         = 2015,
+  month        = {Jan},
+  day          = 19,
+  journal      = {Journal of Cheminformatics},
+  volume       = 7,
+  number       = 1,
+  pages        = {S2},
+  doi          = {10.1186/1758-2946-7-S1-S2},
+  issn         = {1758-2946},
+  url          = {https://doi.org/10.1186/1758-2946-7-S1-S2},
+  abstract     = {
+    The automatic extraction of chemical information from text requires the
+    recognition of chemical entity mentions as one of its key steps. When
+    developing supervised named entity recognition (NER) systems, the
+    availability of a large, manually annotated text corpus is desirable.
+    Furthermore, large corpora permit the robust evaluation and comparison of
+    different approaches that detect chemicals in documents. We present the
+    CHEMDNER corpus, a collection of 10,000 PubMed abstracts that contain a
+    total of 84,355 chemical entity mentions labeled manually by expert
+    chemistry literature curators, following annotation guidelines specifically
+    defined for this task. The abstracts of the CHEMDNER corpus were selected
+    to be representative for all major chemical disciplines. Each of the
+    chemical entity mentions was manually labeled according to its
+    structure-associated chemical entity mention (SACEM) class: abbreviation,
+    family, formula, identifier, multiple, systematic and trivial. The
+    difficulty and consistency of tagging chemicals in text was measured using
+    an agreement study between annotators, obtaining a percentage agreement of
+    91. For a subset of the CHEMDNER corpus (the test set of 3,000 abstracts)
+    we provide not only the Gold Standard manual annotations, but also mentions
+    automatically detected by the 26 teams that participated in the BioCreative
+    IV CHEMDNER chemical mention recognition task. In addition, we release the
+    CHEMDNER silver standard corpus of automatically extracted mentions from
+    17,000 randomly selected PubMed abstracts. A version of the CHEMDNER corpus
+    in the BioC format has been generated as well. We propose a standard for
+    required minimum information about entity annotations for the construction
+    of domain specific corpora on chemical and drug entities. The CHEMDNER
+    corpus and annotation guidelines are available at:
+    ttp://www.biocreative.org/resources/biocreative-iv/chemdner-corpus/
+  }
+}
+"""
+
+_DESCRIPTION = """\
+We present the CHEMDNER corpus, a collection of 10,000 PubMed abstracts that
+contain a total of 84,355 chemical entity mentions labeled manually by expert
+chemistry literature curators, following annotation guidelines specifically
+defined for this task. The abstracts of the CHEMDNER corpus were selected to be
+representative for all major chemical disciplines. Each of the chemical entity
+mentions was manually labeled according to its structure-associated chemical
+entity mention (SACEM) class: abbreviation, family, formula, identifier,
+multiple, systematic and trivial.
+"""
+
+_DATASETNAME = "chemdner"
+_DISPLAYNAME = "CHEMDNER"
+
+_HOMEPAGE = "https://biocreative.bioinformatics.udel.edu/resources/biocreative-iv/chemdner-corpus/"
+
+_LICENSE = 'License information unavailable'
+
+_URLs = {
+    "source": "https://ftp.ncbi.nlm.nih.gov/pub/lu/BC7-NLM-Chem-track/BC7T2-CHEMDNER-corpus_v2.BioC.xml.gz",
+    "bigbio_kb": "https://ftp.ncbi.nlm.nih.gov/pub/lu/BC7-NLM-Chem-track/BC7T2-CHEMDNER-corpus_v2.BioC.xml.gz",
+    "bigbio_text": "https://ftp.ncbi.nlm.nih.gov/pub/lu/BC7-NLM-Chem-track/BC7T2-CHEMDNER-corpus_v2.BioC.xml.gz",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.TEXT_CLASSIFICATION,
+]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class CHEMDNERDataset(datasets.GeneratorBasedBuilder):
+    """CHEMDNER"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="chemdner_source",
+            version=SOURCE_VERSION,
+            description="CHEMDNER source schema",
+            schema="source",
+            subset_id="chemdner",
+        ),
+        BigBioConfig(
+            name="chemdner_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="CHEMDNER BigBio schema (KB)",
+            schema="bigbio_kb",
+            subset_id="chemdner",
+        ),
+        BigBioConfig(
+            name="chemdner_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="CHEMDNER BigBio schema (TEXT)",
+            schema="bigbio_text",
+            subset_id="chemdner",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "chemdner_source"
+
+    def _info(self):
+
+        if self.config.schema == "source":
+            # this is a variation on the BioC format
+            features = datasets.Features(
+                {
+                    "passages": [
+                        {
+                            "document_id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                            "offset": datasets.Value("int32"),
+                            "entities": [
+                                {
+                                    "id": datasets.Value("string"),
+                                    "offsets": [[datasets.Value("int32")]],
+                                    "text": [datasets.Value("string")],
+                                    "type": datasets.Value("string"),
+                                    "normalized": [
+                                        {
+                                            "db_name": datasets.Value("string"),
+                                            "db_id": datasets.Value("string"),
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ]
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        elif self.config.schema == "bigbio_text":
+            features = text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            supervised_keys=None,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+
+        my_urls = _URLs[self.config.schema]
+        data_dir = dl_manager.download_and_extract(my_urls) + "/"
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # These kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "BC7T2-CHEMDNER-corpus-training.BioC.xml"
+                    ),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                # These kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "BC7T2-CHEMDNER-corpus-evaluation.BioC.xml"
+                    ),
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                # These kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "BC7T2-CHEMDNER-corpus-development.BioC.xml"
+                    ),
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _get_passages_and_entities(
+        self, d: bioc.BioCDocument
+    ) -> Tuple[List[Dict], List[List[Dict]]]:
+
+        passages: List[Dict] = []
+        entities: List[List[Dict]] = []
+
+        text_total_length = 0
+
+        po_start = 0
+
+        for i, p in enumerate(d.passages):
+
+            eo = p.offset - text_total_length
+
+            text_total_length += len(p.text) + 1
+
+            po_end = po_start + len(p.text)
+
+            dp = {
+                "text": p.text,
+                "type": p.infons.get("type"),
+                "offsets": [(po_start, po_end)],
+                "offset": p.offset,  # original offset
+            }
+
+            po_start = po_end + 1
+
+            passages.append(dp)
+
+            pe = []
+
+            for a in p.annotations:
+
+                a_type = a.infons.get("type")
+
+                if (
+                    self.config.schema == "bigbio_kb"
+                    and a_type == "MeSH_Indexing_Chemical"
+                ):
+                    continue
+
+                if (
+                    a.text == None or a.text == ""
+                ) and self.config.schema == "bigbio_kb":
+                    continue
+
+                offsets, text = get_texts_and_offsets_from_bioc_ann(a)
+
+                da = {
+                    "type": a_type,
+                    "offsets": [(start - eo, end - eo) for (start, end) in offsets],
+                    "text": text,
+                    "id": a.id,
+                    "normalized": self._get_normalized(a),
+                }
+
+                pe.append(da)
+
+            entities.append(pe)
+
+        return passages, entities
+
+    def _get_normalized(self, a: bioc.BioCAnnotation) -> List[Dict]:
+        """
+        Get normalization DB and ID from annotation identifiers
+        """
+
+        identifiers = a.infons.get("identifier")
+
+        if identifiers is not None:
+
+            identifiers = re.split(r",|;", identifiers)
+
+            identifiers = [i for i in identifiers if i != "-"]
+
+            normalized = [i.split(":") for i in identifiers]
+
+            normalized = [
+                {"db_name": elems[0], "db_id": elems[1]} for elems in normalized
+            ]
+
+        else:
+
+            # No normalization
+            normalized = []
+
+        return normalized
+
+    def _get_textcls_example(self, d: bioc.BioCDocument) -> Dict:
+
+        example = {"document_id": d.id, "text": [], "labels": []}
+
+        for p in d.passages:
+
+            example["text"].append(p.text)
+
+            for a in p.annotations:
+
+                if a.infons.get("type") == "MeSH_Indexing_Chemical":
+
+                    example["labels"].append(a.infons.get("identifier"))
+
+        example["text"] = " ".join(example["text"])
+
+        return example
+
+    def _generate_examples(
+        self,
+        filepath: str,
+        split: str,
+    ) -> Iterator[Tuple[int, Dict]]:
+        """Yields examples as (key, example) tuples."""
+
+        reader = biocxml.BioCXMLDocumentReader(str(filepath))
+
+        if self.config.schema == "source":
+
+            for uid, doc in enumerate(reader):
+
+                passages, passages_entities = self._get_passages_and_entities(doc)
+
+                for p, pe in zip(passages, passages_entities):
+
+                    p.pop("offsets")  # BioC has only start for passages offsets
+
+                    p["document_id"] = doc.id
+                    p["entities"] = pe  # BioC has per passage entities
+
+                yield uid, {"passages": passages}
+
+        elif self.config.schema == "bigbio_kb":
+
+            uid = 0
+
+            for idx, doc in enumerate(reader):
+
+                passages, passages_entities = self._get_passages_and_entities(doc)
+
+                # global id
+                uid += 1
+
+                # unpack per-passage entities
+                entities = [e for pe in passages_entities for e in pe]
+
+                for p in passages:
+                    p.pop("offset")  # drop original offset
+                    p["text"] = (p["text"],)  # text in passage is Sequence
+                    p["id"] = uid  # override BioC default id
+                    uid += 1
+
+                for e in entities:
+                    e["id"] = uid  # override BioC default id
+                    uid += 1
+
+                yield idx, {
+                    "id": uid,
+                    "document_id": doc.id,
+                    "passages": passages,
+                    "entities": entities,
+                    "events": [],
+                    "coreferences": [],
+                    "relations": [],
+                }
+
+        elif self.config.schema == "bigbio_text":
+
+            uid = 0
+
+            for idx, doc in enumerate(reader):
+
+                example = self._get_textcls_example(doc)
+                example["id"] = uid
+
+                # global id
+                uid += 1
+
+                yield idx, example

--- a/hub/hubscripts/chemprot_hub.py
+++ b/hub/hubscripts/chemprot_hub.py
@@ -1,0 +1,446 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+The BioCreative VI Chemical-Protein interaction dataset identifies entities of
+chemicals and proteins and their likely relation to one other. Compounds are
+generally agonists (activators) or antagonists (inhibitors) of proteins. The
+script loads dataset in bigbio schema (using knowledgebase schema: schemas/kb)
+AND/OR source (default) schema
+"""
+import os
+from typing import Dict, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{DBLP:journals/biodb/LiSJSWLDMWL16,
+  author    = {Krallinger, M., Rabal, O., Lourenço, A.},
+  title     = {Overview of the BioCreative VI chemical-protein interaction Track},
+  journal   = {Proceedings of the BioCreative VI Workshop,},
+  volume    = {141-146},
+  year      = {2017},
+  url       = {https://biocreative.bioinformatics.udel.edu/tasks/biocreative-vi/track-5/},
+  doi       = {},
+  biburl    = {},
+  bibsource = {}
+}
+"""
+_DESCRIPTION = """\
+The BioCreative VI Chemical-Protein interaction dataset identifies entities of
+chemicals and proteins and their likely relation to one other. Compounds are
+generally agonists (activators) or antagonists (inhibitors) of proteins.
+"""
+
+_DATASETNAME = "chemprot"
+_DISPLAYNAME = "ChemProt"
+
+_HOMEPAGE = "https://biocreative.bioinformatics.udel.edu/tasks/biocreative-vi/track-5/"
+
+_LICENSE = 'Public Domain Mark 1.0'
+
+_URLs = {
+    "source": "https://biocreative.bioinformatics.udel.edu/media/store/files/2017/ChemProt_Corpus.zip",
+    "bigbio_kb": "https://biocreative.bioinformatics.udel.edu/media/store/files/2017/ChemProt_Corpus.zip",
+}
+
+_SUPPORTED_TASKS = [Tasks.RELATION_EXTRACTION, Tasks.NAMED_ENTITY_RECOGNITION]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+# Chemprot specific variables
+# NOTE: There are 3 examples (2 in dev, 1 in training) with CPR:0
+_GROUP_LABELS = {
+    "CPR:0": "Undefined",
+    "CPR:1": "Part_of",
+    "CPR:2": "Regulator",
+    "CPR:3": "Upregulator",
+    "CPR:4": "Downregulator",
+    "CPR:5": "Agonist",
+    "CPR:6": "Antagonist",
+    "CPR:7": "Modulator",
+    "CPR:8": "Cofactor",
+    "CPR:9": "Substrate",
+    "CPR:10": "Not",
+}
+
+
+class ChemprotDataset(datasets.GeneratorBasedBuilder):
+    """BioCreative VI Chemical-Protein Interaction Task."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="chemprot_full_source",
+            version=SOURCE_VERSION,
+            description="chemprot source schema",
+            schema="source",
+            subset_id="chemprot_full",
+        ),
+        BigBioConfig(
+            name="chemprot_shared_task_eval_source",
+            version=SOURCE_VERSION,
+            description="chemprot source schema with only the relation types that were used in the shared task evaluation",
+            schema="source",
+            subset_id="chemprot_shared_task_eval",
+        ),
+        BigBioConfig(
+            name="chemprot_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="chemprot BigBio schema",
+            schema="bigbio_kb",
+            subset_id="chemprot",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "chemprot_full_source"
+
+    def _info(self):
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "pmid": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "entities": datasets.Sequence(
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                            "offsets": datasets.Sequence(datasets.Value("int64")),
+                        }
+                    ),
+                    "relations": datasets.Sequence(
+                        {
+                            "type": datasets.Value("string"),
+                            "arg1": datasets.Value("string"),
+                            "arg2": datasets.Value("string"),
+                        }
+                    ),
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+        my_urls = _URLs[self.config.schema]
+        data_dir = dl_manager.download_and_extract(my_urls)
+
+        # Extract each of the individual folders
+        # NOTE: omitting "extract" call cause it uses a new folder
+        train_path = dl_manager.extract(
+            os.path.join(data_dir, "ChemProt_Corpus/chemprot_training.zip")
+        )
+        test_path = dl_manager.extract(
+            os.path.join(data_dir, "ChemProt_Corpus/chemprot_test_gs.zip")
+        )
+        dev_path = dl_manager.extract(
+            os.path.join(data_dir, "ChemProt_Corpus/chemprot_development.zip")
+        )
+        sample_path = dl_manager.extract(
+            os.path.join(data_dir, "ChemProt_Corpus/chemprot_sample.zip")
+        )
+
+        return [
+            datasets.SplitGenerator(
+                name="sample",  # should be a named split : /
+                gen_kwargs={
+                    "filepath": os.path.join(sample_path, "chemprot_sample"),
+                    "abstract_file": "chemprot_sample_abstracts.tsv",
+                    "entity_file": "chemprot_sample_entities.tsv",
+                    "relation_file": "chemprot_sample_relations.tsv",
+                    "gold_standard_file": "chemprot_sample_gold_standard.tsv",
+                    "split": "sample",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(train_path, "chemprot_training"),
+                    "abstract_file": "chemprot_training_abstracts.tsv",
+                    "entity_file": "chemprot_training_entities.tsv",
+                    "relation_file": "chemprot_training_relations.tsv",
+                    "gold_standard_file": "chemprot_training_gold_standard.tsv",
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(test_path, "chemprot_test_gs"),
+                    "abstract_file": "chemprot_test_abstracts_gs.tsv",
+                    "entity_file": "chemprot_test_entities_gs.tsv",
+                    "relation_file": "chemprot_test_relations_gs.tsv",
+                    "gold_standard_file": "chemprot_test_gold_standard.tsv",
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(dev_path, "chemprot_development"),
+                    "abstract_file": "chemprot_development_abstracts.tsv",
+                    "entity_file": "chemprot_development_entities.tsv",
+                    "relation_file": "chemprot_development_relations.tsv",
+                    "gold_standard_file": "chemprot_development_gold_standard.tsv",
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(
+        self,
+        filepath,
+        abstract_file,
+        entity_file,
+        relation_file,
+        gold_standard_file,
+        split,
+    ):
+        """Yields examples as (key, example) tuples."""
+        if self.config.schema == "source":
+            abstracts = self._get_abstract(os.path.join(filepath, abstract_file))
+
+            entities, entity_id = self._get_entities(
+                os.path.join(filepath, entity_file)
+            )
+
+            if self.config.subset_id == "chemprot_full":
+                relations = self._get_relations(os.path.join(filepath, relation_file))
+            elif self.config.subset_id == "chemprot_shared_task_eval":
+                relations = self._get_relations_gs(
+                    os.path.join(filepath, gold_standard_file)
+                )
+            else:
+                raise ValueError(self.config)
+
+            for id_, pmid in enumerate(abstracts.keys()):
+                yield id_, {
+                    "pmid": pmid,
+                    "text": abstracts[pmid],
+                    "entities": entities[pmid],
+                    "relations": relations.get(pmid, []),
+                }
+
+        elif self.config.schema == "bigbio_kb":
+
+            abstracts = self._get_abstract(os.path.join(filepath, abstract_file))
+            entities, entity_id = self._get_entities(
+                os.path.join(filepath, entity_file)
+            )
+            relations = self._get_relations(
+                os.path.join(filepath, relation_file), is_mapped=True
+            )
+
+            uid = 0
+            for id_, pmid in enumerate(abstracts.keys()):
+                data = {
+                    "id": str(uid),
+                    "document_id": str(pmid),
+                    "passages": [],
+                    "entities": [],
+                    "relations": [],
+                    "events": [],
+                    "coreferences": [],
+                }
+                uid += 1
+
+                data["passages"] = [
+                    {
+                        "id": str(uid),
+                        "type": "title and abstract",
+                        "text": [abstracts[pmid]],
+                        "offsets": [[0, len(abstracts[pmid])]],
+                    }
+                ]
+                uid += 1
+
+                entity_to_id = {}
+                for entity in entities[pmid]:
+                    _text = entity["text"]
+                    entity.update({"text": [_text]})
+                    entity_to_id[entity["id"]] = str(uid)
+                    entity.update({"id": str(uid)})
+                    _offsets = entity["offsets"]
+                    entity.update({"offsets": [_offsets]})
+                    entity["normalized"] = []
+                    data["entities"].append(entity)
+                    uid += 1
+
+                for relation in relations.get(pmid, []):
+                    relation["arg1_id"] = entity_to_id[relation.pop("arg1")]
+                    relation["arg2_id"] = entity_to_id[relation.pop("arg2")]
+                    relation.update({"id": str(uid)})
+                    relation["normalized"] = []
+                    data["relations"].append(relation)
+                    uid += 1
+
+                yield id_, data
+
+    @staticmethod
+    def _get_abstract(abs_filename: str) -> Dict[str, str]:
+        """
+        For each document in PubMed ID (PMID) in the ChemProt abstract data file, return the abstract. Data is tab-separated.
+
+        :param filename: `*_abstracts.tsv from ChemProt
+
+        :returns Dictionary with PMID keys and abstract text as values.
+        """
+        with open(abs_filename, "r") as f:
+            contents = [i.strip() for i in f.readlines()]
+
+        # PMID is the first column, Abstract is last
+        return {
+            doc.split("\t")[0]: "\n".join(doc.split("\t")[1:]) for doc in contents
+        }  # Includes title as line 1
+
+    @staticmethod
+    def _get_entities(ents_filename: str) -> Tuple[Dict[str, str]]:
+        """
+        For each document in the corpus, return entity annotations per PMID.
+        Each column in the entity file is as follows:
+        (1) PMID
+        (2) Entity Number
+        (3) Entity Type (Chemical, Gene-Y, Gene-N)
+        (4) Start index
+        (5) End index
+        (6) Actual text of entity
+
+        :param ents_filename: `_*entities.tsv` file from ChemProt
+
+        :returns: Dictionary with PMID keys and entity annotations.
+        """
+        with open(ents_filename, "r") as f:
+            contents = [i.strip() for i in f.readlines()]
+
+        entities = {}
+        entity_id = {}
+
+        for line in contents:
+
+            pmid, idx, label, start_offset, end_offset, name = line.split("\t")
+
+            # Populate entity dictionary
+            if pmid not in entities:
+                entities[pmid] = []
+
+            ann = {
+                "offsets": [int(start_offset), int(end_offset)],
+                "text": name,
+                "type": label,
+                "id": idx,
+            }
+
+            entities[pmid].append(ann)
+
+            # Populate entity mapping
+            entity_id.update({idx: name})
+
+        return entities, entity_id
+
+    @staticmethod
+    def _get_relations(rel_filename: str, is_mapped: bool = False) -> Dict[str, str]:
+        """For each document in the ChemProt corpus, create an annotation for all relationships.
+
+        :param is_mapped: Whether to convert into NL the relation tags. Default is OFF
+        """
+        with open(rel_filename, "r") as f:
+            contents = [i.strip() for i in f.readlines()]
+
+        relations = {}
+
+        for line in contents:
+            pmid, label, _, _, arg1, arg2 = line.split("\t")
+            arg1 = arg1.split("Arg1:")[-1]
+            arg2 = arg2.split("Arg2:")[-1]
+
+            if pmid not in relations:
+                relations[pmid] = []
+
+            if is_mapped:
+                label = _GROUP_LABELS[label]
+
+            ann = {
+                "type": label,
+                "arg1": arg1,
+                "arg2": arg2,
+            }
+
+            relations[pmid].append(ann)
+
+        return relations
+
+    @staticmethod
+    def _get_relations_gs(rel_filename: str, is_mapped: bool = False) -> Dict[str, str]:
+        """
+        For each document in the ChemProt corpus, create an annotation for the gold-standard relationships.
+
+        The columns include:
+        (1) PMID
+        (2) Relationship Label (CPR)
+        (3) Used in shared task
+        (3) Interactor Argument 1 Entity Identifier
+        (4) Interactor Argument 2 Entity Identifier
+
+        Gold standard includes CPRs 3-9. Relationships are always Gene + Protein.
+        Unlike entities, there is no counter, hence once must be made
+
+        :param rel_filename: Gold standard file name
+        :param ent_dict: Entity Identifier to text
+        """
+        with open(rel_filename, "r") as f:
+            contents = [i.strip() for i in f.readlines()]
+
+        relations = {}
+
+        for line in contents:
+            pmid, label, arg1, arg2 = line.split("\t")
+            arg1 = arg1.split("Arg1:")[-1]
+            arg2 = arg2.split("Arg2:")[-1]
+
+            if pmid not in relations:
+                relations[pmid] = []
+
+            if is_mapped:
+                label = _GROUP_LABELS[label]
+
+            ann = {
+                "type": label,
+                "arg1": arg1,
+                "arg2": arg2,
+            }
+
+            relations[pmid].append(ann)
+
+        return relations

--- a/hub/hubscripts/chia_hub.py
+++ b/hub/hubscripts/chia_hub.py
@@ -1,0 +1,647 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+A large annotated corpus of patient eligibility criteria extracted from 1,000
+interventional, Phase IV clinical trials registered in ClinicalTrials.gov. This
+dataset includes 12,409 annotated eligibility criteria, represented by 41,487
+distinctive entities of 15 entity types and 25,017 relationships of 12
+relationship types."""
+from pathlib import Path
+from typing import Dict, Iterator, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@article{kury2020chia,
+  title        = {Chia, a large annotated corpus of clinical trial eligibility criteria},
+  author       = {
+    Kury, Fabr{\'\\i}cio and Butler, Alex and Yuan, Chi and Fu, Li-heng and
+    Sun, Yingcheng and Liu, Hao and Sim, Ida and Carini, Simona and Weng,
+    Chunhua
+  },
+  year         = 2020,
+  journal      = {Scientific data},
+  publisher    = {Nature Publishing Group},
+  volume       = 7,
+  number       = 1,
+  pages        = {1--11}
+}
+"""
+
+_DATASETNAME = "chia"
+_DISPLAYNAME = "CHIA"
+
+_DESCRIPTION = """\
+A large annotated corpus of patient eligibility criteria extracted from 1,000
+interventional, Phase IV clinical trials registered in ClinicalTrials.gov. This
+dataset includes 12,409 annotated eligibility criteria, represented by 41,487
+distinctive entities of 15 entity types and 25,017 relationships of 12
+relationship types.
+"""
+
+_HOMEPAGE = "https://github.com/WengLab-InformaticsResearch/CHIA"
+
+_LICENSE = 'Creative Commons Attribution 4.0 International'
+
+_URLS = {
+    _DATASETNAME: "https://figshare.com/ndownloader/files/21728850",
+    _DATASETNAME + "_wo_scope": "https://figshare.com/ndownloader/files/21728853",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
+
+_SOURCE_VERSION = "2.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+# For further information see appendix of the publication
+_DOMAIN_ENTITY_TYPES = [
+    "Condition",
+    "Device",
+    "Drug",
+    "Measurement",
+    "Observation",
+    "Person",
+    "Procedure",
+    "Visit",
+]
+
+# For further information see appendix of the publication
+_FIELD_ENTITY_TYPES = [
+    "Temporal",
+    "Value",
+]
+
+# For further information see appendix of the publication
+_CONSTRUCT_ENTITY_TYPES = [
+    "Scope",  # Not part of the "without scope" schema / version
+    "Negation",
+    "Multiplier",
+    "Qualifier",
+    "Reference_point",
+    "Mood",
+]
+
+_ALL_ENTITY_TYPES = _DOMAIN_ENTITY_TYPES + _FIELD_ENTITY_TYPES + _CONSTRUCT_ENTITY_TYPES
+
+_RELATION_TYPES = [
+    "AND",
+    "OR",
+    "SUBSUMES",
+    "HAS_NEGATION",
+    "HAS_MULTIPLIER",
+    "HAS_QUALIFIER",
+    "HAS_VALUE",
+    "HAS_TEMPORAL",
+    "HAS_INDEX",
+    "HAS_MOOD",
+    "HAS_CONTEXT ",
+    "HAS_SCOPE",  # Not part of the "without scope" schema / version
+]
+
+_MAX_OFFSET_CORRECTION = 100
+
+
+class ChiaDataset(datasets.GeneratorBasedBuilder):
+    """
+    A large annotated corpus of patient eligibility criteria extracted from 1,000 interventional,
+    Phase IV clinical trials registered in ClinicalTrials.gov.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="chia_source",
+            version=SOURCE_VERSION,
+            description="Chia source schema",
+            schema="source",
+            subset_id="chia",
+        ),
+        BigBioConfig(
+            name="chia_fixed_source",
+            version=SOURCE_VERSION,
+            description="Chia source schema (with fixed entity offsets)",
+            schema="source",
+            subset_id="chia_fixed",
+        ),
+        BigBioConfig(
+            name="chia_without_scope_source",
+            version=SOURCE_VERSION,
+            description="Chia without scope source schema",
+            schema="source",
+            subset_id="chia_without_scope",
+        ),
+        BigBioConfig(
+            name="chia_without_scope_fixed_source",
+            version=SOURCE_VERSION,
+            description="Chia without scope source schema (with fixed entity offsets)",
+            schema="source",
+            subset_id="chia_without_scope_fixed",
+        ),
+        BigBioConfig(
+            name="chia_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="Chia BigBio schema",
+            schema="bigbio_kb",
+            subset_id="chia",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "chia_source"
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value(
+                        "string"
+                    ),  # NCT-ID from clinicialtrials.gov
+                    "text": datasets.Value("string"),
+                    "text_type": datasets.Value(
+                        "string"
+                    ),  # inclusion or exclusion (criteria)
+                    "entities": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "normalized": [
+                                {
+                                    "db_name": datasets.Value("string"),
+                                    "db_id": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                    "relations": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arg1_id": datasets.Value("string"),
+                            "arg2_id": datasets.Value("string"),
+                            "normalized": [
+                                {
+                                    "db_name": datasets.Value("string"),
+                                    "db_id": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        url_key = _DATASETNAME
+
+        if self.config.subset_id.startswith("chia_without_scope"):
+            url_key += "_wo_scope"
+
+        urls = _URLS[url_key]
+        data_dir = Path(dl_manager.download_and_extract(urls))
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"data_dir": data_dir},
+            )
+        ]
+
+    def _generate_examples(self, data_dir: Path) -> Iterator[Tuple[str, Dict]]:
+        if self.config.schema == "source":
+            fix_offsets = "fixed" in self.config.subset_id
+
+            for file in data_dir.iterdir():
+                if not file.name.endswith(".txt"):
+                    continue
+
+                brat_example = parse_brat_file(file, [".ann"])
+                source_example = self._to_source_example(
+                    file, brat_example, fix_offsets
+                )
+                yield source_example["id"], source_example
+
+        elif self.config.schema == "bigbio_kb":
+            for file in data_dir.iterdir():
+                if not file.name.endswith(".txt"):
+                    continue
+
+                brat_example = parse_brat_file(file, [".ann"])
+                source_example = self._to_source_example(file, brat_example, True)
+
+                bigbio_example = {
+                    "id": source_example["id"],
+                    "document_id": source_example["document_id"],
+                    "passages": [
+                        {
+                            "id": source_example["id"] + "_text",
+                            "type": source_example["text_type"],
+                            "text": [source_example["text"]],
+                            "offsets": [[0, len(source_example["text"])]],
+                        }
+                    ],
+                    "entities": source_example["entities"],
+                    "relations": source_example["relations"],
+                    "events": [],
+                    "coreferences": [],
+                }
+
+                yield bigbio_example["id"], bigbio_example
+
+    def _to_source_example(
+        self, input_file: Path, brat_example: Dict, fix_offsets: bool
+    ) -> Dict:
+        """
+        Converts the generic brat example to the source schema format.
+        """
+        example_id = str(input_file.stem)
+        document_id = example_id.split("_")[0]
+        criteria_type = "inclusion" if "_inc" in input_file.stem else "exclusion"
+
+        text = brat_example["text"]
+
+        source_example = {
+            "id": example_id,
+            "document_id": document_id,
+            "text_type": criteria_type,
+            "text": text,
+            "entities": [],
+            "relations": [],
+        }
+
+        example_prefix = example_id + "_"
+        entity_ids = {}
+
+        for tb_annotation in brat_example["text_bound_annotations"]:
+            if tb_annotation["type"].capitalize() not in _ALL_ENTITY_TYPES:
+                continue
+
+            entity_ann = tb_annotation.copy()
+            entity_ann["id"] = example_prefix + entity_ann["id"]
+            entity_ids[entity_ann["id"]] = True
+
+            if fix_offsets:
+                if len(entity_ann["offsets"]) > 1:
+                    entity_ann["text"] = self._get_texts_for_multiple_offsets(
+                        text, entity_ann["offsets"]
+                    )
+
+                fixed_offsets = []
+                fixed_texts = []
+                for entity_text, offsets in zip(
+                    entity_ann["text"], entity_ann["offsets"]
+                ):
+                    fixed_offset = self._fix_entity_offsets(text, entity_text, offsets)
+                    fixed_offsets.append(fixed_offset)
+                    fixed_texts.append(text[fixed_offset[0] : fixed_offset[1]])
+
+                entity_ann["offsets"] = fixed_offsets
+                entity_ann["text"] = fixed_texts
+
+            entity_ann["normalized"] = []
+            source_example["entities"].append(entity_ann)
+
+        for base_rel_annotation in brat_example["relations"]:
+            if base_rel_annotation["type"].upper() not in _RELATION_TYPES:
+                continue
+
+            head_id = example_prefix + base_rel_annotation["head"]["ref_id"]
+            tail_id = example_prefix + base_rel_annotation["tail"]["ref_id"]
+
+            if head_id not in entity_ids or tail_id not in entity_ids:
+                continue
+
+            relation = {
+                "id": example_prefix + base_rel_annotation["id"],
+                "type": base_rel_annotation["type"],
+                "arg1_id": head_id,
+                "arg2_id": tail_id,
+                "normalized": [],
+            }
+
+            source_example["relations"].append(relation)
+
+        relation_id = len(brat_example["relations"]) + 10
+        for base_co_reference in brat_example["equivalences"]:
+            ref_ids = base_co_reference["ref_ids"]
+            for i, arg1 in enumerate(ref_ids[:-1]):
+                for arg2 in ref_ids[i + 1 :]:
+                    if arg1 not in entity_ids or arg2 not in entity_ids:
+                        continue
+
+                    or_relation = {
+                        "id": example_prefix + f"R{relation_id}",
+                        "type": "OR",
+                        "arg1_id": example_prefix + arg1,
+                        "arg2_id": example_prefix + arg2,
+                        "normalized": [],
+                    }
+
+                    source_example["relations"].append(or_relation)
+                    relation_id += 1
+
+        return source_example
+
+    def _fix_entity_offsets(
+        self, doc_text: str, entity_text: str, given_offsets: List[int]
+    ) -> List[int]:
+        """
+        Fixes incorrect mention offsets by checking whether the given entity mention text can be
+        found to the left or right of the given offsets by considering incrementally larger shifts.
+        """
+        left = given_offsets[0]
+        right = given_offsets[1]
+
+        # Some annotations contain whitespaces - we ignore them
+        clean_entity_text = entity_text.strip()
+
+        i = 0
+        while i <= _MAX_OFFSET_CORRECTION:
+            # Move mention window to the left
+            if doc_text[left - i : right - i].strip() == clean_entity_text:
+                return [left - i, left - i + len(clean_entity_text)]
+
+            # Move mention window to the right
+            elif doc_text[left + i : right + i].strip() == clean_entity_text:
+                return [left + i, left + i + len(clean_entity_text)]
+
+            i += 1
+
+        # We can't find any better offsets
+        return given_offsets
+
+    def _get_texts_for_multiple_offsets(
+        self, document_text: str, offsets: List[List[int]]
+    ) -> List[str]:
+        """
+        Extracts the single text span for a given list of offsets.
+        """
+        texts = []
+        for offset in offsets:
+            texts.append(document_text[offset[0] : offset[1]])
+        return texts
+
+
+def parse_brat_file(txt_file: Path, annotation_file_suffixes: List[str] = None) -> Dict:
+    """
+    Parse a brat file into the schema defined below.
+    `txt_file` should be the path to the brat '.txt' file you want to parse, e.g. 'data/1234.txt'
+    Assumes that the annotations are contained in one or more of the corresponding '.a1', '.a2' or '.ann' files,
+    e.g. 'data/1234.ann' or 'data/1234.a1' and 'data/1234.a2'.
+
+    Schema of the parse:
+       features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "trigger": datasets.Value(
+                                "string"
+                            ),  # refers to the text_bound_annotation of the trigger,
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arguments": datasets.Sequence(
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "attributes": [  # M or A lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value(
+                                "string"
+                            ),  # Name of the resource, e.g. "Wikipedia"
+                            "cuid": datasets.Value(
+                                "string"
+                            ),  # ID in the resource, e.g. 534366
+                            "text": datasets.Value(
+                                "string"
+                            ),  # Human readable description/name of the entity, e.g. "Barack Obama"
+                        }
+                    ],
+                },
+            )
+    """
+
+    example = {}
+    example["document_id"] = txt_file.with_suffix("").name
+    with txt_file.open() as f:
+        example["text"] = f.read()
+
+    # If no specific suffixes of the to-be-read annotation files are given - take standard suffixes
+    # for event extraction
+    if annotation_file_suffixes is None:
+        annotation_file_suffixes = [".a1", ".a2", ".ann"]
+
+    if len(annotation_file_suffixes) == 0:
+        raise AssertionError(
+            "At least one suffix for the to-be-read annotation files should be given!"
+        )
+
+    ann_lines = []
+    for suffix in annotation_file_suffixes:
+        annotation_file = txt_file.with_suffix(suffix)
+        if annotation_file.exists():
+            with annotation_file.open() as f:
+                ann_lines.extend(f.readlines())
+
+    example["text_bound_annotations"] = []
+    example["events"] = []
+    example["relations"] = []
+    example["equivalences"] = []
+    example["attributes"] = []
+    example["normalizations"] = []
+
+    prev_tb_annotation = None
+
+    for line in ann_lines:
+        orig_line = line
+        line = line.strip()
+        if not line:
+            continue
+
+        # If an (entity) annotation spans multiple lines, this will result in multiple
+        # lines also in the annotation file
+        if "\t" not in line and prev_tb_annotation is not None:
+            prev_tb_annotation["text"][0] += "\n" + orig_line[:-1]
+            continue
+
+        if line.startswith("T"):  # Text bound
+            ann = {}
+            fields = line.split("\t")
+
+            ann["id"] = fields[0]
+            ann["text"] = [fields[2]]
+            ann["type"] = fields[1].split()[0]
+            ann["offsets"] = []
+            span_str = parsing.remove_prefix(fields[1], (ann["type"] + " "))
+            for span in span_str.split(";"):
+                start, end = span.split()
+                ann["offsets"].append([int(start), int(end)])
+
+            example["text_bound_annotations"].append(ann)
+            prev_tb_annotation = ann
+
+        elif line.startswith("E"):
+            ann = {}
+            fields = line.split("\t")
+
+            ann["id"] = fields[0]
+
+            ann["type"], ann["trigger"] = fields[1].split()[0].split(":")
+
+            ann["arguments"] = []
+            for role_ref_id in fields[1].split()[1:]:
+                argument = {
+                    "role": (role_ref_id.split(":"))[0],
+                    "ref_id": (role_ref_id.split(":"))[1],
+                }
+                ann["arguments"].append(argument)
+
+            example["events"].append(ann)
+            prev_tb_annotation = None
+
+        elif line.startswith("R"):
+            ann = {}
+            fields = line.split("\t")
+
+            ann["id"] = fields[0]
+            ann["type"] = fields[1].split()[0]
+
+            ann["head"] = {
+                "role": fields[1].split()[1].split(":")[0],
+                "ref_id": fields[1].split()[1].split(":")[1],
+            }
+            ann["tail"] = {
+                "role": fields[1].split()[2].split(":")[0],
+                "ref_id": fields[1].split()[2].split(":")[1],
+            }
+
+            example["relations"].append(ann)
+            prev_tb_annotation = None
+
+        # '*' seems to be the legacy way to mark equivalences,
+        # but I couldn't find any info on the current way
+        # this might have to be adapted dependent on the brat version
+        # of the annotation
+        elif line.startswith("*"):
+            ann = {}
+            fields = line.split("\t")
+
+            ann["id"] = fields[0]
+            ann["ref_ids"] = fields[1].split()[1:]
+
+            example["equivalences"].append(ann)
+            prev_tb_annotation = None
+
+        elif line.startswith("A") or line.startswith("M"):
+            ann = {}
+            fields = line.split("\t")
+
+            ann["id"] = fields[0]
+
+            info = fields[1].split()
+            ann["type"] = info[0]
+            ann["ref_id"] = info[1]
+
+            if len(info) > 2:
+                ann["value"] = info[2]
+            else:
+                ann["value"] = ""
+
+            example["attributes"].append(ann)
+            prev_tb_annotation = None
+
+        elif line.startswith("N"):
+            ann = {}
+            fields = line.split("\t")
+
+            ann["id"] = fields[0]
+            ann["text"] = fields[2]
+
+            info = fields[1].split()
+
+            ann["type"] = info[0]
+            ann["ref_id"] = info[1]
+            ann["resource_name"] = info[2].split(":")[0]
+            ann["cuid"] = info[2].split(":")[1]
+
+            example["normalizations"].append(ann)
+            prev_tb_annotation = None
+
+    return example

--- a/hub/hubscripts/citation_gia_test_collection_hub.py
+++ b/hub/hubscripts/citation_gia_test_collection_hub.py
@@ -1,0 +1,350 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+from typing import List
+
+import datasets
+import xml.etree.ElementTree as ET
+import uuid
+import html
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{Wei2015,
+  title        = {
+    {GNormPlus}: An Integrative Approach for Tagging Genes,  Gene Families,
+    and Protein Domains
+  },
+  author       = {Chih-Hsuan Wei and Hung-Yu Kao and Zhiyong Lu},
+  year         = 2015,
+  journal      = {{BioMed} Research International},
+  publisher    = {Hindawi Limited},
+  volume       = 2015,
+  pages        = {1--7},
+  doi          = {10.1155/2015/918710},
+  url          = {https://doi.org/10.1155/2015/918710}
+}
+"""
+
+_DATASETNAME = "citation_gia_test_collection"
+_DISPLAYNAME = "Citation GIA Test Collection"
+
+_DESCRIPTION = """\
+The Citation GIA Test Collection was recently created for gene indexing at the
+NLM and includes 151 PubMed abstracts with both mention-level and document-level
+annotations. They are selected because both have a focus on human genes.
+"""
+
+_HOMEPAGE = "https://www.ncbi.nlm.nih.gov/research/bionlp/Tools/gnormplus/"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: [
+        "https://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/tmTools/download/GNormPlus/GNormPlusCorpus.zip"
+    ]
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class CitationGIATestCollection(datasets.GeneratorBasedBuilder):
+    """
+    The Citation GIA Test Collection was recently created for gene indexing at the
+    NLM and includes 151 PubMed abstracts with both mention-level and document-level
+    annotations. They are selected because both have a focus on human genes.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="citation_gia_test_collection_source",
+            version=SOURCE_VERSION,
+            description="citation_gia_test_collection source schema",
+            schema="source",
+            subset_id="citation_gia_test_collection",
+        ),
+        BigBioConfig(
+            name="citation_gia_test_collection_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="citation_gia_test_collection BigBio schema",
+            schema="bigbio_kb",
+            subset_id="citation_gia_test_collection",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "citation_gia_test_collection_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "passages": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                        }
+                    ],
+                    "entities": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "normalized": [
+                                {
+                                    "db_name": datasets.Value("string"),
+                                    "db_id": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir[0], "GNormPlusCorpus/NLMIAT.BioC.xml"
+                    ),
+                    "split": "NLMIAT",
+                },
+            ),
+        ]
+
+    def _get_entities(self, annot_d: dict) -> dict:
+        """'
+        Converts annotation dict to entity dict.
+        """
+        ent = {
+            "id": str(uuid.uuid4()),
+            "type": annot_d["type"],
+            "text": [annot_d["text"]],
+            "offsets": [annot_d["offsets"]],
+            "normalized": [
+                {
+                    "db_name": "NCBI Gene" if annot_d["type"].isdigit() else "",
+                    "db_id": annot_d["type"] if annot_d["type"].isdigit() else "",
+                }
+            ],
+        }
+
+        return ent
+
+    def _get_offsets_entities(
+        child, parent_text: str, child_text: str, offset: int
+    ) -> List[int]:
+        """
+        Extracts child text offsets from parent text for entities.
+        Some offsets that were present in the datset were wrong mainly because of string encodings.
+        Also a little fraction of parent strings doesn't contain its respective child strings.
+        Hence few assertion errors in the entitity offsets checking test.
+        """
+        if child_text in parent_text:
+            index = parent_text.index(child_text)
+            start = index + offset
+
+        else:
+            start = offset
+        end = start + len(child_text)
+
+        return [start, end]
+
+    def _process_annot(self, annot: ET.Element, passages: dict) -> dict:
+        """'
+        Converts annotation XML Element to Python dict.
+        """
+        parent_text = " ".join([p["text"] for p in passages.values()])
+        annot_d = dict()
+        a_d = {a.tag: a.text for a in annot}
+
+        for a in list(annot):
+
+            if a.tag == "location":
+                offset = int(a.attrib["offset"])
+                annot_d["offsets"] = self._get_offsets_entities(
+                    html.escape(parent_text[offset:]), html.escape(a_d["text"]), offset
+                )
+
+            elif a.tag != "infon":
+                annot_d[a.tag] = html.escape(a.text)
+
+            else:
+                annot_d[a.attrib["key"]] = html.escape(a.text)
+
+        return annot_d
+
+    def _parse_elem(self, elem: ET.Element) -> dict:
+        """'
+        Converts document XML Element to Python dict.
+        """
+        elem_d = dict()
+        passages = dict()
+        annotations = elem.findall(".//annotation")
+        elem_d["entities"] = []
+
+        for child in elem:
+            elem_d[child.tag] = []
+
+        for child in elem:
+            if child.tag == "passage":
+                elem_d[child.tag].append(
+                    {
+                        c.tag: html.escape(
+                            " ".join(
+                                list(
+                                    filter(
+                                        lambda item: item,
+                                        [t.strip("\n") for t in c.itertext()],
+                                    )
+                                )
+                            )
+                        )
+                        for c in child
+                    }
+                )
+
+            elif child.tag == "id":
+                elem_d[child.tag] = html.escape(child.text)
+
+        for passage in elem_d["passage"]:
+            infon = passage["infon"]
+            passage.pop("infon", None)
+            passages[infon] = passage
+
+        elem_d["passages"] = passages
+        elem_d.pop("passage", None)
+
+        for a in annotations:
+            elem_d["entities"].append(self._process_annot(a, elem_d["passages"]))
+
+        return elem_d
+
+    def _generate_examples(self, filepath, split):
+
+        root = ET.parse(filepath).getroot()
+
+        if self.config.schema == "source":
+            uid = 0
+            for elem in root.findall("document"):
+                row = self._parse_elem(elem)
+                uid += 1
+                passages = row["passages"]
+                yield uid, {
+                    "id": str(uid),
+                    "passages": [
+                        {
+                            "id": str(uuid.uuid4()),
+                            "type": "title",
+                            "text": [passages["title"]["text"]],
+                            "offsets": [
+                                [
+                                    int(passages["title"]["offset"]),
+                                    int(passages["title"]["offset"])
+                                    + len(passages["title"]["text"]),
+                                ]
+                            ],
+                        },
+                        {
+                            "id": str(uuid.uuid4()),
+                            "type": "abstract",
+                            "text": [passages["abstract"]["text"]],
+                            "offsets": [
+                                [
+                                    int(passages["abstract"]["offset"]),
+                                    int(passages["abstract"]["offset"])
+                                    + len(passages["abstract"]["text"]),
+                                ]
+                            ],
+                        },
+                    ],
+                    "entities": [self._get_entities(a) for a in row["entities"]],
+                }
+
+        elif self.config.schema == "bigbio_kb":
+            uid = 0
+            for elem in root.findall("document"):
+                row = self._parse_elem(elem)
+                uid += 1
+                passages = row["passages"]
+                yield uid, {
+                    "id": str(uid),
+                    "document_id": str(uuid.uuid4()),
+                    "passages": [
+                        {
+                            "id": str(uuid.uuid4()),
+                            "type": "title",
+                            "text": [passages["title"]["text"]],
+                            "offsets": [
+                                [
+                                    int(passages["title"]["offset"]),
+                                    int(passages["title"]["offset"])
+                                    + len(passages["title"]["text"]),
+                                ]
+                            ],
+                        },
+                        {
+                            "id": str(uuid.uuid4()),
+                            "type": "abstract",
+                            "text": [passages["abstract"]["text"]],
+                            "offsets": [
+                                [
+                                    int(passages["abstract"]["offset"]),
+                                    int(passages["abstract"]["offset"])
+                                    + len(passages["abstract"]["text"]),
+                                ]
+                            ],
+                        },
+                    ],
+                    "entities": [self._get_entities(a) for a in row["entities"]],
+                    "relations": [],
+                    "events": [],
+                    "coreferences": [],
+                }

--- a/hub/hubscripts/codiesp_hub.py
+++ b/hub/hubscripts/codiesp_hub.py
@@ -1,0 +1,462 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A dataset loading script for the CODIESP corpus.
+
+The CODIESP dataset is a collection of 1,000 manually selected clinical
+case studies in Spanish that was designed for the Clinical Case Coding
+in Spanish Shared Task, as part of the CLEF 2020 conference. This community
+task was divided into 3 sub-tasks: diagnosis coding (CodiEsp-D), procedure
+coding (CodiEsp-P) and Explainable AI (CodiEsp-X). The script can also load
+an additional dataset of abstracts with ICD10 codes.
+"""
+
+import json
+import os
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['Spanish']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@article{miranda2020overview,
+  title={Overview of Automatic Clinical Coding: Annotations, Guidelines, and Solutions for non-English Clinical Cases at CodiEsp Track of CLEF eHealth 2020.},
+  author={Miranda-Escalada, Antonio and Gonzalez-Agirre, Aitor and Armengol-Estap{\'e}, Jordi and Krallinger, Martin},
+  journal={CLEF (Working Notes)},
+  volume={2020},
+  year={2020}
+}
+"""
+
+_DATASETNAME = "codiesp"
+_DISPLAYNAME = "CodiEsp"
+
+_DESCRIPTION = """\
+Synthetic corpus of 1,000 manually selected clinical case studies in Spanish
+that was designed for the Clinical Case Coding in Spanish Shared Task, as part
+of the CLEF 2020 conference.
+
+The goal of the task was to automatically assign ICD10 codes (CIE-10, in
+Spanish) to clinical case documents, being evaluated against manually generated
+ICD10 codifications. The CodiEsp corpus was selected manually by practicing
+physicians and clinical documentalists and annotated by clinical coding
+professionals meeting strict quality criteria. They reached an inter-annotator
+agreement of 88.6% for diagnosis coding, 88.9% for procedure coding and 80.5%
+for the textual reference annotation.
+
+The final collection of 1,000 clinical cases that make up the corpus had a total
+of 16,504 sentences and 396,988 words. All documents are in Spanish language and
+CIE10 is the coding terminology (the Spanish version of ICD10-CM and ICD10-PCS).
+The CodiEsp corpus has been randomly sampled into three subsets. The train set
+contains 500 clinical cases, while the development and test sets have 250
+clinical cases each. In addition to these, a collection of 176,294 abstracts
+from Lilacs and Ibecs with the corresponding ICD10 codes (ICD10-CM and
+ICD10-PCS) was provided by the task organizers. Every abstract has at least one
+associated code, with an average of 2.5 ICD10 codes per abstract.
+
+The CodiEsp track was divided into three sub-tracks (2 main and 1 exploratory):
+
+- CodiEsp-D: The Diagnosis Coding sub-task, which requires automatic ICD10-CM
+  [CIE10-Diagnóstico] code assignment.
+- CodiEsp-P: The Procedure Coding sub-task, which requires automatic ICD10-PCS
+  [CIE10-Procedimiento] code assignment.
+- CodiEsp-X: The Explainable AI exploratory sub-task, which requires to submit
+  the reference to the predicted codes (both ICD10-CM and ICD10-PCS). The goal 
+  of this novel task was not only to predict the correct codes but also to 
+  present the reference in the text that supports the code predictions.
+
+For further information, please visit https://temu.bsc.es/codiesp or send an
+email to encargo-pln-life@bsc.es
+"""
+
+_HOMEPAGE = "https://temu.bsc.es/codiesp/"
+
+_LICENSE = 'Creative Commons Attribution 4.0 International'
+
+_URLS = {
+    "codiesp": "https://zenodo.org/record/3837305/files/codiesp.zip?download=1",
+    "extra": "https://zenodo.org/record/3606662/files/abstractsWithCIE10_v2.zip?download=1",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.TEXT_CLASSIFICATION,
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.NAMED_ENTITY_DISAMBIGUATION,
+]
+
+_SOURCE_VERSION = "1.4.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class CodiespDataset(datasets.GeneratorBasedBuilder):
+    """Collection of 1,000 manually selected clinical case studies in Spanish."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="codiesp_D_source",
+            version=SOURCE_VERSION,
+            description="CodiEsp source schema for the Diagnosis Coding subtask",
+            schema="source",
+            subset_id="codiesp_d",
+        ),
+        BigBioConfig(
+            name="codiesp_P_source",
+            version=SOURCE_VERSION,
+            description="CodiEsp source schema for the Procedure Coding sub-task",
+            schema="source",
+            subset_id="codiesp_p",
+        ),
+        BigBioConfig(
+            name="codiesp_X_source",
+            version=SOURCE_VERSION,
+            description="CodiEsp source schema for the Explainable AI sub-task",
+            schema="source",
+            subset_id="codiesp_x",
+        ),
+        BigBioConfig(
+            name="codiesp_extra_mesh_source",
+            version=SOURCE_VERSION,
+            description="Abstracts from Lilacs and Ibecs with MESH Codes",
+            schema="source",
+            subset_id="codiesp_extra_mesh",
+        ),
+        BigBioConfig(
+            name="codiesp_extra_cie_source",
+            version=SOURCE_VERSION,
+            description="Abstracts from Lilacs and Ibecs with CIE10 Codes",
+            schema="source",
+            subset_id="codiesp_extra_cie",
+        ),
+        BigBioConfig(
+            name="codiesp_D_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="CodiEsp BigBio schema for the Diagnosis Coding subtask",
+            schema="bigbio_text",
+            subset_id="codiesp_d",
+        ),
+        BigBioConfig(
+            name="codiesp_P_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="CodiEsp BigBio schema for the Procedure Coding sub-task",
+            schema="bigbio_text",
+            subset_id="codiesp_p",
+        ),
+        BigBioConfig(
+            name="codiesp_X_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="CodiEsp BigBio schema for the Explainable AI sub-task",
+            schema="bigbio_kb",
+            subset_id="codiesp_x",
+        ),
+        BigBioConfig(
+            name="codiesp_extra_mesh_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="Abstracts from Lilacs and Ibecs with MESH Codes",
+            schema="bigbio_text",
+            subset_id="codiesp_extra_mesh",
+        ),
+        BigBioConfig(
+            name="codiesp_extra_cie_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="Abstracts from Lilacs and Ibecs with CIE10 Codes",
+            schema="bigbio_text",
+            subset_id="codiesp_extra_cie",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "codiesp_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source" and self.config.name != "codiesp_X_source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "labels": datasets.Sequence(datasets.Value("string")),
+                },
+            )
+
+        elif self.config.schema == "source" and self.config.name == "codiesp_X_source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "task_x": [
+                        {
+                            "label": datasets.Value("string"),
+                            "code": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                            "spans": datasets.Sequence(datasets.Value("int32")),
+                        }
+                    ],
+                },
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        elif self.config.schema == "bigbio_text":
+            features = text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """
+        Downloads/extracts the data to generate the train, validation and test splits.
+
+        Each split is created by instantiating a `datasets.SplitGenerator`, which will
+        call `this._generate_examples` with the keyword arguments in `gen_kwargs`.
+        """
+
+        data_dir = dl_manager.download_and_extract(_URLS)
+
+        if "extra" in self.config.name:
+            return [
+                datasets.SplitGenerator(
+                    name=datasets.Split.TRAIN,
+                    gen_kwargs={
+                        "filepath": Path(
+                            os.path.join(
+                                data_dir["extra"], "abstractsWithCIE10_v2.json"
+                            )
+                        ),
+                        "split": "train",
+                    },
+                )
+            ]
+        else:
+            return [
+                datasets.SplitGenerator(
+                    name=datasets.Split.TRAIN,
+                    gen_kwargs={
+                        "filepath": Path(
+                            os.path.join(
+                                data_dir["codiesp"], "final_dataset_v4_to_publish/train"
+                            )
+                        ),
+                        "split": "train",
+                    },
+                ),
+                datasets.SplitGenerator(
+                    name=datasets.Split.TEST,
+                    gen_kwargs={
+                        "filepath": Path(
+                            os.path.join(
+                                data_dir["codiesp"], "final_dataset_v4_to_publish/test"
+                            )
+                        ),
+                        "split": "test",
+                    },
+                ),
+                datasets.SplitGenerator(
+                    name=datasets.Split.VALIDATION,
+                    gen_kwargs={
+                        "filepath": Path(
+                            os.path.join(
+                                data_dir["codiesp"], "final_dataset_v4_to_publish/dev"
+                            )
+                        ),
+                        "split": "dev",
+                    },
+                ),
+            ]
+
+    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+        """
+        This method handles input defined in _split_generators to yield (key, example) tuples from the dataset.
+        Method parameters are unpacked from `gen_kwargs` as given in `_split_generators`.
+        """
+
+        if "extra" not in self.config.name:
+            paths = {"text_files": Path(os.path.join(filepath, "text_files"))}
+            for task in ["codiesp_d", "codiesp_p", "codiesp_x"]:
+                paths[task] = Path(
+                    os.path.join(filepath, f"{split}{task[-1].upper()}.tsv")
+                )
+
+        if (
+            self.config.name == "codiesp_D_bigbio_text"
+            or self.config.name == "codiesp_P_bigbio_text"
+        ):
+            df = pd.read_csv(paths[self.config.subset_id], sep="\t", header=None)
+
+            file_codes_dict = defaultdict(list)
+            for idx, row in df.iterrows():
+                file, code = row[0], row[1]
+                file_codes_dict[file].append(code)
+
+            for guid, (file, codes) in enumerate(file_codes_dict.items()):
+                text_file = Path(os.path.join(paths["text_files"], f"{file}.txt"))
+                example = {
+                    "id": str(guid),
+                    "document_id": file,
+                    "text": text_file.read_text(),
+                    "labels": codes,
+                }
+                yield guid, example
+
+        elif self.config.name == "codiesp_X_bigbio_kb":
+            df = pd.read_csv(paths[self.config.subset_id], sep="\t", header=None)
+
+            task_x_dict = defaultdict(list)
+            for idx, row in df.iterrows():
+                file, label, code, text, spans = row[0], row[1], row[2], row[3], row[4]
+
+                appearances = spans.split(";")
+                spans = []
+                for a in appearances:
+                    spans.append((int(a.split()[0]), int(a.split()[1])))
+
+                task_x_dict[file].append(
+                    {"label": label, "code": code, "text": text, "spans": spans}
+                )
+
+            for guid, (file, data) in enumerate(task_x_dict.items()):
+                example = {
+                    "id": str(guid),
+                    "document_id": file,
+                    "passages": [],
+                    "entities": [],
+                    "events": [],
+                    "coreferences": [],
+                    "relations": [],
+                }
+
+                for idx, d in enumerate(data):
+                    example["entities"].append(
+                        {
+                            "id": str(guid) + str(idx),
+                            "type": d["label"],
+                            "text": [d["text"]],
+                            "offsets": d["spans"],
+                            "normalized": [
+                                {
+                                    "db_name": "ICD10-PCS"
+                                    if d["label"] == "PROCEDIMIENTO"
+                                    else "ICD10-CM",
+                                    "db_id": d["code"],
+                                }
+                            ],
+                        }
+                    )
+
+                yield guid, example
+
+        elif (
+            self.config.name == "codiesp_D_source"
+            or self.config.name == "codiesp_P_source"
+        ):
+            df = pd.read_csv(paths[self.config.subset_id], sep="\t", header=None)
+
+            file_codes_dict = defaultdict(list)
+            for idx, row in df.iterrows():
+                file, code = row[0], row[1]
+                file_codes_dict[file].append(code)
+
+            for guid, (file, codes) in enumerate(file_codes_dict.items()):
+                example = {
+                    "id": guid,
+                    "document_id": file,
+                    "text": Path(
+                        os.path.join(paths["text_files"], f"{file}.txt")
+                    ).read_text(),
+                    "labels": codes,
+                }
+
+                yield guid, example
+
+        elif self.config.name == "codiesp_X_source":
+            df = pd.read_csv(paths[self.config.subset_id], sep="\t", header=None)
+            file_codes_dict = defaultdict(list)
+            for idx, row in df.iterrows():
+                file, label, code, text, spans = row[0], row[1], row[2], row[3], row[4]
+                appearances = spans.split(";")
+                spans = []
+                for a in appearances:
+                    spans.append([int(a.split()[0]), int(a.split()[1])])
+                file_codes_dict[file].append(
+                    {"label": label, "code": code, "text": text, "spans": spans[0]}
+                )
+
+            for guid, (file, codes) in enumerate(file_codes_dict.items()):
+                example = {
+                    "id": guid,
+                    "document_id": file,
+                    "text": Path(
+                        os.path.join(paths["text_files"], f"{file}.txt")
+                    ).read_text(),
+                    "task_x": file_codes_dict[file],
+                }
+
+                yield guid, example
+
+        elif "extra" in self.config.name:
+            with open(filepath) as file:
+                json_data = json.load(file)
+
+            if "mesh" in self.config.name:
+                for guid, article in enumerate(json_data["articles"]):
+                    example = {
+                        "id": str(guid),
+                        "document_id": article["pmid"],
+                        "text": str(article["title"])
+                        + " <SEP> "
+                        + str(article["abstractText"]),
+                        "labels": [mesh["Code"] for mesh in article["Mesh"]],
+                    }
+                    yield guid, example
+
+            else:  # CIE ID codes
+                for guid, article in enumerate(json_data["articles"]):
+                    example = {
+                        "id": str(guid),
+                        "document_id": article["pmid"],
+                        "text": str(article["title"])
+                        + " <SEP> "
+                        + str(article["abstractText"]),
+                        "labels": [
+                            code
+                            for mesh in article["Mesh"]
+                            if "CIE" in mesh
+                            for code in mesh["CIE"]
+                        ],
+                    }
+                    yield guid, example
+
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/hub/hubscripts/ctebmsp_hub.py
+++ b/hub/hubscripts/ctebmsp_hub.py
@@ -1,0 +1,274 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The Clinical Trials for Evidence-Based Medicine in Spanish (CT-EBM-SP) Corpus
+gathers 1200 texts about clinical trial studies for NER; this resource contains
+500 abstracts of journal articles about clinical trials and 700 announcements
+of trial protocols (292 173 tokens), with 46 699 annotated entities.
+
+Entities were annotated according to the Unified Medical Language System (UMLS)
+semantic groups: anatomy (ANAT), pharmacological and chemical substances (CHEM),
+pathologies (DISO), and lab tests, diagnostic or therapeutic procedures (PROC).
+"""
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['Spanish']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{CampillosLlanos2021,
+  author    = {Leonardo Campillos-Llanos and
+               Ana Valverde-Mateos and
+               Adri{\'{a}}n Capllonch-Carri{\'{o}}n and
+               Antonio Moreno-Sandoval},
+  title     = {A clinical trials corpus annotated with {UMLS}
+               entities to enhance the access to evidence-based medicine},
+  journal   = {{BMC} Medical Informatics and Decision Making},
+  volume    = {21},
+  year      = {2021},
+  url       = {https://doi.org/10.1186/s12911-021-01395-z},
+  doi       = {10.1186/s12911-021-01395-z},
+  biburl    = {},
+  bibsource = {}
+}
+"""
+
+_DATASETNAME = "ctebmsp"
+_DISPLAYNAME = "CT-EBM-SP"
+
+_ABSTRACTS_DESCRIPTION = """\
+The "abstracts" subset of the Clinical Trials for Evidence-Based Medicine in Spanish
+(CT-EBM-SP) corpus contains 500 abstracts of clinical trial studies in Spanish,
+published in journals with a Creative Commons license. Most were downloaded from
+the SciELO repository and free abstracts in PubMed.
+
+Abstracts were retrieved with the query:
+Clinical Trial[ptyp] AND “loattrfree full text”[sb] AND “spanish”[la].
+
+(Information collected from 10.1186/s12911-021-01395-z)
+"""
+
+_EUDRACT_DESCRIPTION = """\
+The "abstracts" subset of the Clinical Trials for Evidence-Based Medicine in Spanish
+(CT-EBM-SP) corpus contains 500 abstracts of clinical trial studies in Spanish,
+published in journals with a Creative Commons license. Most were downloaded from
+the SciELO repository and free abstracts in PubMed.
+
+Abstracts were retrieved with the query:
+Clinical Trial[ptyp] AND “loattrfree full text”[sb] AND “spanish”[la].
+
+(Information collected from 10.1186/s12911-021-01395-z)
+"""
+
+_DESCRIPTION = {
+    "ctebmsp_abstracts": _ABSTRACTS_DESCRIPTION,
+    "ctebmsp_eudract": _EUDRACT_DESCRIPTION,
+}
+
+_HOMEPAGE = "http://www.lllf.uam.es/ESP/nlpmedterm_en.html"
+
+_LICENSE = 'Creative Commons Attribution Non Commercial 4.0 International'
+
+_URLS = {
+    _DATASETNAME: "http://www.lllf.uam.es/ESP/nlpdata/wp2/CT-EBM-SP.zip",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class CTEBMSpDataset(datasets.GeneratorBasedBuilder):
+    """A Spanish clinical trials corpus annotated with UMLS entities"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = []
+
+    for study in ["abstracts", "eudract"]:
+        BUILDER_CONFIGS.append(
+            BigBioConfig(
+                name=f"ctebmsp_{study}_source",
+                version=SOURCE_VERSION,
+                description=f"CT-EBM-SP {study.capitalize()} source schema",
+                schema="source",
+                subset_id=f"ctebmsp_{study}",
+            )
+        )
+
+        BUILDER_CONFIGS.append(
+            BigBioConfig(
+                name=f"ctebmsp_{study}_bigbio_kb",
+                version=BIGBIO_VERSION,
+                description=f"CT-EBM-SP {study.capitalize()} BigBio schema",
+                schema="bigbio_kb",
+                subset_id=f"ctebmsp_{study}",
+            ),
+        )
+
+    DEFAULT_CONFIG_NAME = "ctebmsp_abstracts_source"
+
+    # Entities from the Unified Medical Language System (UMLS) semantic groups
+
+    def _info(self) -> datasets.DatasetInfo:
+        """
+        Provide information about CT-EBM-SP
+        """
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "trigger": datasets.Value(
+                                "string"
+                            ),  # refers to the text_bound_annotation of the trigger,
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arguments": datasets.Sequence(
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "attributes": [  # M or A lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value(
+                                "string"
+                            ),  # Name of the resource, e.g. "Wikipedia"
+                            "cuid": datasets.Value(
+                                "string"
+                            ),  # ID in the resource, e.g. 534366
+                            "text": datasets.Value(
+                                "string"
+                            ),  # Human readable description/name of the entity, e.g. "Barack Obama"
+                        }
+                    ],
+                },
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION[self.config.subset_id],
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[_DATASETNAME]
+        data_dir = Path(dl_manager.download_and_extract(urls))
+        studies_path = {
+            "ctebmsp_abstracts": "abstracts",
+            "ctebmsp_eudract": "eudract",
+        }
+
+        study_path = studies_path[self.config.subset_id]
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"dir_files": data_dir / "train" / study_path},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"dir_files": data_dir / "test" / study_path},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"dir_files": data_dir / "dev" / study_path},
+            ),
+        ]
+
+    def _generate_examples(self, dir_files) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        txt_files = list(dir_files.glob("*txt"))
+
+        if self.config.schema == "source":
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.parse_brat_file(txt_file)
+                example["id"] = str(guid)
+                yield guid, example
+
+        elif self.config.schema == "bigbio_kb":
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.brat_parse_to_bigbio_kb(
+                    parsing.parse_brat_file(txt_file)
+                )
+                example["id"] = str(guid)
+                yield guid, example
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/hub/hubscripts/ddi_corpus_hub.py
+++ b/hub/hubscripts/ddi_corpus_hub.py
@@ -1,0 +1,222 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The DDI corpus has been manually annotated with drugs and pharmacokinetics and
+pharmacodynamics interactions. It contains 1025 documents from two different
+sources: DrugBank database and MedLine.
+"""
+
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{HERREROZAZO2013914,
+  title        = {
+    The DDI corpus: An annotated corpus with pharmacological substances and
+    drug-drug interactions
+  },
+  author       = {
+    María Herrero-Zazo and Isabel Segura-Bedmar and Paloma Martínez and Thierry
+    Declerck
+  },
+  year         = 2013,
+  journal      = {Journal of Biomedical Informatics},
+  volume       = 46,
+  number       = 5,
+  pages        = {914--920},
+  doi          = {https://doi.org/10.1016/j.jbi.2013.07.011},
+  issn         = {1532-0464},
+  url          = {https://www.sciencedirect.com/science/article/pii/S1532046413001123},
+  keywords     = {Biomedical corpora, Drug interaction, Information extraction}
+}
+
+"""
+
+_DATASETNAME = "ddi_corpus"
+_DISPLAYNAME = "DDI Corpus"
+
+_DESCRIPTION = """\
+The DDI corpus has been manually annotated with drugs and pharmacokinetics and \
+pharmacodynamics interactions. It contains 1025 documents from two different \
+sources: DrugBank database and MedLine.
+"""
+
+_HOMEPAGE = "https://github.com/isegura/DDICorpus"
+
+_LICENSE = 'Creative Commons Attribution Non Commercial 4.0 International'
+
+_URLS = {
+    _DATASETNAME: "https://github.com/isegura/DDICorpus/raw/master/DDICorpus-2013(BRAT).zip",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class DDICorpusDataset(datasets.GeneratorBasedBuilder):
+    """DDI Corpus"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="ddi_corpus_source",
+            version=SOURCE_VERSION,
+            description="DDI Corpus source schema",
+            schema="source",
+            subset_id="ddi_corpus",
+        ),
+        BigBioConfig(
+            name="ddi_corpus_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="DDI Corpus BigBio schema",
+            schema="bigbio_kb",
+            subset_id="ddi_corpus",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "ddi_corpus_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "entities": [
+                        {
+                            "offsets": datasets.Sequence(datasets.Value("int32")),
+                            "text": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "relations": [
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        standoff_dir = os.path.join(data_dir, "DDICorpusBrat")
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(standoff_dir, "Train"),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(standoff_dir, "Test"),
+                    "split": "test",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath: str, split: str) -> Tuple[int, Dict]:
+        if self.config.schema == "source":
+            for subdir, _, files in os.walk(filepath):
+                for file in files:
+                    # Ignore configuration files and annotation files - we just consider the brat text files
+                    if not file.endswith(".txt"):
+                        continue
+
+                    brat_example = parsing.parse_brat_file(Path(subdir) / file)
+                    source_example = self._to_source_example(brat_example)
+
+                    yield source_example["document_id"], source_example
+
+        elif self.config.schema == "bigbio_kb":
+            for subdir, _, files in os.walk(filepath):
+                for file in files:
+                    # Ignore configuration files and annotation files - we just consider the brat text files
+                    if not file.endswith(".txt"):
+                        continue
+
+                    # Read brat annotations for the given text file and convert example to the BigBio-KB format
+                    brat_example = parsing.parse_brat_file(Path(subdir) / file)
+                    kb_example = parsing.brat_parse_to_bigbio_kb(brat_example)
+                    kb_example["id"] = kb_example["document_id"]
+
+                    yield kb_example["id"], kb_example
+
+    @staticmethod
+    def _to_source_example(brat_example: Dict) -> Dict:
+        source_example = {
+            "document_id": brat_example["document_id"],
+            "text": brat_example["text"],
+            "relations": brat_example["relations"],
+        }
+
+        source_example["entities"] = []
+        for entity_annotation in brat_example["text_bound_annotations"]:
+            entity_ann = entity_annotation.copy()
+
+            source_example["entities"].append(
+                {
+                    # These are lists in the parsed output, so just take the first element to
+                    # match the source schema.
+                    "offsets": entity_annotation["offsets"][0],
+                    "text": entity_ann["text"][0],
+                    "type": entity_ann["type"],
+                    "id": entity_ann["id"],
+                }
+            )
+
+        return source_example

--- a/hub/hubscripts/distemist_hub.py
+++ b/hub/hubscripts/distemist_hub.py
@@ -1,0 +1,220 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@dataset{luis_gasco_2022_6458455,
+  author       = {Luis Gasco and Eulàlia Farré and Miranda-Escalada, Antonio and Salvador Lima and Martin Krallinger},
+  title        = {{DisTEMIST corpus: detection and normalization of disease mentions in spanish clinical cases}},
+  month        = apr,
+  year         = 2022,
+  note         = {{Funded by the Plan de Impulso de las Tecnologías del Lenguaje (Plan TL).}},
+  publisher    = {Zenodo},
+  version      = {2.0.0},
+  doi          = {10.5281/zenodo.6458455},
+  url          = {https://doi.org/10.5281/zenodo.6458455}
+}
+"""
+
+_DATASETNAME = "distemist"
+_DISPLAYNAME = "DisTEMIST"
+
+_DESCRIPTION = """\
+The DisTEMIST corpus is a collection of 1000 clinical cases with disease annotations linked with Snomed-CT concepts.
+All documents are released in the context of the BioASQ DisTEMIST track for CLEF 2022.
+"""
+
+_HOMEPAGE = "https://zenodo.org/record/6458455"
+
+_LICENSE = 'Creative Commons Attribution 4.0 International'
+
+_URLS = {
+    _DATASETNAME: "https://zenodo.org/record/6458455/files/distemist.zip?download=1",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "2.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class DistemistDataset(datasets.GeneratorBasedBuilder):
+    """
+    The DisTEMIST corpus is a collection of 1000 clinical cases with disease annotations linked with Snomed-CT
+    concepts.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="distemist_source",
+            version=SOURCE_VERSION,
+            description="DisTEMIST source schema",
+            schema="source",
+            subset_id="distemist",
+        ),
+        BigBioConfig(
+            name="distemist_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="DisTEMIST BigBio schema",
+            schema="bigbio_kb",
+            subset_id="distemist",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "distemist_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "passages": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                        }
+                    ],
+                    "entities": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "concept_codes": datasets.Sequence(
+                                datasets.Value("string")
+                            ),
+                            "semantic_relations": datasets.Sequence(
+                                datasets.Value("string")
+                            ),
+                        }
+                    ],
+                }
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "entities_mapping_file_path": Path(data_dir)
+                    / "training/subtrack1_entities/distemist_subtrack1_training_mentions.tsv",
+                    "linking_mapping_file_path": Path(data_dir)
+                    / "training/subtrack2_linking/distemist_subtrack1_training1_linking.tsv",
+                    "text_files_dir": Path(data_dir) / "training/text_files",
+                },
+            ),
+        ]
+
+    def _generate_examples(
+        self,
+        entities_mapping_file_path: Path,
+        linking_mapping_file_path: Path,
+        text_files_dir: Path,
+    ) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        entities_mapping = pd.read_csv(entities_mapping_file_path, sep="\t")
+        linking_mapping = pd.read_csv(linking_mapping_file_path, sep="\t")
+
+        entity_file_names = set(entities_mapping["filename"])
+        linking_file_names = set(linking_mapping["filename"])
+
+        # entity_file_names = entity_file_names.difference(linking_file_names)
+
+        for uid, filename in enumerate(entity_file_names):
+            text_file = text_files_dir / f"{filename}.txt"
+
+            doc_text = text_file.read_text()
+            # doc_text = doc_text.replace("\n", "")
+
+            if filename in linking_file_names:
+                entities_df: pd.DataFrame = linking_mapping[
+                    linking_mapping["filename"] == filename
+                ]
+            else:
+                entities_df: pd.DataFrame = entities_mapping[
+                    entities_mapping["filename"] == filename
+                ]
+
+            example = {
+                "id": f"{uid}",
+                "document_id": filename,
+                "passages": [
+                    {
+                        "id": f"{uid}_{filename}_passage",
+                        "type": "clinical_case",
+                        "text": [doc_text],
+                        "offsets": [[0, len(doc_text)]],
+                    }
+                ],
+            }
+            if self.config.schema == "bigbio_kb":
+                example["events"] = []
+                example["coreferences"] = []
+                example["relations"] = []
+
+            entities = []
+            for row in entities_df.itertuples(name="Entity"):
+                entity = {
+                    "id": f"{uid}_{row.filename}_{row.Index}_entity_id_{row.mark}",
+                    "type": row.label,
+                    "text": [row.span],
+                    "offsets": [[row.off0, row.off1]],
+                }
+                if self.config.schema == "source":
+                    entity["concept_codes"] = []
+                    entity["semantic_relations"] = []
+                    if filename in linking_file_names:
+                        entity["concept_codes"] = row.code.split("+")
+                        entity["semantic_relations"] = row.semantic_rel.split("+")
+
+                elif self.config.schema == "bigbio_kb":
+                    entity["normalized"] = []
+
+                entities.append(entity)
+
+            example["entities"] = entities
+            yield uid, example

--- a/hub/hubscripts/ebm_pico_hub.py
+++ b/hub/hubscripts/ebm_pico_hub.py
@@ -1,0 +1,338 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This corpus release contains 4,993 abstracts annotated with (P)articipants,
+(I)nterventions, and (O)utcomes. Training labels are sourced from AMT workers and
+aggregated to reduce noise. Test labels are collected from medical professionals.
+"""
+
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple, Union
+
+import datasets
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{nye-etal-2018-corpus,
+    title = "A Corpus with Multi-Level Annotations of Patients, Interventions and Outcomes to Support Language Processing for Medical Literature",
+    author = "Nye, Benjamin  and
+      Li, Junyi Jessy  and
+      Patel, Roma  and
+      Yang, Yinfei  and
+      Marshall, Iain  and
+      Nenkova, Ani  and
+      Wallace, Byron",
+    booktitle = "Proceedings of the 56th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
+    month = jul,
+    year = "2018",
+    address = "Melbourne, Australia",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/P18-1019",
+    doi = "10.18653/v1/P18-1019",
+    pages = "197--207",
+}
+"""
+
+_DATASETNAME = "ebm_pico"
+_DISPLAYNAME = "EBM NLP"
+
+_DESCRIPTION = """\
+This corpus release contains 4,993 abstracts annotated with (P)articipants,
+(I)nterventions, and (O)utcomes. Training labels are sourced from AMT workers and
+aggregated to reduce noise. Test labels are collected from medical professionals.
+"""
+
+_HOMEPAGE = "https://github.com/bepnye/EBM-NLP"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: "https://github.com/bepnye/EBM-NLP/raw/master/ebm_nlp_2_00.tar.gz"
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "2.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+PHASES = ("starting_spans", "hierarchical_labels")
+LABEL_DECODERS = {
+    PHASES[0]: {
+        "participants": {0: "No Label", 1: "Participant"},
+        "interventions": {0: "No Label", 1: "Intervention"},
+        "outcomes": {0: "No Label", 1: "Outcome"},
+    },
+    PHASES[1]: {
+        "participants": {
+            0: "No label",
+            1: "Age",
+            2: "Sex",
+            3: "Sample-size",
+            4: "Condition",
+        },
+        "interventions": {
+            0: "No label",
+            1: "Surgical",
+            2: "Physical",
+            3: "Pharmacological",
+            4: "Educational",
+            5: "Psychological",
+            6: "Other",
+            7: "Control",
+        },
+        "outcomes": {
+            0: "No label",
+            1: "Physical",
+            2: "Pain",
+            3: "Mortality",
+            4: "Adverse-effects",
+            5: "Mental",
+            6: "Other",
+        },
+    },
+}
+
+
+def _get_entities_pico(
+    annotation_dict: Dict[str, List[int]],
+    tokenized: List[str],
+    document_content: str,
+) -> List[Dict[str, Union[int, str]]]:
+    """extract PIO entities from documents using annotation_dict"""
+
+    def _partition(alist, indices):
+        return [alist[i:j] for i, j in zip([0] + indices, indices + [None])]
+
+    ents = []
+    for annotation_type, annotations in annotation_dict.items():
+        indices = [idx for idx, val in enumerate(annotations) if val != 0]
+
+        if len(indices) > 0:  # if annotations exist for this sentence
+            split_indices = []
+            # if there are two annotations of one type in one sentence
+            for item_index, item in enumerate(indices):
+                if item_index + 1 == len(indices):
+                    break
+                if indices[item_index] + 1 != indices[item_index + 1]:
+                    split_indices.append(item_index + 1)
+                elif annotations[item] != annotations[item + 1]:
+                    split_indices.append(item_index + 1)
+            multiple_indices = _partition(indices, split_indices)
+
+            for _indices in multiple_indices:
+                high_level_type = LABEL_DECODERS["starting_spans"][annotation_type][1]
+                fine_grained_type = LABEL_DECODERS["hierarchical_labels"][
+                    annotation_type
+                ][annotations[_indices[0]]]
+                annotation_text = " ".join([tokenized[ind] for ind in _indices])
+
+                char_start = document_content.find(annotation_text)
+                char_end = char_start + len(annotation_text)
+
+                ent = {
+                    "annotation_text": annotation_text,
+                    "high_level_annotation_type": high_level_type,
+                    "fine_grained_annotation_type": fine_grained_type,
+                    "char_start": char_start,
+                    "char_end": char_end,
+                }
+
+                ents.append(ent)
+    return ents
+
+
+class EbmPico(datasets.GeneratorBasedBuilder):
+    """A Corpus with Multi-Level Annotations of Patients, Interventions and Outcomes to
+    Support Language Processing for Medical Literature."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="ebm_pico_source",
+            version=SOURCE_VERSION,
+            description="ebm_pico source schema",
+            schema="source",
+            subset_id="ebm_pico",
+        ),
+        BigBioConfig(
+            name="ebm_pico_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="ebm_pico BigBio schema",
+            schema="bigbio_kb",
+            subset_id="ebm_pico",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "ebm_pico_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "doc_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "entities": [
+                        {
+                            "text": datasets.Value("string"),
+                            "annotation_type": datasets.Value("string"),
+                            "fine_grained_annotation_type": datasets.Value("string"),
+                            "start": datasets.Value("int64"),
+                            "end": datasets.Value("int64"),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+        else:
+            raise ValueError("config.schema must be either source or bigbio_kb")
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        documents_folder = Path(data_dir) / "ebm_nlp_2_00" / "documents"
+        annotations_folder = (
+            Path(data_dir) / "ebm_nlp_2_00" / "annotations" / "aggregated"
+        )
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "documents_folder": documents_folder,
+                    "annotations_folder": annotations_folder,
+                    "split_folder": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "documents_folder": documents_folder,
+                    "annotations_folder": annotations_folder,
+                    "split_folder": "test/gold",
+                },
+            ),
+        ]
+
+    def _generate_examples(
+        self, documents_folder, annotations_folder, split_folder: str
+    ) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        annotation_types = ["interventions", "outcomes", "participants"]
+
+        docs_path = os.path.join(
+            annotations_folder,
+            f"hierarchical_labels/{annotation_types[0]}/{split_folder}/",
+        )
+        documents_in_split = os.listdir(docs_path)
+
+        uid = 0
+        for id_, document in enumerate(documents_in_split):
+            document_id = document.split(".")[0]
+            with open(f"{documents_folder}/{document_id}.tokens") as fp:
+                tokenized = fp.read().splitlines()
+            document_content = " ".join(tokenized)
+
+            annotation_dict = {}
+            for annotation_type in annotation_types:
+                try:
+                    with open(
+                        f"{annotations_folder}/hierarchical_labels/{annotation_type}/{split_folder}/{document}"
+                    ) as fp:
+                        annotation_dict[annotation_type] = [
+                            int(x) for x in fp.read().splitlines()
+                        ]
+                except OSError:
+                    annotation_dict[annotation_type] = []
+
+            ents = _get_entities_pico(
+                annotation_dict, tokenized=tokenized, document_content=document_content
+            )
+
+            if self.config.schema == "source":
+
+                data = {
+                    "doc_id": document_id,
+                    "text": document_content,
+                    "entities": [
+                        {
+                            "text": ent["annotation_text"],
+                            "annotation_type": ent["high_level_annotation_type"],
+                            "fine_grained_annotation_type": ent[
+                                "fine_grained_annotation_type"
+                            ],
+                            "start": ent["char_start"],
+                            "end": ent["char_end"],
+                        }
+                        for ent in ents
+                    ],
+                }
+                yield id_, data
+
+            elif self.config.schema == "bigbio_kb":
+                data = {
+                    "id": str(uid),
+                    "document_id": document_id,
+                    "passages": [],
+                    "entities": [],
+                    "relations": [],
+                    "events": [],
+                    "coreferences": [],
+                }
+                uid += 1
+
+                data["passages"] = [
+                    {
+                        "id": str(uid),
+                        "type": "document",
+                        "text": [document_content],
+                        "offsets": [[0, len(document_content)]],
+                    }
+                ]
+                uid += 1
+
+                for ent in ents:
+                    entity = {
+                        "id": uid,
+                        "type": f'{ent["high_level_annotation_type"]}_{ent["fine_grained_annotation_type"]}',
+                        "text": [ent["annotation_text"]],
+                        "offsets": [[ent["char_start"], ent["char_end"]]],
+                        "normalized": [],
+                    }
+                    data["entities"].append(entity)
+                    uid += 1
+
+                yield uid, data

--- a/hub/hubscripts/ehr_rel_hub.py
+++ b/hub/hubscripts/ehr_rel_hub.py
@@ -1,0 +1,222 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+EHR-Rel is a novel open-source1 biomedical concept relatedness dataset consisting of 3630 concept pairs, six times more
+ than the largest existing dataset.  Instead of manually selecting and pairing concepts as done in previous work,
+ the dataset is sampled from EHRs to ensure concepts are relevant for the EHR concept retrieval task.
+ A detailed analysis of the concepts in the dataset reveals a far larger coverage compared to existing datasets.
+"""
+
+import csv
+from pathlib import Path
+from typing import Dict, Iterator, List, Tuple
+
+import datasets
+
+from .bigbiohub import pairs_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@inproceedings{schulz-etal-2020-biomedical,
+    title = {Biomedical Concept Relatedness {--} A large {EHR}-based benchmark},
+    author = {Schulz, Claudia  and
+      Levy-Kramer, Josh  and
+      Van Assel, Camille  and
+      Kepes, Miklos  and
+      Hammerla, Nils},
+    booktitle = {Proceedings of the 28th International Conference on Computational Linguistics},
+    month = {dec},
+    year = {2020},
+    address = {Barcelona, Spain (Online)},
+    publisher = {International Committee on Computational Linguistics},
+    url = {https://aclanthology.org/2020.coling-main.577},
+    doi = {10.18653/v1/2020.coling-main.577},
+    pages = {6565--6575},
+    }
+"""
+
+_DATASETNAME = "ehr_rel"
+_DISPLAYNAME = "EHR-Rel"
+
+_DESCRIPTION = """\
+EHR-Rel is a novel open-source1 biomedical concept relatedness dataset consisting of 3630 concept pairs, six times more
+than the largest existing dataset.  Instead of manually selecting and pairing concepts as done in previous work,
+the dataset is sampled from EHRs to ensure concepts are relevant for the EHR concept retrieval task.
+A detailed analysis of the concepts in the dataset reveals a far larger coverage compared to existing datasets.
+"""
+
+_HOMEPAGE = "https://github.com/babylonhealth/EHR-Rel"
+
+_LICENSE = 'Apache License 2.0'
+
+_URLS = {
+    _DATASETNAME: "https://github.com/babylonhealth/EHR-Rel/archive/refs/heads/master.zip",
+}
+
+_SUPPORTED_TASKS = [Tasks.SEMANTIC_SIMILARITY]
+
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class EHRRelDataset(datasets.GeneratorBasedBuilder):
+    """Dataset for EHR-Rel Corpus"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="ehr_rel_source",
+            version=SOURCE_VERSION,
+            description="EHR-Rel combined source schema",
+            schema="source",
+            subset_id="ehr_rel",
+        ),
+        BigBioConfig(
+            name="ehr_rel_a_source",
+            version=SOURCE_VERSION,
+            description="EHR-Rel-A source schema",
+            schema="source",
+            subset_id="ehr_rel_a",
+        ),
+        BigBioConfig(
+            name="ehr_rel_b_source",
+            version=SOURCE_VERSION,
+            description="EHR-Rel-B source schema",
+            schema="source",
+            subset_id="ehr_rel_b",
+        ),
+        BigBioConfig(
+            name="ehr_rel_bigbio_pairs",
+            version=BIGBIO_VERSION,
+            description="EHR-Rel BigBio schema",
+            schema="bigbio_pairs",
+            subset_id="ehr_rel",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "ehr_rel_bigbio_pairs"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "snomed_id_1": datasets.Value("string"),
+                    "snomed_label_1": datasets.Value("string"),
+                    "snomed_id_2": datasets.Value("string"),
+                    "snomed_label_2": datasets.Value("string"),
+                    "rater_A": datasets.Value("string"),
+                    "rater_B": datasets.Value("string"),
+                    "rater_C": datasets.Value("string"),
+                    "rater_D": datasets.Value("string"),
+                    "rater_E": datasets.Value("string"),
+                    "mean_rating": datasets.Value("string"),
+                    "CUI_1": datasets.Value("string"),
+                    "CUI_2": datasets.Value("string"),
+                }
+            )
+
+        elif self.config.schema == "bigbio_pairs":
+            features = pairs_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        data_dir = Path(dl_manager.download_and_extract(urls))
+        data_dir = data_dir.joinpath("EHR-Rel-master")
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"data_dir": data_dir},
+            ),
+        ]
+
+    def _generate_examples(self, data_dir: Path) -> Iterator[Tuple[str, Dict]]:
+
+        if self.config.subset_id == "ehr_rel_a":
+            files = ["EHR-RelA.tsv"]
+        elif self.config.subset_id == "ehr_rel_b":
+            files = ["EHR-RelB.tsv"]
+        else:
+            files = ["EHR-RelA.tsv", "EHR-RelB.tsv"]
+
+        uid = -1  # want first instance to be 0
+
+        for filename in files:
+            file = data_dir.joinpath(filename)
+            document_id = str(file.stem)
+            with open(file, encoding="utf-8") as csv_file:
+                csv_reader = csv.reader(csv_file, quotechar='"', delimiter="\t")
+                next(csv_reader, None)  # remove column headers
+                for id_, row in enumerate(csv_reader):
+                    uid += 1
+                    (
+                        snomed_id_1,
+                        snomed_label_1,
+                        snomed_id_2,
+                        snomed_label_2,
+                        rater_A,
+                        rater_B,
+                        rater_C,
+                        rater_D,
+                        rater_E,
+                        mean_rating,
+                        CUI_1,
+                        CUI_2,
+                    ) = row
+
+                    if self.config.schema == "source":
+                        yield uid, {
+                            "document_id": document_id,
+                            "snomed_id_1": snomed_id_1,
+                            "snomed_label_1": snomed_label_1,
+                            "snomed_id_2": snomed_id_1,
+                            "snomed_label_2": snomed_label_2,
+                            "rater_A": rater_A,
+                            "rater_B": rater_B,
+                            "rater_C": rater_C,
+                            "rater_D": rater_D,
+                            "rater_E": rater_E,
+                            "mean_rating": mean_rating,
+                            "CUI_1": CUI_1,
+                            "CUI_2": CUI_2,
+                        }
+
+                    elif self.config.schema == "bigbio_pairs":
+                        yield uid, {
+                            "id": uid,
+                            "document_id": document_id,
+                            "text_1": snomed_label_1,
+                            "text_2": snomed_label_2,
+                            "label": mean_rating,
+                        }

--- a/hub/hubscripts/essai_hub.py
+++ b/hub/hubscripts/essai_hub.py
@@ -1,0 +1,221 @@
+import os
+
+import datasets
+import numpy as np
+import pandas as pd
+
+from .bigbiohub import text_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['French']
+_PUBMED = False
+_LOCAL = True
+_CITATION = """\
+ @misc{dalloux, title={Datasets – Clément Dalloux}, url={http://clementdalloux.fr/?page_id=28}, journal={Clément Dalloux}, author={Dalloux, Clément}} 
+"""
+
+_DATASETNAME = "essai"
+_DISPLAYNAME = "ESSAI"
+
+_DESCRIPTION = """\
+We manually annotated two corpora from the biomedical field. The ESSAI corpus \
+contains clinical trial protocols in French. They were mainly obtained from the \
+National Cancer Institute The typical protocol consists of two parts: the \
+summary of the trial, which indicates the purpose of the trial and the methods \
+applied; and a detailed description of the trial with the inclusion and \
+exclusion criteria. The CAS corpus contains clinical cases published in \
+scientific literature and training material. They are published in different \
+journals from French-speaking countries (France, Belgium, Switzerland, Canada, \
+African countries, tropical countries) and are related to various medical \
+specialties (cardiology, urology, oncology, obstetrics, pulmonology, \
+gastro-enterology). The purpose of clinical cases is to describe clinical \
+situations of patients. Hence, their content is close to the content of clinical \
+narratives (description of diagnoses, treatments or procedures, evolution, \
+family history, expected audience, etc.). In clinical cases, the negation is \
+frequently used for describing the patient signs, symptoms, and diagnosis. \
+Speculation is present as well but less frequently.
+
+This version only contain the annotated ESSAI corpus
+"""
+
+_HOMEPAGE = "https://clementdalloux.fr/?page_id=28"
+
+_LICENSE = 'Data User Agreement'
+
+_URLS = {
+    "essai_source": "",
+    "essai_bigbio_text": "",
+    "essai_bigbio_kb": "",
+}
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+_SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
+
+
+class ESSAI(datasets.GeneratorBasedBuilder):
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    DEFAULT_CONFIG_NAME = "essai_source"
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="essai_source",
+            version=SOURCE_VERSION,
+            description="ESSAI source schema",
+            schema="source",
+            subset_id="essai",
+        ),
+        BigBioConfig(
+            name="essai_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="ESSAI simplified BigBio schema for negation/speculation classification",
+            schema="bigbio_text",
+            subset_id="essai",
+        ),
+        BigBioConfig(
+            name="essai_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="ESSAI simplified BigBio schema for part-of-speech-tagging",
+            schema="bigbio_kb",
+            subset_id="essai",
+        ),
+    ]
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": [datasets.Value("string")],
+                    "lemmas": [datasets.Value("string")],
+                    "POS_tags": [datasets.Value("string")],
+                    "labels": [datasets.Value("string")],
+                }
+            )
+        elif self.config.schema == "bigbio_text":
+            features = text_features
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            supervised_keys=None,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
+        else:
+            data_dir = self.config.data_dir
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"datadir": data_dir},
+            ),
+        ]
+
+    def _generate_examples(self, datadir):
+        key = 0
+        for file in ["ESSAI_neg.txt", "ESSAI_spec.txt"]:
+            filepath = os.path.join(datadir, file)
+            label = "negation" if "neg" in file else "speculation"
+            id_docs = []
+            id_words = []
+            words = []
+            lemmas = []
+            POS_tags = []
+
+            with open(filepath) as f:
+                for line in f.readlines():
+                    line_content = line.split("\t")
+                    if len(line_content) > 1:
+                        id_docs.append(line_content[0])
+                        id_words.append(line_content[1])
+                        words.append(line_content[2])
+                        lemmas.append(line_content[3])
+                        POS_tags.append(line_content[4])
+
+            dic = {
+                "id_docs": np.array(list(map(int, id_docs))),
+                "id_words": id_words,
+                "words": words,
+                "lemmas": lemmas,
+                "POS_tags": POS_tags,
+            }
+            if self.config.schema == "source":
+                for doc_id in set(dic["id_docs"]):
+                    idces = np.argwhere(dic["id_docs"] == doc_id)[:, 0]
+                    text = [dic["words"][id] for id in idces]
+                    text_lemmas = [dic["lemmas"][id] for id in idces]
+                    POS_tags_ = [dic["POS_tags"][id] for id in idces]
+                    yield key, {
+                        "id": key,
+                        "document_id": doc_id,
+                        "text": text,
+                        "lemmas": text_lemmas,
+                        "POS_tags": POS_tags_,
+                        "labels": [label],
+                    }
+                    key += 1
+            elif self.config.schema == "bigbio_text":
+                for doc_id in set(dic["id_docs"]):
+                    idces = np.argwhere(dic["id_docs"] == doc_id)[:, 0]
+                    text = " ".join([dic["words"][id] for id in idces])
+                    yield key, {
+                        "id": key,
+                        "document_id": doc_id,
+                        "text": text,
+                        "labels": [label],
+                    }
+                    key += 1
+            elif self.config.schema == "bigbio_kb":
+                for doc_id in set(dic["id_docs"]):
+                    idces = np.argwhere(dic["id_docs"] == doc_id)[:, 0]
+                    text = [dic["words"][id] for id in idces]
+                    POS_tags_ = [dic["POS_tags"][id] for id in idces]
+
+                    data = {
+                        "id": str(key),
+                        "document_id": doc_id,
+                        "passages": [],
+                        "entities": [],
+                        "relations": [],
+                        "events": [],
+                        "coreferences": [],
+                    }
+                    key += 1
+
+                    data["passages"] = [
+                        {
+                            "id": str(key + i),
+                            "type": "sentence",
+                            "text": [text[i]],
+                            "offsets": [[i, i + 1]],
+                        }
+                        for i in range(len(text))
+                    ]
+                    key += len(text)
+
+                    for i in range(len(text)):
+                        entity = {
+                            "id": key,
+                            "type": "POS_tag",
+                            "text": [POS_tags_[i]],
+                            "offsets": [[i, i + 1]],
+                            "normalized": [],
+                        }
+                        data["entities"].append(entity)
+                        key += 1
+
+                    yield key, data

--- a/hub/hubscripts/euadr_hub.py
+++ b/hub/hubscripts/euadr_hub.py
@@ -1,0 +1,317 @@
+import os
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{VANMULLIGEN2012879,
+title = {The EU-ADR corpus: Annotated drugs, diseases, targets, and their relationships},
+journal = {Journal of Biomedical Informatics},
+volume = {45},
+number = {5},
+pages = {879-884},
+year = {2012},
+note = {Text Mining and Natural Language Processing in Pharmacogenomics},
+issn = {1532-0464},
+doi = {https://doi.org/10.1016/j.jbi.2012.04.004},
+url = {https://www.sciencedirect.com/science/article/pii/S1532046412000573},
+author = {Erik M. {van Mulligen} and Annie Fourrier-Reglat and David Gurwitz and Mariam Molokhia and Ainhoa Nieto and Gianluca Trifiro and Jan A. Kors and Laura I. Furlong},
+keywords = {Text mining, Corpus development, Machine learning, Adverse drug reactions},
+abstract = {Corpora with specific entities and relationships annotated are essential to train and evaluate text-mining systems that are developed to extract specific structured information from a large corpus. In this paper we describe an approach where a named-entity recognition system produces a first annotation and annotators revise this annotation using a web-based interface. The agreement figures achieved show that the inter-annotator agreement is much better than the agreement with the system provided annotations. The corpus has been annotated for drugs, disorders, genes and their inter-relationships. For each of the drug–disorder, drug–target, and target–disorder relations three experts have annotated a set of 100 abstracts. These annotated relationships will be used to train and evaluate text-mining software to capture these relationships in texts.}
+}
+"""
+
+_DATASETNAME = "euadr"
+_DISPLAYNAME = "EU-ADR"
+
+_DESCRIPTION = """\
+Corpora with specific entities and relationships annotated are essential to \
+train and evaluate text-mining systems that are developed to extract specific \
+structured information from a large corpus. In this paper we describe an \
+approach where a named-entity recognition system produces a first annotation and \
+annotators revise this annotation using a web-based interface. The agreement \
+figures achieved show that the inter-annotator agreement is much better than the \
+agreement with the system provided annotations. The corpus has been annotated \
+for drugs, disorders, genes and their inter-relationships. For each of the \
+drug-disorder, drug-target, and target-disorder relations three experts \
+have annotated a set of 100 abstracts. These annotated relationships will be \
+used to train and evaluate text-mining software to capture these relationships \
+in texts.
+"""
+
+_HOMEPAGE = "https://www.sciencedirect.com/science/article/pii/S1532046412000573"
+
+_LICENSE = 'License information unavailable'
+
+_URL = "https://biosemantics.erasmusmc.nl/downloads/euadr.tgz"
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
+
+
+class EUADR(datasets.GeneratorBasedBuilder):
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    DEFAULT_CONFIG_NAME = "euadr_bigbio_kb"
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="euadr_source",
+            version=SOURCE_VERSION,
+            description="EU-ADR source schema",
+            schema="source",
+            subset_id="euadr",
+        ),
+        BigBioConfig(
+            name="euadr_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="EU-ADR simplified BigBio schema for named entity recognition and relation extraction",
+            schema="bigbio_kb",
+            subset_id="euadr",
+        ),
+    ]
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "pmid": datasets.Value("string"),
+                    "title": datasets.Value("string"),
+                    "abstract": datasets.Value("string"),
+                    "annotations": datasets.Sequence(datasets.Value("string")),
+                }
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            supervised_keys=None,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        urls = _URL
+        datapath = dl_manager.download_and_extract(urls)
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"datapath": datapath, "dl_manager": dl_manager},
+            ),
+        ]
+
+    def _generate_examples(self, datapath, dl_manager):
+        def replace_html_special_chars(string):
+            # since we are getting the text as an HTML file, we need to replace
+            # special characters
+            for (i, r) in [
+                ("&#34;", '"'),
+                ("&quot;", '"'),
+                ("&#39;", "'"),
+                ("&apos;", "'"),
+                ("&#38;", "&"),
+                ("&amp;", "&"),
+                ("&#60;", "<"),
+                ("&lt;", "<"),
+                ("&#62;", ">"),
+                ("&gt;", ">"),
+                ("&#x27;", "'"),
+            ]:
+                string = string.replace(i, r)
+            return string
+
+        def suppr_blank(l_str):
+            r = []
+            for string in l_str:
+                if len(string) > 0:
+                    r.append(string)
+            return r
+
+        folder_path = os.path.join(datapath, "euadr_corpus")
+        key = 0
+        if self.config.schema == "source":
+            for filename in os.listdir(folder_path):
+                if "_" not in filename:
+                    corpus_path = dl_manager.download_and_extract(
+                        f"https://pubmed.ncbi.nlm.nih.gov/{filename[:-4]}/?format=pubmed"
+                    )
+                    with open(corpus_path, "r", encoding="latin") as f:
+                        full_html = replace_html_special_chars(
+                            ("".join(f.readlines()))
+                            .replace("\r\n", "")
+                            .replace("\n", "")
+                        )
+                        abstract = " ".join(
+                            suppr_blank(
+                                full_html.split("AB  -")[-1]
+                                .split("FAU -")[0]
+                                .split(" ")
+                            )
+                        )
+                        title = " ".join(
+                            suppr_blank(
+                                full_html.split("TI  -")[-1].split("PG")[0].split(" ")
+                            )
+                        )
+                        full_text = " ".join([title, abstract])
+                    with open(
+                        os.path.join(folder_path, filename), "r", encoding="latin"
+                    ) as f:
+                        lines = f.readlines()
+                    yield key, {
+                        "pmid": filename[:-4],
+                        "title": title,
+                        "abstract": abstract,
+                        "annotations": lines,
+                    }
+                    key += 1
+        elif self.config.schema == "bigbio_kb":
+            for filename in os.listdir(folder_path):
+                if "_" not in filename:
+                    corpus_path = dl_manager.download_and_extract(
+                        f"https://pubmed.ncbi.nlm.nih.gov/{filename[:-4]}/?format=pubmed"
+                    )
+                    with open(corpus_path, "r", encoding="latin") as f:
+                        full_html = replace_html_special_chars(
+                            ("".join(f.readlines()))
+                            .replace("\r\n", "")
+                            .replace("\n", "")
+                        )
+                        abstract = " ".join(
+                            suppr_blank(
+                                full_html.split("AB  -")[-1]
+                                .split("FAU -")[0]
+                                .split(" ")
+                            )
+                        )
+                        title = " ".join(
+                            suppr_blank(
+                                full_html.split("TI  -")[-1].split("PG")[0].split(" ")
+                            )
+                        )
+                        full_text = " ".join([title, abstract])
+                    with open(
+                        os.path.join(folder_path, filename), "r", encoding="latin"
+                    ) as f:
+                        lines = f.readlines()
+                        data = {
+                            "id": str(key),
+                            "document_id": str(key),
+                            "passages": [],
+                            "entities": [],
+                            "events": [],
+                            "coreferences": [],
+                            "relations": [],
+                        }
+                        key += 1
+                        data["passages"].append(
+                            {
+                                "id": str(key),
+                                "type": "title",
+                                "text": [title],
+                                "offsets": [[0, len(title)]],
+                            }
+                        )
+                        key += 1
+                        data["passages"].append(
+                            {
+                                "id": str(key),
+                                "type": "abstract",
+                                "text": [abstract],
+                                "offsets": [
+                                    [len(title) + 1, len(title) + 1 + len(abstract)]
+                                ],
+                            }
+                        )
+                        key += 1
+                        for line in lines:
+                            line_processed = line.split("\t")
+                            if line_processed[2] == "relation":
+                                data["entities"].append(
+                                    {
+                                        "id": str(key),
+                                        "offsets": [
+                                            [
+                                                int(line_processed[7].split(":")[0]),
+                                                int(line_processed[7].split(":")[1]),
+                                            ]
+                                        ],
+                                        "text": [
+                                            full_text[
+                                                int(
+                                                    line_processed[7].split(":")[0]
+                                                ) : int(line_processed[7].split(":")[1])
+                                            ]
+                                        ],
+                                        "type": "",
+                                        "normalized": [],
+                                    }
+                                )
+                                key += 1
+                                data["entities"].append(
+                                    {
+                                        "id": str(key),
+                                        "offsets": [
+                                            [
+                                                int(line_processed[8].split(":")[0]),
+                                                int(line_processed[8].split(":")[1]),
+                                            ]
+                                        ],
+                                        "text": [
+                                            full_text[
+                                                int(
+                                                    line_processed[8].split(":")[0]
+                                                ) : int(line_processed[8].split(":")[1])
+                                            ]
+                                        ],
+                                        "type": "",
+                                        "normalized": [],
+                                    }
+                                )
+                                key += 1
+                                data["relations"].append(
+                                    {
+                                        "id": str(key),
+                                        "type": line_processed[-1].split("\n")[0],
+                                        "arg1_id": str(key - 2),
+                                        "arg2_id": str(key - 1),
+                                        "normalized": [],
+                                    }
+                                )
+                                key += 1
+                            elif line_processed[2] == "concept":
+                                data["entities"].append(
+                                    {
+                                        "id": str(key),
+                                        "offsets": [
+                                            [
+                                                int(line_processed[4]),
+                                                int(line_processed[5]),
+                                            ]
+                                        ],
+                                        "text": [
+                                            full_text[
+                                                int(line_processed[4]) : int(
+                                                    line_processed[5]
+                                                )
+                                            ]
+                                        ],
+                                        "type": line_processed[-1].split("\n")[0],
+                                        "normalized": [],
+                                    }
+                                )
+                                key += 1
+                    yield key, data
+                    key += 1

--- a/hub/hubscripts/evidence_inference_hub.py
+++ b/hub/hubscripts/evidence_inference_hub.py
@@ -1,0 +1,293 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The dataset consists of biomedical articles describing randomized control trials (RCTs)
+that compare multiple treatments. Each of these articles will have multiple questions,
+or 'prompts' associated with them. These prompts will ask about the relationship between
+an intervention and comparator with respect to an outcome, as reported in the trial.
+For example, a prompt may ask about the reported effects of aspirin as compared to placebo
+on the duration of headaches.
+For the sake of this task, we assume that a particular article will report that the intervention of interest either
+significantly increased, significantly decreased or had significant effect on the outcome, relative to the comparator.
+"""
+
+import os
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import qa_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{deyoung-etal-2020-evidence,
+    title = "Evidence Inference 2.0: More Data, Better Models",
+    author = "DeYoung, Jay  and
+      Lehman, Eric  and
+      Nye, Benjamin  and
+      Marshall, Iain  and
+      Wallace, Byron C.",
+    booktitle = "Proceedings of the 19th SIGBioMed Workshop on Biomedical Language Processing",
+    month = jul,
+    year = "2020",
+    address = "Online",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/2020.bionlp-1.13",
+    pages = "123--132",
+}
+"""
+
+_DATASETNAME = "evidence_inference"
+_DISPLAYNAME = "Evidence Inference 2.0"
+
+_DESCRIPTION = """\
+The dataset consists of biomedical articles describing randomized control trials (RCTs) that compare multiple
+treatments. Each of these articles will have multiple questions, or 'prompts' associated with them.
+These prompts will ask about the relationship between an intervention and comparator with respect to an outcome,
+as reported in the trial. For example, a prompt may ask about the reported effects of aspirin as compared
+to placebo on the duration of headaches. For the sake of this task, we assume that a particular article
+will report that the intervention of interest either significantly increased, significantly decreased
+or had significant effect on the outcome, relative to the comparator.
+"""
+
+_HOMEPAGE = "https://github.com/jayded/evidence-inference"
+
+_LICENSE = 'MIT License'
+
+_URLS = {
+    _DATASETNAME: "http://evidence-inference.ebm-nlp.com/v2.0.tar.gz",
+}
+
+_SUPPORTED_TASKS = [Tasks.QUESTION_ANSWERING]
+
+_SOURCE_VERSION = "2.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+QA_CHOICES = [
+    "significantly increased",
+    "no significant difference",
+    "significantly decreased",
+]
+
+# Some examples are removed due to comments on the dataset's github page
+# https://github.com/jayded/evidence-inference/blob/master/annotations/README.md#caveat
+
+INCORRECT_PROMPT_IDS = set([
+    911, 912, 1262, 1261, 3044, 3248, 3111, 3620, 4308, 4490, 4491, 4324,
+    4325, 4492, 4824, 5000, 5001, 5002, 5046, 5047, 4948, 5639, 5710, 5752,
+    5775, 5782, 5841, 5843, 5861, 5862, 5863, 5964, 5965, 5966, 5975, 4807,
+    5776, 5777, 5778, 5779, 5780, 5781, 6034, 6065, 6066, 6666, 6667, 6668,
+    6669, 7040, 7042, 7944, 8590, 8605, 8606, 8639, 8640, 8745, 8747, 8749,
+    8877, 8878, 8593, 8631, 8635, 8884, 8886, 8773, 10032, 10035, 8876, 8875,
+    8885, 8917, 8921, 8118, 10885, 10886, 10887, 10888, 10889, 10890
+])
+
+QUESTIONABLE_PROMPT_IDS = set([
+    7811, 7812, 7813, 7814, 7815, 8197, 8198, 8199,
+    8200, 8201, 9429, 9430, 9431, 8536, 9432
+])
+
+SOMEWHAT_MALFORMED_PROMPT_IDS = set([
+    3514, 346, 5037, 4715, 8767, 9295, 9297, 8870, 9862
+])
+
+SKIP_PROMPT_IDS = INCORRECT_PROMPT_IDS | QUESTIONABLE_PROMPT_IDS | SOMEWHAT_MALFORMED_PROMPT_IDS
+
+
+class EvidenceInferenceDataset(datasets.GeneratorBasedBuilder):
+    f"""{_DESCRIPTION}"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="evidence-inference_source",
+            version=SOURCE_VERSION,
+            description="evidence-inference source schema",
+            schema="source",
+            subset_id="evidence-inference",
+        ),
+        BigBioConfig(
+            name="evidence-inference_bigbio_qa",
+            version=BIGBIO_VERSION,
+            description="evidence-inference BigBio schema",
+            schema="bigbio_qa",
+            subset_id="evidence-inference",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "evidence-inference_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("int64"),
+                    "prompt_id": datasets.Value("int64"),
+                    "pmcid": datasets.Value("int64"),
+                    "label": datasets.Value("string"),
+                    "evidence": datasets.Value("string"),
+                    "intervention": datasets.Value("string"),
+                    "comparator": datasets.Value("string"),
+                    "outcome": datasets.Value("string"),
+                }
+            )
+
+        elif self.config.schema == "bigbio_qa":
+            features = qa_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepaths": [
+                        os.path.join(data_dir, "annotations_merged.csv"),
+                        os.path.join(data_dir, "prompts_merged.csv"),
+                    ],
+                    "datapath": os.path.join(data_dir, "txt_files"),
+                    "split": "train",
+                    "datadir": data_dir,
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepaths": [
+                        os.path.join(data_dir, "annotations_merged.csv"),
+                        os.path.join(data_dir, "prompts_merged.csv"),
+                    ],
+                    "datapath": os.path.join(data_dir, "txt_files"),
+                    "split": "validation",
+                    "datadir": data_dir,
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepaths": [
+                        os.path.join(data_dir, "annotations_merged.csv"),
+                        os.path.join(data_dir, "prompts_merged.csv"),
+                    ],
+                    "datapath": os.path.join(data_dir, "txt_files"),
+                    "split": "test",
+                    "datadir": data_dir,
+                },
+            ),
+        ]
+
+    def _generate_examples(
+        self, filepaths, datapath, split, datadir
+    ) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        with open(f"{datadir}/splits/{split}_article_ids.txt", "r") as f:
+            ids = [int(i.strip()) for i in f.readlines()]
+        prompts = pd.read_csv(filepaths[-1], encoding="utf8")
+        prompts = prompts[prompts["PMCID"].isin(ids)]
+
+        annotations = pd.read_csv(filepaths[0], encoding="utf8").set_index("PromptID")
+        evidences = pd.read_csv(filepaths[0], encoding="utf8").set_index("PMCID")
+        evidences = evidences[evidences["Evidence Start"] != -1]
+        uid = 0
+
+        def lookup(df: pd.DataFrame, id, col) -> str:
+            try:
+                label = df.loc[id][col]
+                if isinstance(label, pd.Series):
+                    return label.values[0]
+                else:
+                    return label
+            except KeyError:
+                return -1
+
+        def extract_evidence(doc_id, start, end):
+            p = f"{datapath}/PMC{doc_id}.txt"
+            with open(p, "r") as f:
+                return f.read()[start:end]
+
+
+        for key, sample in prompts.iterrows():
+
+            pid = sample["PromptID"]
+            pmcid = sample["PMCID"]
+            label = lookup(annotations, pid, "Label")
+            start = lookup(evidences, pmcid, "Evidence Start")
+            end = lookup(evidences, pmcid, "Evidence End")
+
+            if pid in SKIP_PROMPT_IDS:
+                continue
+
+            if label == -1:
+                continue
+
+            evidence = extract_evidence(pmcid, start, end)
+
+            if self.config.schema == "source":
+
+                feature_dict = {
+                    "id": uid,
+                    "pmcid": pmcid,
+                    "prompt_id": pid,
+                    "intervention": sample["Intervention"],
+                    "comparator": sample["Comparator"],
+                    "outcome": sample["Outcome"],
+                    "evidence": evidence,
+                    "label": label,
+                }
+
+                uid += 1
+                yield key, feature_dict
+
+            elif self.config.schema == "bigbio_qa":
+
+                context = evidence
+                question = (
+                    f"Compared to {sample['Comparator']} "
+                    f"what was the result of {sample['Intervention']} on {sample['Outcome']}?"
+                )
+                feature_dict = {
+                    "id": uid,
+                    "question_id": pid,
+                    "document_id": pmcid,
+                    "question": question,
+                    "type": "multiple_choice",
+                    "choices": QA_CHOICES,
+                    "context": context,
+                    "answer": [label],
+                }
+
+                uid += 1
+                yield key, feature_dict

--- a/hub/hubscripts/gad_hub.py
+++ b/hub/hubscripts/gad_hub.py
@@ -1,0 +1,211 @@
+from pathlib import Path
+from typing import List
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import text_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+
+_SOURCE_VIEW_NAME = "source"
+_UNIFIED_VIEW_NAME = "bigbio"
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{Bravo2015,
+  doi = {10.1186/s12859-015-0472-9},
+  url = {https://doi.org/10.1186/s12859-015-0472-9},
+  year = {2015},
+  month = feb,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume = {16},
+  number = {1},
+  author = {{\`{A}}lex Bravo and Janet Pi{\~{n}}ero and N{\'{u}}ria Queralt-Rosinach and Michael Rautschka and Laura I Furlong},
+  title = {Extraction of relations between genes and diseases from text and large-scale data analysis: implications for translational research},
+  journal = {{BMC} Bioinformatics}
+}
+"""
+
+_DESCRIPTION = """\
+A corpus identifying associations between genes and diseases by a semi-automatic
+annotation procedure based on the Genetic Association Database
+"""
+
+_DATASETNAME = "gad"
+_DISPLAYNAME = "GAD"
+
+_HOMEPAGE = "https://github.com/dmis-lab/biobert"  # This data source is used by the BLURB benchmark
+
+_LICENSE = 'Creative Commons Attribution 4.0 International'
+
+_URLs = {
+    "source": "https://drive.google.com/uc?export=download&id=1-jDKGcXREb2X9xTFnuiJ36PvsqoyHWcw",
+    "bigbio_text": "https://drive.google.com/uc?export=download&id=1-jDKGcXREb2X9xTFnuiJ36PvsqoyHWcw",
+}
+
+_SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class GAD(datasets.GeneratorBasedBuilder):
+    """GAD is a weakly labeled dataset for Entity Relations (REL) task which is treated as a sentence classification task."""
+
+    BUILDER_CONFIGS = [
+        # 10-fold source schema
+        BigBioConfig(
+            name=f"gad_fold{i}_source",
+            version=datasets.Version(_SOURCE_VERSION),
+            description="GAD source schema",
+            schema="source",
+            subset_id=f"gad_fold{i}",
+        )
+        for i in range(10)
+    ] + [
+        # 10-fold bigbio schema
+        BigBioConfig(
+            name=f"gad_fold{i}_bigbio_text",
+            version=datasets.Version(_BIGBIO_VERSION),
+            description="GAD BigBio schema",
+            schema="bigbio_text",
+            subset_id=f"gad_fold{i}",
+        )
+        for i in range(10)
+    ]
+
+    # BLURB Benchmark config https://microsoft.github.io/BLURB/
+    BUILDER_CONFIGS.append(
+        BigBioConfig(
+            name=f"gad_blurb_bigbio_text",
+            version=datasets.Version(_BIGBIO_VERSION),
+            description=f"GAD BLURB benchmark in simplified BigBio schema",
+            schema="bigbio_text",
+            subset_id=f"gad_blurb",
+        )
+    )
+
+    DEFAULT_CONFIG_NAME = "gad_fold0_source"
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "index": datasets.Value("string"),
+                    "sentence": datasets.Value("string"),
+                    "label": datasets.Value("int32"),
+                }
+            )
+        elif self.config.schema == "bigbio_text":
+            features = text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+
+        if "blurb" in self.config.name:
+            return self._blurb_split_generator(dl_manager)
+
+        fold_id = int(self.config.subset_id.split("_fold")[1][0]) + 1
+
+        my_urls = _URLs[self.config.schema]
+        data_dir = Path(dl_manager.download_and_extract(my_urls))
+        data_files = {
+            "train": data_dir / "GAD" / str(fold_id) / "train.tsv",
+            "test": data_dir / "GAD" / str(fold_id) / "test.tsv",
+        }
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"filepath": data_files["train"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"filepath": data_files["test"]},
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path):
+        if "train.tsv" in str(filepath):
+            df = pd.read_csv(filepath, sep="\t", header=None).reset_index()
+        else:
+            df = pd.read_csv(filepath, sep="\t")
+        df.columns = ["id", "sentence", "label"]
+
+        if self.config.schema == "source":
+            for id, row in enumerate(df.itertuples()):
+                ex = {
+                    "index": row.id,
+                    "sentence": row.sentence,
+                    "label": int(row.label),
+                }
+                yield id, ex
+        elif self.config.schema == "bigbio_text":
+            for id, row in enumerate(df.itertuples()):
+                ex = {
+                    "id": id,
+                    "document_id": row.id,
+                    "text": row.sentence,
+                    "labels": [str(row.label)],
+                }
+                yield id, ex
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")
+
+    def _blurb_split_generator(self, dl_manager: datasets.DownloadManager):
+        """Creates train/dev/test for BLURB split"""
+
+        my_urls = _URLs[self.config.schema]
+        data_dir = Path(dl_manager.download_and_extract(my_urls))
+        data_files = {
+            "train": data_dir / "GAD" / str(1) / "train.tsv",
+            "test": data_dir / "GAD" / str(1) / "test.tsv",
+        }
+
+        root_path = data_files["train"].parents[1]
+        # Save the train + validation sets accordingly
+        with open(data_files["train"], "r") as f:
+            train_data = f.readlines()
+
+        data = {}
+        data["train"], data["dev"] = train_data[:4261], train_data[4261:]
+
+        for batch in ["train", "dev"]:
+            fname = batch + "_blurb.tsv"
+            fname = root_path / fname
+
+            with open(fname, "w") as f:
+                f.write("index\tsentence\tlabel\n")
+                for idx, line in enumerate(data[batch]):
+                    f.write(f"{idx}\t{line}")
+
+        train_fpath = root_path / "train_blurb.tsv"
+        dev_fpath = root_path / "dev_blurb.tsv"
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"filepath": train_fpath},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"filepath": dev_fpath},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"filepath": data_files["test"]},
+            ),
+        ]

--- a/hub/hubscripts/genetag_hub.py
+++ b/hub/hubscripts/genetag_hub.py
@@ -1,0 +1,381 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Named entity recognition (NER) is an important first step for text mining the biomedical literature.
+Evaluating the performance of biomedical NER systems is impossible without a standardized test corpus.
+The annotation of such a corpus for gene/protein name NER is a difficult process due to the complexity
+of gene/protein names. We describe the construction and annotation of GENETAG, a corpus of 20K MEDLINE®
+sentences for gene/protein NER. 15K GENETAG sentences were used for the BioCreAtIvE Task 1A Competition.
+"""
+
+
+import re
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{Tanabe2005,
+  author    = {Lorraine Tanabe and Natalie Xie and Lynne H Thom and Wayne Matten and W John Wilbur},
+  title     = {{GENETAG}: a tagged corpus for gene/protein named entity recognition},
+  journal   = {{BMC} Bioinformatics},
+  volume    = {6},
+  year      = {2005},
+  url       = {https://doi.org/10.1186/1471-2105-6-S1-S3},
+  doi       = {10.1186/1471-2105-6-s1-s3},
+  biburl    = {},
+  bibsource = {}
+}
+"""
+
+_DATASETNAME = "genetag"
+_DISPLAYNAME = "GENETAG"
+
+_DESCRIPTION = """\
+Named entity recognition (NER) is an important first step for text mining the biomedical literature.
+Evaluating the performance of biomedical NER systems is impossible without a standardized test corpus.
+The annotation of such a corpus for gene/protein name NER is a difficult process due to the complexity
+of gene/protein names. We describe the construction and annotation of GENETAG, a corpus of 20K MEDLINE®
+sentences for gene/protein NER. 15K GENETAG sentences were used for the BioCreAtIvE Task 1A Competition..
+"""
+
+_HOMEPAGE = "https://github.com/openbiocorpora/genetag"
+
+_LICENSE = 'National Center fr Biotechnology Information PUBLIC DOMAIN NOTICE'
+
+_BASE_URL = (
+    "https://raw.githubusercontent.com/openbiocorpora/genetag/master/original-data/"
+)
+
+_URLS = {
+    "test": {
+        "correct": f"{_BASE_URL}test/Correct.Data",
+        "gold": f"{_BASE_URL}test/Gold.format",
+        "text": f"{_BASE_URL}test/TOKENIZED_CORPUS",
+        "postagspath": f"{_BASE_URL}test/TAGGED_GENE_CORPUS",
+    },
+    "train": {
+        "correct": f"{_BASE_URL}train/Correct.Data",
+        "gold": f"{_BASE_URL}train/Gold.format",
+        "text": f"{_BASE_URL}train/TOKENIZED_CORPUS",
+        "postagspath": f"{_BASE_URL}train/TAGGED_GENE_CORPUS",
+    },
+    "round1": {
+        "correct": f"{_BASE_URL}round1/Correct.Data",
+        "gold": f"{_BASE_URL}round1/Gold.format",
+        "text": f"{_BASE_URL}round1/TOKENIZED_CORPUS",
+        "postagspath": f"{_BASE_URL}round1/TAGGED_GENE_CORPUS",
+    },
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class GenetagDataset(datasets.GeneratorBasedBuilder):
+    """GENETAG is a corpus of 15K MEDLINE sentences with annotations for gene/protein NER"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = []
+    for annot_type in ["gold", "correct"]:
+        BUILDER_CONFIGS.append(
+            BigBioConfig(
+                name=f"genetag{annot_type}_source",
+                version=SOURCE_VERSION,
+                description=f"GENETAG {annot_type} annotation source schema",
+                schema="source",
+                subset_id=f"genetag{annot_type}",
+            )
+        )
+
+        BUILDER_CONFIGS.append(
+            BigBioConfig(
+                name=f"genetag{annot_type}_bigbio_kb",
+                version=BIGBIO_VERSION,
+                description=f"GENETAG {annot_type} annotation bigbio schema",
+                schema="bigbio_kb",
+                subset_id=f"genetag{annot_type}",
+            )
+        )
+
+    DEFAULT_CONFIG_NAME = "genetaggold_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "doc_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "tokenized_text": datasets.Sequence(datasets.Value("string")),
+                    "pos_tags": datasets.Sequence(datasets.Value("string")),
+                    "entities": [
+                        {
+                            "token_offsets": datasets.Sequence(
+                                [datasets.Value("int32")]
+                            ),
+                            "text": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "entity_id": datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS
+        data_dir = dl_manager.download_and_extract(urls)
+        annotation_type = self.config.subset_id.split("genetag")[
+            -1
+        ]  # correct or gold annotations
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": data_dir["train"]["text"],
+                    "annotationpath": data_dir["train"][annotation_type],
+                    "postagspath": data_dir["train"]["postagspath"],
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": data_dir["test"]["text"],
+                    "annotationpath": data_dir["test"][annotation_type],
+                    "postagspath": data_dir["test"]["postagspath"],
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": data_dir["round1"]["text"],
+                    "annotationpath": data_dir["round1"][annotation_type],
+                    "postagspath": data_dir["round1"]["postagspath"],
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(
+        self, filepath, annotationpath, postagspath, split: str
+    ) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        corpus, annotations = self._read_files(filepath, annotationpath, postagspath)
+
+        if self.config.schema == "source":
+            source_examples = self._parse_annotations_source(corpus, annotations, split)
+            for uid, doc_id in enumerate(source_examples):
+                yield uid, source_examples[doc_id]
+
+        elif self.config.schema == "bigbio_kb":
+            bb_kb_examples = self._parse_annotations_bb(corpus, annotations, split)
+            for uid, doc_id in enumerate(bb_kb_examples):
+                yield uid, bb_kb_examples[doc_id]
+
+    def _read_files(self, filepath, annotation_path, postagspath):
+        """
+        Reads text corpus and annotations
+        """
+        corpus, annotations = dict(), dict()
+
+        # read corpus
+        with open(filepath, "r") as texts:
+            for line in texts:
+                # "@@95229799480" from "@@95229799480 Cervicovaginal ..."
+                sentence_id = re.search(r"@@\d+", line).group(0)
+                # remove "/TAG" suffix and "./"
+                text = re.sub(r"(/TAG|\/\.)", "", line).split(sentence_id)[-1].strip()
+                corpus[sentence_id] = {
+                    "text": text,
+                    "tokenized_text": text.split(),  # every token is space separated at source
+                }
+
+        with open(postagspath, "r") as texts:
+            for line in texts:
+                sentence_id = re.search(r"@@\d+", line).group(0)
+                _tags = re.findall(r"(\/[A-Z]+|\/[.,:()\"]+)", line)
+                pos_tags = [i.replace("/", "") for i in _tags]
+                corpus[sentence_id]["pos_tags"] = pos_tags
+
+        # read annotations
+        with open(annotation_path, "r") as annots:
+            for line in annots:
+                row = line.split("|")
+                if len(row) == 3:
+                    sentence_id = row[0].strip()
+                    annot = row[2].strip()
+                    start = int(row[1].split()[0])
+                    end = int(row[1].split()[1])
+                    if sentence_id in annotations:
+                        annotations[sentence_id].append(
+                            {"text": annot, "token_start": start, "token_end": end}
+                        )
+                    else:
+                        annotations[sentence_id] = [
+                            {"text": annot, "token_start": start, "token_end": end}
+                        ]
+
+        return corpus, annotations
+
+    def _parse_annotations_source(self, corpus, annotations, split) -> Dict:
+        """
+        Reads source annotations
+        """
+        # Convert to source schema
+        source_examples = {}
+        for sent_id in corpus:
+
+            text = corpus[sent_id]["text"]
+            source_examples[sent_id] = {
+                "doc_id": sent_id,
+                "text": text,
+                "tokenized_text": corpus[sent_id]["tokenized_text"],
+                "pos_tags": corpus[sent_id]["pos_tags"],
+                "entities": [],
+            }
+
+            if annotations.get(sent_id):
+                for uid, entity in enumerate(annotations[sent_id]):
+                    source_examples[sent_id]["entities"].append(
+                        {
+                            "text": entity["text"],
+                            "type": "NEWGENE",
+                            "token_offsets": [
+                                [entity["token_start"], entity["token_end"]]
+                            ],
+                            "entity_id": f"{sent_id}_{uid+1}",
+                        }
+                    )
+
+        return source_examples
+
+    def _parse_annotations_bb(self, corpus, annotations, split) -> Dict:
+        """
+        Convert source annotations to bigbio schema annotations
+        """
+        bb_examples = {}
+
+        for sent_id in corpus:
+            text = corpus[sent_id]["text"]
+            bb_examples[sent_id] = {
+                "id": sent_id,
+                "document_id": sent_id,
+                "passages": [
+                    {
+                        "id": f"{sent_id}_text",
+                        "type": "sentence",
+                        "text": [text],
+                        "offsets": [[0, len(text)]],
+                    }
+                ],
+                "entities": self._add_entities_bb(sent_id, annotations[sent_id], text)
+                if annotations.get(sent_id)
+                else [],
+                "events": [],
+                "coreferences": [],
+                "relations": [],
+            }
+
+        return bb_examples
+
+    def _add_entities_bb(self, doc_id, annotations, text) -> List:
+        """
+        Returns entities in bigbio schema when given annotations
+        (with token indices) for some text
+        a text. e.g: -
+
+        doc_id: @@21234669976
+        annotations: [{'text': 'HLH', 'token_start': 9, 'token_end': 9},
+                      {'text': 'AP-4 HLH', 'token_start': 8, 'token_end': 9},
+                      {'text': 'AP-4 HLH motif', 'token_start': 8, 'token_end': 10}]
+        text: 'Like other members of this family , the AP-4 HLH motif and the adjacent
+               basic domain are necessary and sufficient to confer site-specific DNA binding .'
+
+        returns:  [
+                    {'offsets': [[45, 48]],
+                    'text': ['HLH'],
+                    'type': 'NEWGENE',
+                    'normalized': [],
+                    'id': '@@21234669976_1'},
+                    {'offsets': [[40, 48]],
+                    'text': ['AP-4 HLH'],
+                    'type': 'NEWGENE',
+                    'normalized': [],
+                    'id': '@@21234669976_2'},
+                    {'offsets': [[40, 54]],
+                    'text': ['AP-4 HLH motif'],
+                    'type': 'NEWGENE',
+                    'normalized': [],
+                    'id': '@@21234669976_3'}
+                ]
+
+        Uses the given token level indices to pick correct entities
+        and assign character offsets
+        """
+
+        entities = []
+        for uid, entity in enumerate(annotations):
+            start = entity["token_start"]
+            end = entity["token_end"]
+            for i in range(len(text)):
+
+                if text[i:].startswith(entity["text"]):
+                    # match substring using character and word index
+                    token_end = end + 1
+                    token_end_char = i + len(entity["text"])
+                    if (
+                        " ".join(text.split()[start:token_end])
+                        == text[i:token_end_char]
+                    ):
+                        annot = {
+                            "offsets": [[i, i + len(entity["text"])]],
+                            "text": [entity["text"]],
+                            "type": "NEWGENE",
+                            "normalized": [],
+                        }
+                        if annot not in entities:
+                            annot["id"] = f"{doc_id}_{uid+1}"
+                            entities.append(annot)
+                            break
+        return entities

--- a/hub/hubscripts/genia_ptm_event_corpus_hub.py
+++ b/hub/hubscripts/genia_ptm_event_corpus_hub.py
@@ -1,0 +1,209 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Post-translational-modiﬁcations (PTM), amino acid modiﬁcations of proteins after translation, are one of the posterior
+processes of protein biosynthesis for many proteins, and they are critical for determining protein function such as its
+activity state, localization, turnover and interactions with other biomolecules. While there have been many studies of
+information extraction targeting individual PTM types, there was until recently little effort to address extraction of
+multiple PTM types at once in a unified framework.
+"""
+
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{ohta-etal-2010-event,
+    title = "Event Extraction for Post-Translational Modifications",
+    author = "Ohta, Tomoko  and
+      Pyysalo, Sampo  and
+      Miwa, Makoto  and
+      Kim, Jin-Dong  and
+      Tsujii, Jun{'}ichi",
+    booktitle = "Proceedings of the 2010 Workshop on Biomedical Natural Language Processing",
+    month = jul,
+    year = "2010",
+    address = "Uppsala, Sweden",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/W10-1903",
+    pages = "19--27",
+}
+"""
+
+_DATASETNAME = "genia_ptm_event_corpus"
+_DISPLAYNAME = "PTM Events"
+
+_DESCRIPTION = """\
+Post-translational-modiﬁcations (PTM), amino acid modiﬁcations of proteins \
+after translation, are one of the posterior processes of protein biosynthesis \
+for many proteins, and they are critical for determining protein function such \
+as its activity state, localization, turnover and interactions with other \
+biomolecules. While there have been many studies of information extraction \
+targeting individual PTM types, there was until recently little effort to \
+address extraction of multiple PTM types at once in a unified framework.
+"""
+
+_HOMEPAGE = "http://www.geniaproject.org/other-corpora/ptm-event-corpus"
+
+_LICENSE = 'GENIA Project License for Annotated Corpora'
+
+
+_URLS = {
+    _DATASETNAME: "http://www.geniaproject.org/other-corpora/ptm-event-corpus/post-translational_modifications_training_data.tar.gz?attredirects=0&d=1",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.COREFERENCE_RESOLUTION,
+    Tasks.EVENT_EXTRACTION,
+]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class GeniaPtmEventCorpusDataset(datasets.GeneratorBasedBuilder):
+    """GENIA PTM event corpus."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="genia_ptm_event_corpus_source",
+            version=SOURCE_VERSION,
+            description="genia_ptm_event_corpus source schema",
+            schema="source",
+            subset_id="genia_ptm_event_corpus",
+        ),
+        BigBioConfig(
+            name="genia_ptm_event_corpus_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="genia_ptm_event_corpus BigBio schema",
+            schema="bigbio_kb",
+            subset_id="genia_ptm_event_corpus",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "genia_ptm_event_corpus_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value(
+                                "string"
+                            ),  # refers to the text_bound_annotation of the trigger
+                            "trigger": datasets.Value("string"),
+                            "arguments": [
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                },
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                },
+            ),
+        ]
+
+    def _generate_examples(self, data_dir) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        for dirpath, _, filenames in os.walk(data_dir):
+            for guid, filename in enumerate(filenames):
+                if filename.endswith(".txt"):
+                    txt_file_path = Path(dirpath, filename)
+                    if self.config.schema == "source":
+                        example = parsing.parse_brat_file(
+                            txt_file_path, annotation_file_suffixes=[".a1", ".a2"]
+                        )
+                        example["id"] = str(guid)
+                        for key in ["attributes", "normalizations"]:
+                            del example[key]
+                        yield guid, example
+                    elif self.config.schema == "bigbio_kb":
+                        example = parsing.brat_parse_to_bigbio_kb(
+                            parsing.parse_brat_file(txt_file_path)
+                        )
+                        example["id"] = str(guid)
+                        yield guid, example

--- a/hub/hubscripts/genia_relation_corpus_hub.py
+++ b/hub/hubscripts/genia_relation_corpus_hub.py
@@ -1,0 +1,217 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The extraction of various relations stated to hold between biomolecular entities is one of the most frequently
+addressed information extraction tasks in domain studies. Typical relation extraction targets involve protein-protein
+interactions or gene regulatory relations. However, in the GENIA corpus, such associations involving change in the
+state or properties of biomolecules are captured in the event annotation.
+
+The GENIA corpus relation annotation aims to complement the event annotation of the corpus by capturing (primarily)
+static relations, relations such as part-of that hold between entities without (necessarily) involving change.
+"""
+
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{pyysalo-etal-2009-static,
+    title = "Static Relations: a Piece in the Biomedical Information Extraction Puzzle",
+    author = "Pyysalo, Sampo  and
+      Ohta, Tomoko  and
+      Kim, Jin-Dong  and
+      Tsujii, Jun{'}ichi",
+    booktitle = "Proceedings of the {B}io{NLP} 2009 Workshop",
+    month = jun,
+    year = "2009",
+    address = "Boulder, Colorado",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/W09-1301",
+    pages = "1--9",
+}
+
+@article{article,
+author = {Ohta, Tomoko and Pyysalo, Sampo and Kim, Jin-Dong and Tsujii, Jun'ichi},
+year = {2010},
+month = {10},
+pages = {917-28},
+title = {A reevaluation of biomedical named entity - term relations},
+volume = {8},
+journal = {Journal of bioinformatics and computational biology},
+doi = {10.1142/S0219720010005014}
+}
+
+@MISC{Hoehndorf_applyingontology,
+    author = {Robert Hoehndorf and Axel-cyrille Ngonga Ngomo and Sampo Pyysalo and Tomoko Ohta and Anika Oellrich and
+    Dietrich Rebholz-schuhmann},
+    title = {Applying ontology design patterns to the implementation of relations in GENIA},
+    year = {}
+}
+"""
+
+_DATASETNAME = "genia_relation_corpus"
+_DISPLAYNAME = "GENIA Relation Corpus"
+
+_DESCRIPTION = """\
+The extraction of various relations stated to hold between biomolecular entities is one of the most frequently
+addressed information extraction tasks in domain studies. Typical relation extraction targets involve protein-protein
+interactions or gene regulatory relations. However, in the GENIA corpus, such associations involving change in the
+state or properties of biomolecules are captured in the event annotation.
+
+The GENIA corpus relation annotation aims to complement the event annotation of the corpus by capturing (primarily)
+static relations, relations such as part-of that hold between entities without (necessarily) involving change.
+"""
+
+_HOMEPAGE = "http://www.geniaproject.org/genia-corpus/relation-corpus"
+
+_LICENSE = 'GENIA Project License for Annotated Corpora'
+
+_URLS = {
+    _DATASETNAME: {
+        "train": "http://www.nactem.ac.uk/GENIA/current/GENIA-corpus/Relation/GENIA_relation_annotation_training_data.tar.gz",
+        "validation": "http://www.nactem.ac.uk/GENIA/current/GENIA-corpus/Relation/GENIA_relation_annotation_development_data.tar.gz",
+        "test": "http://www.nactem.ac.uk/GENIA/current/GENIA-corpus/Relation/GENIA_relation_annotation_test_data.tar.gz",
+    },
+}
+
+_SUPPORTED_TASKS = [Tasks.RELATION_EXTRACTION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class GeniaRelationCorpusDataset(datasets.GeneratorBasedBuilder):
+    """GENIA Relation corpus."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="genia_relation_corpus_source",
+            version=SOURCE_VERSION,
+            description="genia_relation_corpus source schema",
+            schema="source",
+            subset_id="genia_relation_corpus",
+        ),
+        BigBioConfig(
+            name="genia_relation_corpus_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="genia_relation_corpus BigBio schema",
+            schema="bigbio_kb",
+            subset_id="genia_relation_corpus",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "genia_relation_corpus_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                },
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+        return [
+            datasets.SplitGenerator(
+                name=split,
+                gen_kwargs={
+                    "data_dir": data_dir[split],
+                },
+            )
+            for split in [
+                datasets.Split.TRAIN,
+                datasets.Split.VALIDATION,
+                datasets.Split.TEST,
+            ]
+        ]
+
+    def _generate_examples(self, data_dir) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        for dirpath, _, filenames in os.walk(data_dir):
+            for guid, filename in enumerate(filenames):
+                if filename.endswith(".txt"):
+                    txt_file_path = Path(dirpath, filename)
+                    if self.config.schema == "source":
+                        example = parsing.parse_brat_file(
+                            txt_file_path, annotation_file_suffixes=[".a1", ".rel"]
+                        )
+                        example["id"] = str(guid)
+                        for key in ["events", "attributes", "normalizations"]:
+                            del example[key]
+                        yield guid, example
+                    elif self.config.schema == "bigbio_kb":
+                        example = parsing.brat_parse_to_bigbio_kb(
+                            parsing.parse_brat_file(txt_file_path)
+                        )
+                        example["id"] = str(guid)
+                        yield guid, example

--- a/hub/hubscripts/genia_term_corpus_hub.py
+++ b/hub/hubscripts/genia_term_corpus_hub.py
@@ -1,0 +1,313 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The identification of linguistic expressions referring to entities of interest in molecular biology such as proteins,
+genes and cells is a fundamental task in biomolecular text mining. The GENIA technical term annotation covers the
+identification of  physical biological entities as well as other important terms. The corpus annotation covers the full
+1,999 abstracts of the primary GENIA corpus.
+"""
+
+import xml.etree.ElementTree as ET
+from itertools import count
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{10.5555/1289189.1289260,
+author = {Ohta, Tomoko and Tateisi, Yuka and Kim, Jin-Dong},
+title = {The GENIA Corpus: An Annotated Research Abstract Corpus in Molecular Biology Domain},
+year = {2002},
+publisher = {Morgan Kaufmann Publishers Inc.},
+address = {San Francisco, CA, USA},
+booktitle = {Proceedings of the Second International Conference on Human Language Technology Research},
+pages = {82–86},
+numpages = {5},
+location = {San Diego, California},
+series = {HLT '02}
+}
+
+@article{Kim2003GENIAC,
+  title={GENIA corpus - a semantically annotated corpus for bio-textmining},
+  author={Jin-Dong Kim and Tomoko Ohta and Yuka Tateisi and Junichi Tsujii},
+  journal={Bioinformatics},
+  year={2003},
+  volume={19 Suppl 1},
+  pages={
+          i180-2
+        }
+}
+
+@inproceedings{10.5555/1567594.1567610,
+author = {Kim, Jin-Dong and Ohta, Tomoko and Tsuruoka, Yoshimasa and Tateisi, Yuka and Collier, Nigel},
+title = {Introduction to the Bio-Entity Recognition Task at JNLPBA},
+year = {2004},
+publisher = {Association for Computational Linguistics},
+address = {USA},
+booktitle = {Proceedings of the International Joint Workshop on Natural Language Processing in Biomedicine and Its
+Applications},
+pages = {70–75},
+numpages = {6},
+location = {Geneva, Switzerland},
+series = {JNLPBA '04}
+}
+"""
+
+_DATASETNAME = "genia_term_corpus"
+_DISPLAYNAME = "GENIA Term Corpus"
+
+_DESCRIPTION = """\
+The identification of linguistic expressions referring to entities of interest in molecular biology such as proteins,
+genes and cells is a fundamental task in biomolecular text mining. The GENIA technical term annotation covers the
+identification of  physical biological entities as well as other important terms. The corpus annotation covers the full
+1,999 abstracts of the primary GENIA corpus.
+"""
+
+_HOMEPAGE = "http://www.geniaproject.org/genia-corpus/term-corpus"
+
+_LICENSE = 'GENIA Project License for Annotated Corpora'
+
+_URLS = {
+    _DATASETNAME: "http://www.nactem.ac.uk/GENIA/current/GENIA-corpus/Term/GENIAcorpus3.02.tgz",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "3.0.2"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class GeniaTermCorpusDataset(datasets.GeneratorBasedBuilder):
+    """TODO: Short description of my dataset."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="genia_term_corpus_source",
+            version=SOURCE_VERSION,
+            description="genia_term_corpus source schema",
+            schema="source",
+            subset_id="genia_term_corpus",
+        ),
+        BigBioConfig(
+            name="genia_term_corpus_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="genia_term_corpus BigBio schema",
+            schema="bigbio_kb",
+            subset_id="genia_term_corpus",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "genia_term_corpus_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "title": [
+                        {
+                            "text": datasets.Value("string"),
+                            "entities": [
+                                {
+                                    "text": datasets.Value("string"),
+                                    "lex": datasets.Value("string"),
+                                    "sem": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                    "abstract": [
+                        {
+                            "text": datasets.Value("string"),
+                            "entities": [
+                                {
+                                    "text": datasets.Value("string"),
+                                    "lex": datasets.Value("string"),
+                                    "sem": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download(urls)
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "archive": dl_manager.iter_archive(data_dir),
+                    "data_path": "GENIA_term_3.02/GENIAcorpus3.02.xml",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, archive, data_path) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        uid = count(0)
+        for path, file in archive:
+            if path == data_path:
+                for key, example in enumerate(iterparse_genia(file)):
+                    if self.config.schema == "source":
+                        yield key, example
+
+                    elif self.config.schema == "bigbio_kb":
+                        yield key, parse_genia_to_bigbio(example, uid)
+
+
+def iterparse_genia(file):
+    # ontology = None
+    for _, element in ET.iterparse(file):
+        # if element.tag == "import":
+        #     ontology = {"name": element.get("resource"), "prefix": element.get("prefix")}
+        if element.tag == "article":
+            bibliomisc = element.find("articleinfo/bibliomisc").text
+            document_id = parse_genia_bibliomisc(bibliomisc)
+            title = element.find("title")
+            title_sentences = parse_genia_sentences(title)
+            abstract = element.find("abstract")
+            abstract_sentences = parse_genia_sentences(abstract)
+            yield {
+                "document_id": document_id,
+                "title": title_sentences,
+                "abstract": abstract_sentences,
+            }
+
+
+def parse_genia_sentences(passage):
+    sentences = []
+    for sentence in passage.iter(tag="sentence"):
+        text = "".join(sentence.itertext())
+        entities = []
+        for entity in sentence.iter(tag="cons"):  # constituent
+            entity_lex = entity.get("lex", "")
+            entity_sem = parse_genia_sem(entity.get("sem", ""))
+            entity_text = "".join(entity.itertext())
+            entities.append({"text": entity_text, "lex": entity_lex, "sem": entity_sem})
+        sentences.append(
+            {
+                "text": text,
+                "entities": entities,
+            }
+        )
+    return sentences
+
+
+def parse_genia_bibliomisc(bibliomisc):
+    """Remove 'MEDLINE:' from 'MEDLINE:96055286'."""
+    return bibliomisc.replace("MEDLINE:", "") if ":" in bibliomisc else bibliomisc
+
+
+def parse_genia_sem(sem):
+    return sem.replace("G#", "") if "G#" in sem else sem
+
+
+def parse_genia_to_bigbio(example, uid):
+    document = {
+        "id": next(uid),
+        "document_id": example["document_id"],
+        "passages": list(generate_bigbio_passages(example, uid)),
+        "entities": list(generate_bigbio_entities(example, uid)),
+        "events": [],
+        "coreferences": [],
+        "relations": [],
+    }
+    return document
+
+
+def parse_genia_to_bigbio_passage(passage, uid, type="", offset=0):
+    text = " ".join(sentence["text"] for sentence in passage)
+    new_offset = offset + len(text)
+    return {
+        "id": next(uid),
+        "type": type,
+        "text": [text],
+        "offsets": [[offset, new_offset]],
+    }, new_offset + 1
+
+
+def generate_bigbio_passages(example, uid):
+    offset = 0
+    for type in ["title", "abstract"]:
+        passage, offset = parse_genia_to_bigbio_passage(
+            example[type], uid, type=type, offset=offset
+        )
+        yield passage
+
+
+def parse_genia_to_bigbio_entity(entity, uid, text="", relative_offset=0, offset=0):
+    try:
+        relative_offset = text.index(entity["text"], relative_offset)
+    except ValueError:
+        # Skip duplicated annotations:
+        # <cons lex="tumour_cell" sem="G#cell_type"><cons lex="tumour_cell" sem="G#cell_type">tumour cells</cons></cons>
+        return None, None
+    new_relative_offset = relative_offset + len(entity["text"])
+    return {
+        "id": next(uid),
+        "offsets": [[offset + relative_offset, offset + new_relative_offset]],
+        "text": [entity["text"]],
+        "type": entity["sem"],
+        "normalized": [],
+    }, new_relative_offset
+
+
+def generate_bigbio_entities(example, uid):
+    sentence_offset = 0
+    for type in ["title", "abstract"]:
+        for sentence in example[type]:
+            relative_offsets = {}
+            for entity in sentence["entities"]:
+                bigbio_entity, new_relative_offset = parse_genia_to_bigbio_entity(
+                    entity,
+                    uid,
+                    text=sentence["text"],
+                    relative_offset=relative_offsets.get(
+                        (entity["text"], entity["lex"], entity["sem"]), 0
+                    ),
+                    offset=sentence_offset,
+                )
+                if bigbio_entity:
+                    relative_offsets[
+                        (entity["text"], entity["lex"], entity["sem"])
+                    ] = new_relative_offset
+                    yield bigbio_entity
+            sentence_offset += len(sentence["text"]) + 1

--- a/hub/hubscripts/geokhoj_v1_hub.py
+++ b/hub/hubscripts/geokhoj_v1_hub.py
@@ -1,0 +1,159 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+GEOKhoj v1 contains metadata for 30,000 samples with their respective labels (control/perturbed),
+which were labelled using the information available in the metadata.
+Metadata has been extracted for samples from Microarray, Transcriptomics
+and Single cell experiments which are available on the GEO (Gene Expression Omnibus) database.
+"""
+
+import os
+from typing import Dict, Tuple
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import text_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@misc{geokhoj_v1,
+  author = {Elucidata, Inc.},
+  title = {GEOKhoj v1},
+  howpublished = {\\url{https://github.com/ElucidataInc/GEOKhoj-datasets/tree/main/geokhoj_v1}},
+}
+"""
+
+_DATASETNAME = "geokhoj_v1"
+_DISPLAYNAME = "GEOKhoj v1"
+
+_DESCRIPTION = """\
+GEOKhoj v1 is a annotated corpus of control/perturbation labels for 30,000 samples
+from Microarray, Transcriptomics and Single cell experiments which are available on
+the GEO (Gene Expression Omnibus) database
+"""
+
+_HOMEPAGE = "https://github.com/ElucidataInc/GEOKhoj-datasets/tree/main/geokhoj_v1"
+
+_LICENSE = 'Creative Commons Attribution Non Commercial 4.0 International'
+
+_URLS = {
+    "source": "https://github.com/ElucidataInc/GEOKhoj-datasets/blob/main/geokhoj_v1/geokhoj_V1.zip?raw=True",
+    "bigbio_text": "https://github.com/ElucidataInc/GEOKhoj-datasets/blob/main/geokhoj_v1/geokhoj_V1.zip?raw=True",
+}
+
+_SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class Geokhojv1Dataset(datasets.GeneratorBasedBuilder):
+    """
+    GEOKhoj v1 text classification dataset
+    """
+
+    DEFAULT_CONFIG_NAME = "geokhoj_v1_source"
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="geokhoj_v1_source",
+            version=SOURCE_VERSION,
+            description="GEOKhoj v1 source schema",
+            schema="source",
+            subset_id="geokhoj_v1",
+        ),
+        BigBioConfig(
+            name="geokhoj_v1_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="GEOKhoj v1 BigBio schema",
+            schema="bigbio_text",
+            subset_id="geokhoj_v1",
+        ),
+    ]
+
+    def _info(self):
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "label": datasets.features.ClassLabel(
+                        names={0: "control", 1: "perturbation"}
+                    ),
+                    "text": datasets.Value("string"),
+                }
+            )
+
+        elif self.config.schema == "bigbio_text":
+            features = text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+        urls = _URLS[self.config.schema]
+        data_dir = dl_manager.download_and_extract(urls)
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "geokhoj_v1/data/train/geo_samples_train.csv"
+                    ),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "geokhoj_v1/data/test/geo_samples_test.csv"
+                    ),
+                    "split": "test",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        df = pd.read_csv(filepath, encoding="utf-8", header=None)
+
+        if self.config.schema == "source":
+            for id_, row in df.iterrows():
+                yield id_, {"id": row[0], "label": row[1], "text": row[2]}
+
+        elif self.config.schema == "bigbio_text":
+            for id_, row in df.iterrows():
+                yield id_, {
+                    "id": id_ + 1,
+                    "document_id": row[0],
+                    "text": row[2],
+                    "labels": [row[1]],
+                }

--- a/hub/hubscripts/gnormplus_hub.py
+++ b/hub/hubscripts/gnormplus_hub.py
@@ -1,0 +1,260 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+import os
+import re
+from typing import Dict, List, Tuple
+
+import datasets
+from bioc import biocxml
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@Article{Wei2015,
+author={Wei, Chih-Hsuan and Kao, Hung-Yu and Lu, Zhiyong},
+title={GNormPlus: An Integrative Approach for Tagging Genes, Gene Families, and Protein Domains},
+journal={BioMed Research International},
+year={2015},
+month={Aug},
+day={25},
+publisher={Hindawi Publishing Corporation},
+volume={2015},
+pages={918710},
+issn={2314-6133},
+doi={10.1155/2015/918710},
+url={https://doi.org/10.1155/2015/918710}
+}
+"""
+
+_DATASETNAME = "gnormplus"
+_DISPLAYNAME = "GNormPlus"
+
+_DESCRIPTION = """\
+We re-annotated two existing gene corpora. The BioCreative II GN corpus is a widely used data set for benchmarking GN
+tools and includes document-level annotations for a total of 543 articles (281 in its training set; and 262 in test).
+The Citation GIA Test Collection was recently created for gene indexing at the NLM and includes 151 PubMed abstracts
+with both mention-level and document-level annotations. They are selected because both have a focus on human genes.
+For both corpora, we added annotations of gene families and protein domains. For the BioCreative GN corpus, we also
+added mention-level gene annotations. As a result, in our new corpus, there are a total of 694 PubMed articles.
+PubTator was used as our annotation tool along with BioC formats.
+"""
+
+_HOMEPAGE = "https://www.ncbi.nlm.nih.gov/research/bionlp/Tools/gnormplus/"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: "https://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/tmTools/download/GNormPlus/GNormPlusCorpus.zip"
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class GnormplusDataset(datasets.GeneratorBasedBuilder):
+    """Dataset loader for GNormPlus corpus."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="gnormplus_source",
+            version=SOURCE_VERSION,
+            description="gnormplus source schema",
+            schema="source",
+            subset_id="gnormplus",
+        ),
+        BigBioConfig(
+            name="gnormplus_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="gnormplus BigBio schema",
+            schema="bigbio_kb",
+            subset_id="gnormplus",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "gnormplus_source"
+
+    _re_tax_id = re.compile(r"(?P<db_id>\d+)\(Tax:(?P<tax_id>\d+)\)")
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "doc_id": datasets.Value("string"),
+                    "passages": [
+                        {
+                            "text": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "location": {
+                                "offset": datasets.Value("int64"),
+                                "length": datasets.Value("int64"),
+                            },
+                        }
+                    ],
+                    "entities": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "normalized": [
+                                {
+                                    "db_name": datasets.Value("string"),
+                                    "db_id": datasets.Value("string"),
+                                    "tax_id": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                }
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+        else:
+            raise NotImplementedError(self.config.schema)
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "GNormPlusCorpus/BC2GNtrain.BioC.xml"
+                    ),
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "GNormPlusCorpus/BC2GNtest.BioC.xml"
+                    ),
+                },
+            ),
+        ]
+
+    def _parse_bioc_entity(self, uid, bioc_ann, db_id_key="NCBI", insert_tax_id=False):
+        offsets, texts = get_texts_and_offsets_from_bioc_ann(bioc_ann)
+        _type = bioc_ann.infons["type"]
+
+        # parse db ids
+        normalized = []
+        if _type in bioc_ann.infons:
+            for _id in bioc_ann.infons[_type].split(","):
+                match = self._re_tax_id.match(_id)
+                if match:
+                    _id = match.group("db_id")
+
+                n = {"db_name": db_id_key, "db_id": _id}
+                if insert_tax_id:
+                    n["tax_id"] = match.group("tax_id") if match else None
+
+                normalized.append(n)
+        return {
+            "id": uid,
+            "offsets": offsets,
+            "text": texts,
+            "type": _type,
+            "normalized": normalized,
+        }
+
+    def _generate_examples(self, filepath) -> Tuple[int, Dict]:
+        uid = map(str, itertools.count(start=0, step=1))
+
+        with open(filepath, "r") as fp:
+            collection = biocxml.load(fp)
+
+            for idx, document in enumerate(collection.documents):
+                if self.config.schema == "source":
+                    features = {
+                        "doc_id": document.id,
+                        "passages": [
+                            {
+                                "text": passage.text,
+                                "type": passage.infons["type"],
+                                "location": {
+                                    "offset": passage.offset,
+                                    "length": passage.total_span.length,
+                                },
+                            }
+                            for passage in document.passages
+                        ],
+                        "entities": [
+                            self._parse_bioc_entity(
+                                next(uid), entity, insert_tax_id=True
+                            )
+                            for passage in document.passages
+                            for entity in passage.annotations
+                        ],
+                    }
+                    yield idx, features
+                elif self.config.schema == "bigbio_kb":
+                    # passage offsets/lengths do not connect, recalculate them for this schema.
+                    passage_spans = []
+                    start = 0
+                    for passage in document.passages:
+                        end = start + len(passage.text)
+                        passage_spans.append((start, end))
+                        start = end + 1
+
+                    features = {
+                        "id": next(uid),
+                        "document_id": document.id,
+                        "passages": [
+                            {
+                                "id": next(uid),
+                                "type": passage.infons["type"],
+                                "text": [passage.text],
+                                "offsets": [span],
+                            }
+                            for passage, span in zip(document.passages, passage_spans)
+                        ],
+                        "entities": [
+                            self._parse_bioc_entity(next(uid), entity)
+                            for passage in document.passages
+                            for entity in passage.annotations
+                        ],
+                        "events": [],
+                        "coreferences": [],
+                        "relations": [],
+                    }
+                    yield idx, features
+                else:
+                    raise NotImplementedError(self.config.schema)

--- a/hub/hubscripts/hallmarks_of_cancer_hub.py
+++ b/hub/hubscripts/hallmarks_of_cancer_hub.py
@@ -1,0 +1,214 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+
+import datasets
+
+from .bigbiohub import text_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{DBLP:journals/bioinformatics/BakerSGAHSK16,
+  author    = {Simon Baker and
+               Ilona Silins and
+               Yufan Guo and
+               Imran Ali and
+               Johan H{\"{o}}gberg and
+               Ulla Stenius and
+               Anna Korhonen},
+  title     = {Automatic semantic classification of scientific literature
+               according to the hallmarks of cancer},
+  journal   = {Bioinform.},
+  volume    = {32},
+  number    = {3},
+  pages     = {432--440},
+  year      = {2016},
+  url       = {https://doi.org/10.1093/bioinformatics/btv585},
+  doi       = {10.1093/bioinformatics/btv585},
+  timestamp = {Thu, 14 Oct 2021 08:57:44 +0200},
+  biburl    = {https://dblp.org/rec/journals/bioinformatics/BakerSGAHSK16.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+"""
+
+_DATASETNAME = "hallmarks_of_cancer"
+_DISPLAYNAME = "Hallmarks of Cancer"
+
+_DESCRIPTION = """\
+The Hallmarks of Cancer (HOC) Corpus consists of 1852 PubMed publication
+abstracts manually annotated by experts according to a taxonomy. The taxonomy
+consists of 37 classes in a hierarchy. Zero or more class labels are assigned
+to each sentence in the corpus. The labels are found under the "labels"
+directory, while the tokenized text can be found under "text" directory.
+The filenames are the corresponding PubMed IDs (PMID).
+"""
+
+_HOMEPAGE = "https://github.com/sb895/Hallmarks-of-Cancer"
+
+_LICENSE = 'GNU General Public License v3.0 only'
+
+_URLs = {
+    "corpus": "https://github.com/sb895/Hallmarks-of-Cancer/archive/refs/heads/master.zip",
+    "split_indices": "https://microsoft.github.io/BLURB/sample_code/data_generation.tar.gz",
+}
+
+_SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+_CLASS_NAMES = [
+    "evading growth suppressors",
+    "tumor promoting inflammation",
+    "enabling replicative immortality",
+    "cellular energetics",
+    "resisting cell death",
+    "activating invasion and metastasis",
+    "genomic instability and mutation",
+    "none",
+    "inducing angiogenesis",
+    "sustaining proliferative signaling",
+    "avoiding immune destruction",
+]
+
+
+class HallmarksOfCancerDataset(datasets.GeneratorBasedBuilder):
+    """Hallmarks Of Cancer Dataset"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="hallmarks_of_cancer_source",
+            version=SOURCE_VERSION,
+            description="Hallmarks of Cancer source schema",
+            schema="source",
+            subset_id="hallmarks_of_cancer",
+        ),
+        BigBioConfig(
+            name="hallmarks_of_cancer_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="Hallmarks of Cancer Biomedical schema",
+            schema="bigbio_text",
+            subset_id="hallmarks_of_cancer",
+        ),
+    ]
+    DEFAULT_CONFIG_NAME = "hallmarks_of_cancer_source"
+
+    def _info(self):
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "label": [datasets.ClassLabel(names=_CLASS_NAMES)],
+                }
+            )
+
+        elif self.config.schema == "bigbio_text":
+            features = text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            supervised_keys=None,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+        data_dir = dl_manager.download_and_extract(_URLs)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "corpuspath": Path(data_dir["corpus"]),
+                    "indicespath": Path(data_dir["split_indices"])
+                    / "data_generation/indexing/HoC/train_pmid.tsv",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "corpuspath": Path(data_dir["corpus"]),
+                    "indicespath": Path(data_dir["split_indices"])
+                    / "data_generation/indexing/HoC/test_pmid.tsv",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "corpuspath": Path(data_dir["corpus"]),
+                    "indicespath": Path(data_dir["split_indices"])
+                    / "data_generation/indexing/HoC/dev_pmid.tsv",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, corpuspath: Path, indicespath: Path):
+
+        indices = indicespath.read_text(encoding="utf8").strip("\n").split(",")
+        dataset_dir = corpuspath / "Hallmarks-of-Cancer-master"
+        texts_dir = dataset_dir / "text"
+        labels_dir = dataset_dir / "labels"
+
+        uid = 1
+        for document_index, document in enumerate(indices):
+            text_file = texts_dir / document
+            label_file = labels_dir / document
+            text = text_file.read_text(encoding="utf8").strip("\n")
+            labels = label_file.read_text(encoding="utf8").strip("\n")
+
+            sentences = text.split("\n")
+            labels = labels.split("<")[1:]
+
+            for example_index, example_pair in enumerate(zip(sentences, labels)):
+                sentence, label = example_pair
+
+                label = label.strip()
+
+                if label == "":
+                    label = "none"
+
+                multi_labels = [m_label.strip() for m_label in label.split("AND")]
+                unique_multi_labels = {
+                    m_label.split("--")[0].lower().lstrip()
+                    for m_label in multi_labels
+                    if m_label != "NULL"
+                }
+
+                arrow_file_unique_key = 100 * document_index + example_index
+                if self.config.schema == "source":
+                    yield arrow_file_unique_key, {
+                        "document_id": f"{text_file.name.split('.')[0]}_{example_index}",
+                        "text": sentence,
+                        "label": list(unique_multi_labels),
+                    }
+                elif self.config.schema == "bigbio_text":
+                    yield arrow_file_unique_key, {
+                        "id": uid,
+                        "document_id": f"{text_file.name.split('.')[0]}_{example_index}",
+                        "text": sentence,
+                        "labels": list(unique_multi_labels),
+                    }
+                    uid += 1

--- a/hub/hubscripts/hprd50_hub.py
+++ b/hub/hubscripts/hprd50_hub.py
@@ -1,0 +1,332 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+HPRD50 is a dataset of randomly selected, hand-annotated abstracts of biomedical papers
+referenced by the Human Protein Reference Database (HPRD). It is parsed in XML format,
+splitting each abstract into sentences, and in each sentence there may be entities and
+interactions between those entities. In this particular dataset, entities are all
+proteins and interactions are thus protein-protein interactions.
+
+Moreover, all entities are normalized to the HPRD database. These normalized terms are
+stored in each entity's 'type' attribute in the source XML. This means the dataset can
+determine e.g. that "Janus kinase 2" and "Jak2" are referencing the same normalized
+entity.
+
+Because the dataset contains entities and relations, it is suitable for Named Entity
+Recognition and Relation Extraction.
+"""
+
+import os
+from glob import glob
+from typing import Dict, List, Tuple
+from xml.etree import ElementTree
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+# TODO: Add BibTeX citation
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{fundel2007relex,
+  title={RelEx—Relation extraction using dependency parse trees},
+  author={Fundel, Katrin and K{\"u}ffner, Robert and Zimmer, Ralf},
+  journal={Bioinformatics},
+  volume={23},
+  number={3},
+  pages={365--371},
+  year={2007},
+  publisher={Oxford University Press}
+}
+"""
+
+_DATASETNAME = "hprd50"
+_DISPLAYNAME = "HPRD50"
+
+_DESCRIPTION = """\
+HPRD50 is a dataset of randomly selected, hand-annotated abstracts of biomedical papers
+referenced by the Human Protein Reference Database (HPRD). It is parsed in XML format,
+splitting each abstract into sentences, and in each sentence there may be entities and
+interactions between those entities. In this particular dataset, entities are all
+proteins and interactions are thus protein-protein interactions.
+
+Moreover, all entities are normalized to the HPRD database. These normalized terms are
+stored in each entity's 'type' attribute in the source XML. This means the dataset can
+determine e.g. that "Janus kinase 2" and "Jak2" are referencing the same normalized
+entity.
+
+Because the dataset contains entities and relations, it is suitable for Named Entity
+Recognition and Relation Extraction.
+"""
+
+_HOMEPAGE = ""
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: "https://github.com/metalrt/ppi-dataset/zipball/master",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.RELATION_EXTRACTION,
+    Tasks.NAMED_ENTITY_RECOGNITION,
+]  # example: [Tasks.TRANSLATION, Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+def parse_xml_source(document_trees):
+    entries = []
+    for doc in document_trees:
+        document = {
+            "id": doc.get("id"),
+            "origId": doc.get("origId"),
+            "set": doc.get("test"),
+            "sentences": [],
+        }
+        for s in doc.findall("sentence"):
+            sentence = {
+                "id": s.get("id"),
+                "origId": s.get("origId"),
+                "charOffset": s.get("charOffset"),
+                "text": s.get("text"),
+                "entities": [],
+                "interactions": [],
+            }
+
+            for e in s.findall("entity"):
+                entity = {
+                    "id": e.get("id"),
+                    "origId": e.get("origId"),
+                    "charOffset": e.get("charOffset"),
+                    "text": e.get("text"),
+                    "type": e.get("type"),
+                }
+
+                sentence["entities"].append(entity)
+
+            for i in s.findall("interaction"):
+                interaction = {
+                    "id": i.get("id"),
+                    "e1": i.get("e1"),
+                    "e2": i.get("e2"),
+                    "type": i.get("type"),
+                }
+                sentence["interactions"].append(interaction)
+
+            document["sentences"].append(sentence)
+
+        entries.append(document)
+    return entries
+
+
+def parse_xml_bigbio_kb(document_trees):
+    entries = []
+    for doc in document_trees:
+        document = {
+            "id": doc.get("id"),
+            "document_id": doc.get("origId"),
+            "passages": [],
+            "entities": [],
+            "relations": [],
+            "events": [],
+            "coreferences": [],
+        }
+        for s in doc.findall("sentence"):
+
+            offset = s.get("charOffset").split("-")
+            start = int(offset[0])
+            end = int(offset[1])
+
+            passage = {
+                "id": s.get("id"),
+                "type": "sentence",
+                "text": [s.get("text")],
+                "offsets": [[start, end]],
+            }
+
+            document["passages"].append(passage)
+
+            for e in s.findall("entity"):
+
+                offset = e.get("charOffset").split("-")
+                start = int(offset[0])
+                end = int(offset[1])
+
+                entity = {
+                    "id": e.get("id"),
+                    "text": [e.get("text")],
+                    "offsets": [[start, end]],
+                    "type": "protein",
+                    "normalized": [{"db_name": "HPRD", "db_id": e.get("type")}],
+                }
+
+                document["entities"].append(entity)
+
+            for i in s.findall("interaction"):
+                relation = {
+                    "id": i.get("id"),
+                    "arg1_id": i.get("e1"),
+                    "arg2_id": i.get("e2"),
+                    "type": i.get("type"),
+                    "normalized": [],
+                }
+                document["relations"].append(relation)
+
+        entries.append(document)
+    return entries
+
+
+class HPRD50Dataset(datasets.GeneratorBasedBuilder):
+    """
+    HPRD50 is a dataset of randomly selected, hand-annotated abstracts of biomedical papers
+    referenced by the Human Protein Reference Database (HPRD). It is parsed in XML format,
+    splitting each abstract into sentences, and in each sentence there may be entities and
+    interactions between those entities. In this particular dataset, entities are all
+    proteins and interactions are thus protein-protein interactions.
+
+    Moreover, all entities are normalized to the HPRD database. These normalized terms are
+    stored in each entity's 'type' attribute in the source XML. This means the dataset can
+    determine e.g. that "Janus kinase 2" and "Jak2" are referencing the same normalized
+    entity.
+
+    Because the dataset contains entities and relations, it is suitable for Named Entity
+    Recognition and Relation Extraction.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="hprd50_source",
+            version=SOURCE_VERSION,
+            description="hprd50 source schema",
+            schema="source",
+            subset_id="hprd50",
+        ),
+        BigBioConfig(
+            name="hprd50_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="hprd50 BigBio schema",
+            schema="bigbio_kb",
+            subset_id="hprd50",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "hprd50_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "origId": datasets.Value("string"),
+                    "set": datasets.Value("string"),
+                    "sentences": [
+                        {
+                            "id": datasets.Value("string"),
+                            "origId": datasets.Value("string"),
+                            "charOffset": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                            "entities": [
+                                {
+                                    "id": datasets.Value("string"),
+                                    "origId": datasets.Value("string"),
+                                    "charOffset": datasets.Value("string"),
+                                    "text": datasets.Value("string"),
+                                    "type": datasets.Value("string"),
+                                }
+                            ],
+                            "interactions": [
+                                {
+                                    "id": datasets.Value("string"),
+                                    "e1": datasets.Value("string"),
+                                    "e2": datasets.Value("string"),
+                                    "type": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+        # Files are actually a few levels down, under this subdirectory, and
+        # intermediate directory names get hashed so this is the easiest way to find it.
+        data_dir = glob(f"{data_dir}/**/csv_output")[0]
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "HPRD50-train.xml"),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "HPRD50-test.xml"),
+                    "split": "test",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        with open(filepath, "r") as f:
+            content = f.read()
+
+        tree = ElementTree.fromstring(content)
+        documents = tree.findall("document")
+
+        if self.config.schema == "source":
+            entries = parse_xml_source(documents)
+            for key, example in enumerate(entries):
+                yield key, example
+
+        elif self.config.schema == "bigbio_kb":
+            entries = parse_xml_bigbio_kb(documents)
+            for key, example in enumerate(entries):
+                yield key, example
+
+
+# This template is based on the following template from the datasets package:
+# https://github.com/huggingface/datasets/blob/master/templates/new_dataset_script.py

--- a/hub/hubscripts/iepa_hub.py
+++ b/hub/hubscripts/iepa_hub.py
@@ -1,0 +1,287 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The IEPA benchmark PPI corpus is designed for relation extraction. It was
+created from 303 PubMed abstracts, each of which contains a specific pair of
+co-occurring chemicals.
+"""
+
+# Comment from Author
+# BigBio schema fixes offsets of entities to an offset where 0 is the start of the document.
+# (In source offsets of entities start from 0 for each passage in document)
+# Offsets of entities in source remain unchanged.
+
+import xml.dom.minidom as xml
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@ARTICLE{ding2001mining,
+  title    = "Mining {MEDLINE}: abstracts, sentences, or phrases?",
+  author   = "Ding, J and Berleant, D and Nettleton, D and Wurtele, E",
+  journal  = "Pac Symp Biocomput",
+  pages    = "326--337",
+  year     =  2002,
+  address  = "United States",
+  language = "en"
+}
+"""
+
+_DATASETNAME = "iepa"
+_DISPLAYNAME = "IEPA"
+
+_DESCRIPTION = """\
+The IEPA benchmark PPI corpus is designed for relation extraction. It was \
+created from 303 PubMed abstracts, each of which contains a specific pair of \
+co-occurring chemicals.
+"""
+
+_HOMEPAGE = "http://psb.stanford.edu/psb-online/proceedings/psb02/abstracts/p326.html"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: {
+        "train": "https://raw.githubusercontent.com/metalrt/ppi-dataset/master/csv_output/IEPA-train.xml",
+        "test": "https://raw.githubusercontent.com/metalrt/ppi-dataset/master/csv_output/IEPA-test.xml",
+    },
+}
+
+_SUPPORTED_TASKS = [Tasks.RELATION_EXTRACTION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class IepaDataset(datasets.GeneratorBasedBuilder):
+    """The IEPA benchmark PPI corpus is designed for relation extraction."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="iepa_source",
+            version=SOURCE_VERSION,
+            description="IEPA source schema",
+            schema="source",
+            subset_id="iepa",
+        ),
+        BigBioConfig(
+            name="iepa_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="IEPA BigBio schema",
+            schema="bigbio_kb",
+            subset_id="iepa",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "iepa_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "PMID": datasets.Value("string"),
+                    "origID": datasets.Value("string"),
+                    "sentences": [
+                        {
+                            "id": datasets.Value("string"),
+                            "origID": datasets.Value("string"),
+                            "offsets": [datasets.Value("int32")],
+                            "text": datasets.Value("string"),
+                            "entities": [
+                                {
+                                    "id": datasets.Value("string"),
+                                    "origID": datasets.Value("string"),
+                                    "text": datasets.Value("string"),
+                                    "offsets": [datasets.Value("int32")],
+                                }
+                            ],
+                            "interactions": [
+                                {
+                                    "id": datasets.Value("string"),
+                                    "e1": datasets.Value("string"),
+                                    "e2": datasets.Value("string"),
+                                    "type": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_dir["train"],
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": data_dir["test"],
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        collection = xml.parse(filepath).documentElement
+
+        if self.config.schema == "source":
+            for id, document in self._parse_documents(collection):
+                yield id, document
+
+        elif self.config.schema == "bigbio_kb":
+            for id, document in self._parse_documents(collection):
+                yield id, self._source_to_bigbio(document)
+
+    def _parse_documents(self, collection):
+        for document in collection.getElementsByTagName("document"):
+            pmid_doc = self._strict_get_attribute(document, "PMID")
+            id_doc = self._strict_get_attribute(document, "id")
+            origID_doc = self._strict_get_attribute(document, "origID")
+            sentences = []
+            for sentence in document.getElementsByTagName("sentence"):
+                offsets_sent = self._strict_get_attribute(sentence, "charOffset").split(
+                    "-"
+                )
+                id_sent = self._strict_get_attribute(sentence, "id")
+                origID_sent = self._strict_get_attribute(sentence, "origID")
+                text_sent = self._strict_get_attribute(sentence, "text")
+
+                entities = []
+                for entity in sentence.getElementsByTagName("entity"):
+                    id_ent = self._strict_get_attribute(entity, "id")
+                    origID_ent = self._strict_get_attribute(entity, "origID")
+                    text_ent = self._strict_get_attribute(entity, "text")
+                    offsets_ent = self._strict_get_attribute(
+                        entity, "charOffset"
+                    ).split("-")
+                    entities.append(
+                        {
+                            "id": id_ent,
+                            "origID": origID_ent,
+                            "text": text_ent,
+                            "offsets": offsets_ent,
+                        }
+                    )
+
+                interactions = []
+                for interaction in sentence.getElementsByTagName("interaction"):
+                    id_int = self._strict_get_attribute(interaction, "id")
+                    e1_int = self._strict_get_attribute(interaction, "e1")
+                    e2_int = self._strict_get_attribute(interaction, "e2")
+                    type_int = self._strict_get_attribute(interaction, "type")
+                    interactions.append(
+                        {"id": id_int, "e1": e1_int, "e2": e2_int, "type": type_int}
+                    )
+
+                sentences.append(
+                    {
+                        "id": id_sent,
+                        "origID": origID_sent,
+                        "offsets": offsets_sent,
+                        "text": text_sent,
+                        "entities": entities,
+                        "interactions": interactions,
+                    }
+                )
+            yield id_doc, {
+                "id": id_doc,
+                "PMID": pmid_doc,
+                "origID": origID_doc,
+                "sentences": sentences,
+            }
+
+    def _strict_get_attribute(self, element, key):
+        if element.hasAttribute(key):
+            return element.getAttribute(key)
+        else:
+            raise ValueError(f"No such key exists in element: {element.tagName} {key}")
+
+    def _source_to_bigbio(self, document_):
+        document = {}
+        document["id"] = document_["id"]
+        document["document_id"] = document_["PMID"]
+
+        passages = []
+        entities = []
+        relations = []
+        for sentence_ in document_["sentences"]:
+            for entity_ in sentence_["entities"]:
+                entity_["type"] = ""
+                entity_["normalized"] = []
+                entity_.pop("origID")
+                entity_["text"] = [entity_["text"]]
+                entity_["offsets"] = [
+                    [
+                        int(sentence_["offsets"][0]) + int(entity_["offsets"][0]),
+                        int(sentence_["offsets"][0]) + int(entity_["offsets"][1]),
+                    ]
+                ]
+                entities.append(entity_)
+            for relation_ in sentence_["interactions"]:
+                relation_["arg1_id"] = relation_.pop("e1")
+                relation_["arg2_id"] = relation_.pop("e2")
+                relation_["normalized"] = []
+                relations.append(relation_)
+
+            sentence_.pop("entities")
+            sentence_.pop("interactions")
+            sentence_.pop("origID")
+            sentence_["type"] = ""
+            sentence_["text"] = [sentence_["text"]]
+            sentence_["offsets"] = [sentence_["offsets"]]
+            passages.append(sentence_)
+
+        document["passages"] = passages
+        document["entities"] = entities
+        document["relations"] = relations
+        document["events"] = []
+        document["coreferences"] = []
+        return document

--- a/hub/hubscripts/jnlpba_hub.py
+++ b/hub/hubscripts/jnlpba_hub.py
@@ -1,0 +1,181 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The data came from the GENIA version 3.02 corpus (Kim et al., 2003).
+This was formed from a controlled search on MEDLINE using the MeSH terms human, blood cells and transcription factors.
+From this search 2,000 abstracts were selected and hand annotated according to a small taxonomy of 48 classes based on
+a chemical classification. Among the classes, 36 terminal classes were used to annotate the GENIA corpus.
+"""
+
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+
+# TODO: Add BibTeX citation
+_CITATION = """\
+@inproceedings{collier-kim-2004-introduction,
+title = "Introduction to the Bio-entity Recognition Task at {JNLPBA}",
+author = "Collier, Nigel and Kim, Jin-Dong",
+booktitle = "Proceedings of the International Joint Workshop
+on Natural Language Processing in Biomedicine and its Applications
+({NLPBA}/{B}io{NLP})",
+month = aug # " 28th and 29th", year = "2004",
+address = "Geneva, Switzerland",
+publisher = "COLING",
+url = "https://aclanthology.org/W04-1213",
+pages = "73--78",
+}
+"""
+
+_DATASETNAME = "jnlpba"
+_DISPLAYNAME = "JNLPBA"
+
+_DESCRIPTION = """\
+NER For Bio-Entities
+"""
+
+_HOMEPAGE = "http://www.geniaproject.org/shared-tasks/bionlp-jnlpba-shared-task-2004"
+
+_LICENSE = 'Creative Commons Attribution 3.0 Unported'
+
+_URLS = {
+    _DATASETNAME: "http://www.nactem.ac.uk/GENIA/current/Shared-tasks/JNLPBA/Train/Genia4ERtraining.tar.gz",
+}
+
+# TODO: add supported task by dataset. One dataset may support multiple tasks
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION
+]  # example: [Tasks.TRANSLATION, Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
+
+# TODO: set this to a version that is associated with the dataset. if none exists use "1.0.0"
+#  This version doesn't have to be consistent with semantic versioning. Anything that is
+#  provided by the original dataset as a version goes.
+_SOURCE_VERSION = "3.2.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class JNLPBADataset(datasets.GeneratorBasedBuilder):
+    """
+    The data came from the GENIA version 3.02 corpus
+    (Kim et al., 2003).
+    This was formed from a controlled search on MEDLINE
+    using the MeSH terms human, blood cells and transcription factors.
+    From this search 2,000 abstracts were selected and hand annotated
+    according to a small taxonomy of 48 classes based on
+    a chemical classification.
+    Among the classes, 36 terminal classes were used to annotate the GENIA corpus.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="jnlpba_source",
+            version=SOURCE_VERSION,
+            description="jnlpba source schema",
+            schema="source",
+            subset_id="jnlpba",
+        ),
+        BigBioConfig(
+            name="jnlpba_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="jnlpba BigBio schema",
+            schema="bigbio_kb",
+            subset_id="jnlpba",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "jnlpba_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.load_dataset("jnlpba", split="train").features
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        data = datasets.load_dataset("jnlpba")
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={"data": data["train"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"data": data["validation"]},
+            ),
+        ]
+
+    def _generate_examples(self, data: datasets.Dataset) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        uid = 0
+
+        if self.config.schema == "source":
+            for key, sample in enumerate(data):
+                yield key, sample
+
+        elif self.config.schema == "bigbio_kb":
+            for i, sample in enumerate(data):
+                feature_dict = {
+                    "id": uid,
+                    "document_id": "NULL",
+                    "passages": [],
+                    "entities": [],
+                    "relations": [],
+                    "events": [],
+                    "coreferences": [],
+                }
+
+                uid += 1
+                offset_start = 0
+                for token, tag in zip(sample["tokens"], sample["ner_tags"]):
+                    offset_start += len(token) + 1
+                    feature_dict["entities"].append(
+                        {
+                            "id": uid,
+                            "offsets": [[offset_start, offset_start + len(token)]],
+                            "text": [token],
+                            "type": tag,
+                            "normalized": [],
+                        }
+                    )
+                    uid += 1
+
+                # entities
+                yield i, feature_dict

--- a/hub/hubscripts/linnaeus_hub.py
+++ b/hub/hubscripts/linnaeus_hub.py
@@ -1,0 +1,271 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+LINNAEUS provides a novel corpus of full-text documents manually annotated for species mentions.
+
+To understand the true performance of the LINNAEUS system, we generated a gold standard dataset specifically
+annotated to evaluate species name identification software. The reliability of this gold standard is high,
+however some species names are likely to be omitted from this evaluation set, as shown by IAA analysis.
+Performance of species tagging by LINNAEUS on full-text articles is very good, with 94.3% recall and
+97.1% precision on mention level, and 98.1% recall and 90.4% precision on document level.
+"""
+
+import csv
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@Article{gerner2010linnaeus,
+title={LINNAEUS: a species name identification system for biomedical literature},
+author={Gerner, Martin and Nenadic, Goran and Bergman, Casey M},
+journal={BMC bioinformatics},
+volume={11},
+number={1},
+pages={1--17},
+year={2010},
+publisher={BioMed Central}
+}
+"""
+
+_DATASETNAME = "linnaeus"
+_DISPLAYNAME = "LINNAEUS"
+
+_DESCRIPTION = """\
+Linnaeus is a novel corpus of full-text documents manually annotated for species mentions.
+"""
+
+_HOMEPAGE = "http://linnaeus.sourceforge.net/"
+
+_LICENSE = 'Creative Commons Attribution 4.0 International'
+
+_URLS = {
+    _DATASETNAME: "https://sourceforge.net/projects/linnaeus/files/Corpora/manual-corpus-species-1.0.tar.gz/download",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class LinnaeusDataset(datasets.GeneratorBasedBuilder):
+    """Linneaus provides a new gold-standard corpus of full-text articles
+    with manually annotated mentions of species names."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="linnaeus_source",
+            version=SOURCE_VERSION,
+            description="Linnaeus source schema",
+            schema="source",
+            subset_id="linnaeus",
+        ),
+        BigBioConfig(
+            name="linnaeus_filtered_source",
+            version=SOURCE_VERSION,
+            description="Linnaeus source schema (filtered tags)",
+            schema="source",
+            subset_id="linnaeus_filtered",
+        ),
+        BigBioConfig(
+            name="linnaeus_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="Linnaeus BigBio schema",
+            schema="bigbio_kb",
+            subset_id="linnaeus",
+        ),
+        BigBioConfig(
+            name="linnaeus_filtered_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="Linnaeus BigBio schema (filtered tags)",
+            schema="bigbio_kb",
+            subset_id="linnaeus_filtered",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "linneaus_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "document_type": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "entities": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "normalized": [
+                                {
+                                    "db_name": datasets.Value("string"),
+                                    "db_id": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "data_files": os.path.join(data_dir, "manual-corpus-species-1.0")
+                },
+            ),
+        ]
+
+    def _generate_examples(self, data_files: Path) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        data_path = Path(os.path.join(data_files, "txt"))
+        if self.config.subset_id.endswith("filtered"):
+            tags_path = Path(os.path.join(data_files, "filtered_tags.tsv"))
+        else:
+            tags_path = Path(os.path.join(data_files, "tags.tsv"))
+        data_files = list(data_path.glob("*txt"))
+        tags = self._load_tags(tags_path)
+
+        if self.config.schema == "source":
+            for guid, data_file in enumerate(data_files):
+                document_key = data_file.stem
+                if document_key not in tags:
+                    continue
+                example = self._create_source_example(data_file, tags.get(document_key))
+                example["document_id"] = str(document_key)
+                yield guid, example
+
+        elif self.config.schema == "bigbio_kb":
+            for guid, data_file in enumerate(data_files):
+                document_key = data_file.stem
+                if document_key not in tags:
+                    continue
+                example = self._create_kb_example(data_file, tags.get(document_key))
+                example["document_id"] = str(document_key)
+                example["id"] = guid
+                yield guid, example
+
+    @staticmethod
+    def _load_tags(path: Path) -> Dict:
+        """Loads all tags into a dictionary with document ID as keys and all annotations to that file as values."""
+        tags = {}
+        document_id_col = 1
+
+        with open(path, encoding="utf-8") as csv_file:
+            reader = csv.reader(csv_file, delimiter="\t")
+            next(reader)
+            for line in reader:
+                document_id = line[document_id_col]
+                line.pop(document_id_col)
+                if document_id not in tags:
+                    tags[document_id] = [line]
+                else:
+                    tags[document_id].append(line)
+        return tags
+
+    def _create_source_example(self, txt_file, tags) -> Dict:
+        """Creates example in source schema."""
+        example = {}
+        example["entities"] = []
+        with open(txt_file, "r") as file:
+            text = file.read()
+        example["text"] = text
+        example["document_type"] = "Article"
+        for tag_id, tag in enumerate(tags):
+            species_id, start, end, entity_text, _ = tag
+            entity_type, db_name, db_id = species_id.split(":")
+            entity = {
+                "id": str(tag_id),
+                "type": entity_type,
+                "text": [entity_text],
+                "offsets": [(int(start), int(end))],
+                "normalized": [
+                    {
+                        "db_name": db_name,
+                        "db_id": db_id,
+                    }
+                ],
+            }
+            example["entities"].append(entity)
+        return example
+
+    def _create_kb_example(self, txt_file, tags) -> Dict:
+        """Creates example in BigBio KB schema."""
+        example = {}
+        with open(txt_file, "r") as file:
+            text = file.read()
+        # Passages
+        example["passages"] = [
+            {
+                "id": f"{txt_file.stem}__text",
+                "text": [text],
+                "type": "Article",
+                "offsets": [(0, len(text))],
+            }
+        ]
+        # Entities
+        example["entities"] = []
+        for tag_id, tag in enumerate(tags):
+            species_id, start, end, entity_text, _ = tag
+            entity_type, db_name, db_id = species_id.split(":")
+            entity = {
+                "id": f"{txt_file.stem}__T{str(tag_id)}",
+                "type": entity_type,
+                "text": [entity_text],
+                "offsets": [(int(start), int(end))],
+                "normalized": [
+                    {
+                        "db_name": db_name,
+                        "db_id": db_id,
+                    }
+                ],
+            }
+            example["entities"].append(entity)
+        example["events"] = []
+        example["relations"] = []
+        example["coreferences"] = []
+        return example

--- a/hub/hubscripts/lll_hub.py
+++ b/hub/hubscripts/lll_hub.py
@@ -1,0 +1,328 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and Simon Ott, github: nomisto
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The LLL05 challenge task is to learn rules to extract protein/gene interactions from biology abstracts from the Medline
+bibliography database. The goal of the challenge is to test the ability of the participating IE systems to identify the
+interactions and the gene/proteins that interact. The participants will test their IE patterns on a test set with the
+aim of extracting the correct agent and target.The challenge focuses on information extraction of gene interactions in
+Bacillus subtilis. Extracting gene interaction is the most popular event IE task in biology. Bacillus subtilis (Bs) is
+a model bacterium and many papers have been published on direct gene interactions involved in sporulation. The gene
+interactions are generally mentioned in the abstract and the full text of the paper is not needed. Extracting gene
+interaction means, extracting the agent (proteins) and the target (genes) of all couples of genic interactions from
+sentences.
+"""
+
+# NOTE:
+# word stop offsets are increased by one to be consistent with python slicing.
+# test set does not include entity relation information
+
+import itertools as it
+from typing import List
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+    @article{article,
+    author = {Nédellec, C.},
+    year = {2005},
+    month = {01},
+    pages = {},
+    title = {Learning Language in Logic - Genic Interaction Extraction Challenge},
+    journal = {Proceedings of the Learning Language in Logic 2005 Workshop at the \
+        International Conference on Machine Learning}
+}
+"""
+
+_DATASETNAME = "lll"
+_DISPLAYNAME = "LLL05"
+
+_DESCRIPTION = """\
+The LLL05 challenge task is to learn rules to extract protein/gene interactions from biology abstracts from the Medline
+bibliography database. The goal of the challenge is to test the ability of the participating IE systems to identify the
+interactions and the gene/proteins that interact. The participants will test their IE patterns on a test set with the
+aim of extracting the correct agent and target.The challenge focuses on information extraction of gene interactions in
+Bacillus subtilis. Extracting gene interaction is the most popular event IE task in biology. Bacillus subtilis (Bs) is
+a model bacterium and many papers have been published on direct gene interactions involved in sporulation. The gene
+interactions are generally mentioned in the abstract and the full text of the paper is not needed. Extracting gene
+interaction means, extracting the agent (proteins) and the target (genes) of all couples of genic interactions from
+sentences.
+"""
+
+_HOMEPAGE = "http://genome.jouy.inra.fr/texte/LLLchallenge"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: [
+        "http://genome.jouy.inra.fr/texte/LLLchallenge/data/LLLChalenge05/data/train/task2/genic_interaction_linguistic_data.txt",  # noqa
+        "http://genome.jouy.inra.fr/texte/LLLchallenge/data/LLLChalenge05/data/train/task2/genic_interaction_linguistic_data_coref.txt",  # noqa
+        "http://genome.jouy.inra.fr/texte/LLLchallenge/data/LLLChalenge05/data/test/task2/enriched_test_data.txt",  # noqa
+    ]
+}
+
+_SUPPORTED_TASKS = [Tasks.RELATION_EXTRACTION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class LLLDataset(datasets.GeneratorBasedBuilder):
+    """LLL dataset for gene interaction extraction (RE)"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="lll_source",
+            version=SOURCE_VERSION,
+            description="LLL source schema",
+            schema="source",
+            subset_id="lll",
+        ),
+        BigBioConfig(
+            name="lll_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="LLL BigBio schema",
+            schema="bigbio_kb",
+            subset_id="lll",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "lll_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "sentence": datasets.Value("string"),
+                    "words": [
+                        {
+                            "id": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                            "offsets": datasets.Sequence(datasets.Value("int32")),
+                        }
+                    ],
+                    "genic_interactions": [
+                        {
+                            "ref_id1": datasets.Value("string"),
+                            "ref_id2": datasets.Value("string"),
+                        }
+                    ],
+                    "agents": [
+                        {
+                            "ref_id": datasets.Value("string"),
+                        }
+                    ],
+                    "targets": [
+                        {
+                            "ref_id": datasets.Value("string"),
+                        }
+                    ],
+                    "lemmas": [
+                        {
+                            "ref_id": datasets.Value("string"),
+                            "lemma": datasets.Value("string"),
+                        }
+                    ],
+                    "syntactic_relations": [
+                        {
+                            "type": datasets.Value("string"),
+                            "ref_id1": datasets.Value("string"),
+                            "ref_id2": datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+
+        urls = _URLS[_DATASETNAME]
+        train_path, train_coref_path, test_path = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "data_paths": [train_path, train_coref_path],
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"data_paths": [test_path], "split": "test"},
+            ),
+        ]
+
+    def _generate_examples(self, data_paths, split):
+
+        if self.config.schema == "source":
+            for path in data_paths:
+                with open(path, encoding="utf8") as documents:
+                    for document in self._generate_parsed_documents(documents, split):
+                        yield document["id"], document
+
+        elif self.config.schema == "bigbio_kb":
+            uid = it.count(0)
+            for path in data_paths:
+                with open(path, encoding="utf8") as documents:
+                    for document in self._generate_parsed_documents(documents, split):
+                        document_ = {}
+                        document_["id"] = next(uid)
+                        document_["document_id"] = document["id"]
+
+                        document_["passages"] = [
+                            {
+                                "id": next(uid),
+                                "type": BigBioValues.NULL,
+                                "text": [document["sentence"]],
+                                "offsets": [[0, len(document["sentence"])]],
+                            }
+                        ]
+
+                        id_to_word = {i["id"]: i for i in document["words"]}
+                        document_["entities"] = []
+                        for agent in document["agents"]:
+                            word = id_to_word[agent["ref_id"]]
+                            document_["entities"].append(
+                                {
+                                    "id": f"{document_['id']}-agent-{word['id']}",
+                                    "type": "agent",
+                                    "text": [word["text"]],
+                                    "offsets": [
+                                        [word["offsets"][0], word["offsets"][1]]
+                                    ],
+                                    "normalized": [],
+                                }
+                            )
+                        for agent in document["targets"]:
+                            word = id_to_word[agent["ref_id"]]
+                            document_["entities"].append(
+                                {
+                                    "id": f"{document_['id']}-target-{word['id']}",
+                                    "type": "target",
+                                    "text": [word["text"]],
+                                    "offsets": [
+                                        [word["offsets"][0], word["offsets"][1]]
+                                    ],
+                                    "normalized": [],
+                                }
+                            )
+
+                        document_["relations"] = [
+                            {
+                                "id": next(uid),
+                                "type": "genic_interaction",
+                                "arg1_id": f"{document_['id']}-agent-{relation['ref_id1']}",
+                                "arg2_id": f"{document_['id']}-target-{relation['ref_id2']}",
+                                "normalized": [],
+                            }
+                            for relation in document["genic_interactions"]
+                        ]
+
+                        document_["events"] = []
+                        document_["coreferences"] = []
+                        yield document_["document_id"], document_
+
+    def _generate_parsed_documents(self, fstream, split):
+        for raw_document in self._generate_raw_documents(fstream):
+            yield self._parse_document(raw_document, split)
+
+    def _generate_raw_documents(self, fstream):
+        raw_document = []
+        for line in fstream:
+            if "%" in line:
+                continue
+            elif line.strip():
+                raw_document.append(line.strip())
+            elif raw_document:
+                if raw_document:
+                    yield raw_document
+                raw_document = []
+        # needed for last document
+        if raw_document:
+            yield raw_document
+
+    def _parse_document(self, raw_document, split):
+        document = {}
+        for line in raw_document:
+            key, value = line.split("\t", 1)
+            if key in ["ID", "sentence"]:
+                document[key.lower()] = value
+            elif key in [
+                "words",
+                "genic_interactions",
+                "agents",
+                "targets",
+                "lemmas",
+                "syntactic_relations",
+            ]:
+                document[key.lower()] = self._parse_elements(value, key)
+            else:
+                raise NotImplementedError()
+
+        # Needed as testset does not contain agents, targets and genic_interactions (dataset was part of a challenge)
+        if split == "test":
+            document.setdefault("genic_interactions", [])
+            document.setdefault("agents", [])
+            document.setdefault("targets", [])
+
+        return document
+
+    def _parse_elements(self, values, type):
+        return [self._parse_element(atom, type) for atom in values.split("\t")]
+
+    def _parse_element(self, atom, type):
+        # Sorry for that abomination, parses the arguments from atoms like rel(arg1, ..., argn)
+        args = atom.split("(", 1)[1][:-1].split(",")
+        if type == "words":
+            # fix offsets for python slicing
+            return {
+                "id": args[0],
+                "text": args[1].strip("'"),
+                "offsets": [int(args[2]), int(args[3]) + 1],
+            }
+        elif type == "genic_interactions":
+            return {"ref_id1": args[0], "ref_id2": args[1]}
+        elif type == "agents":
+            return {"ref_id": args[0]}
+        elif type == "targets":
+            return {"ref_id": args[0]}
+        elif type == "lemmas":
+            return {"ref_id": args[0], "lemma": args[1].strip("'")}
+        elif type == "syntactic_relations":
+            return {"type": args[0].strip("'"), "ref_id1": args[1], "ref_id2": args[2]}

--- a/hub/hubscripts/mayosrs_hub.py
+++ b/hub/hubscripts/mayosrs_hub.py
@@ -1,0 +1,162 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+MayoSRS consists of 101 clinical term pairs whose relatedness was determined by
+nine medical coders and three physicians from the Mayo Clinic.
+"""
+
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import pairs_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@article{pedersen2007measures,
+  title={Measures of semantic similarity and relatedness in the biomedical domain},
+  author={Pedersen, Ted and Pakhomov, Serguei VS and Patwardhan, Siddharth and Chute, Christopher G},
+  journal={Journal of biomedical informatics},
+  volume={40},
+  number={3},
+  pages={288--299},
+  year={2007},
+  publisher={Elsevier}
+}
+"""
+
+_DATASETNAME = "mayosrs"
+_DISPLAYNAME = "MayoSRS"
+
+_DESCRIPTION = """\
+MayoSRS consists of 101 clinical term pairs whose relatedness was determined by \
+nine medical coders and three physicians from the Mayo Clinic.
+"""
+
+_HOMEPAGE = "https://conservancy.umn.edu/handle/11299/196265"
+
+_LICENSE = 'Creative Commons Zero v1.0 Universal'
+
+_URLS = {
+    _DATASETNAME: "https://conservancy.umn.edu/bitstream/handle/11299/196265/MayoSRS.csv?sequence=1&isAllowed=y"
+}
+
+_SUPPORTED_TASKS = [Tasks.SEMANTIC_SIMILARITY]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class MayosrsDataset(datasets.GeneratorBasedBuilder):
+    """MayoSRS consists of 101 clinical term pairs whose relatedness was
+    determined by nine medical coders and three physicians from the Mayo Clinic."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="mayosrs_source",
+            version=SOURCE_VERSION,
+            description="MayoSRS source schema",
+            schema="source",
+            subset_id="mayosrs",
+        ),
+        BigBioConfig(
+            name="mayosrs_bigbio_pairs",
+            version=BIGBIO_VERSION,
+            description="MayoSRS BigBio schema",
+            schema="bigbio_pairs",
+            subset_id="mayosrs",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "mayosrs_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "text_1": datasets.Value("string"),
+                    "text_2": datasets.Value("string"),
+                    "label": datasets.Value("float32"),
+                    "code_1": datasets.Value("string"),
+                    "code_2": datasets.Value("string"),
+                }
+            )
+
+        elif self.config.schema == "bigbio_pairs":
+            features = pairs_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[_DATASETNAME]
+        filepath = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": filepath,
+                    "split": "train",
+                },
+            )
+        ]
+
+    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        if split == "train":
+
+            data = pd.read_csv(
+                filepath,
+                sep=",",
+                header=0,
+                names=["label", "code_1", "code_2", "text_1", "text_2"],
+            )
+
+            if self.config.schema == "source":
+                for id_, row in data.iterrows():
+                    yield id_, row.to_dict()
+
+            elif self.config.schema == "bigbio_pairs":
+                for id_, row in data.iterrows():
+                    yield id_, {
+                        "id": id_,  # uid is an unique identifier for every record that starts from 1
+                        "document_id": id_,
+                        "text_1": row["text_1"],
+                        "text_2": row["text_2"],
+                        "label": str(row["label"]),
+                    }
+
+        else:
+            print("There's no test/val split available for the given dataset")
+            return

--- a/hub/hubscripts/med_qa_hub.py
+++ b/hub/hubscripts/med_qa_hub.py
@@ -1,0 +1,230 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+In this work, we present the first free-form multiple-choice OpenQA dataset for solving medical problems, MedQA,
+collected from the professional medical board exams. It covers three languages: English, simplified Chinese, and
+traditional Chinese, and contains 12,723, 34,251, and 14,123 questions for the three languages, respectively. Together
+with the question data, we also collect and release a large-scale corpus from medical textbooks from which the reading
+comprehension models can obtain necessary knowledge for answering the questions.
+"""
+
+import os
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import qa_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+
+# TODO: Add BibTeX citation
+_CITATION = """\
+@article{jin2021disease,
+  title={What disease does this patient have? a large-scale open domain question answering dataset from medical exams},
+  author={Jin, Di and Pan, Eileen and Oufattole, Nassim and Weng, Wei-Hung and Fang, Hanyi and Szolovits, Peter},
+  journal={Applied Sciences},
+  volume={11},
+  number={14},
+  pages={6421},
+  year={2021},
+  publisher={MDPI}
+}
+"""
+
+_DATASETNAME = "med_qa"
+_DISPLAYNAME = "MedQA"
+
+_DESCRIPTION = """\
+In this work, we present the first free-form multiple-choice OpenQA dataset for solving medical problems, MedQA,
+collected from the professional medical board exams. It covers three languages: English, simplified Chinese, and
+traditional Chinese, and contains 12,723, 34,251, and 14,123 questions for the three languages, respectively. Together
+with the question data, we also collect and release a large-scale corpus from medical textbooks from which the reading
+comprehension models can obtain necessary knowledge for answering the questions.
+"""
+
+_HOMEPAGE = "https://github.com/jind11/MedQA"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: "https://drive.google.com/u/0/uc?export=download&confirm=t&id=1ImYUSLk9JbgHXOemfvyiDiirluZHPeQw",
+}
+
+_SUPPORTED_TASKS = [Tasks.QUESTION_ANSWERING]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+_SUBSET2NAME = {
+    "en": "English",
+    "zh": "Chinese (Simplified)",
+    "tw": "Chinese (Traditional, Taiwan)",
+    "tw_en": "Chinese (Traditional, Taiwan) translated to English",
+    "tw_zh": "Chinese (Traditional, Taiwan) translated to Chinese (Simplified)",
+}
+
+
+class MedQADataset(datasets.GeneratorBasedBuilder):
+    """Free-form multiple-choice OpenQA dataset covering three languages."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = []
+
+    for subset in ["en", "zh", "tw", "tw_en", "tw_zh"]:
+        BUILDER_CONFIGS.append(
+            BigBioConfig(
+                name=f"med_qa_{subset}_source",
+                version=SOURCE_VERSION,
+                description=f"MedQA {_SUBSET2NAME.get(subset)} source schema",
+                schema="source",
+                subset_id=f"med_qa_{subset}",
+            )
+        )
+        BUILDER_CONFIGS.append(
+            BigBioConfig(
+                name=f"med_qa_{subset}_bigbio_qa",
+                version=BIGBIO_VERSION,
+                description=f"MedQA {_SUBSET2NAME.get(subset)} BigBio schema",
+                schema="bigbio_qa",
+                subset_id=f"med_qa_{subset}",
+            )
+        )
+
+    DEFAULT_CONFIG_NAME = "med_qa_en_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "meta_info": datasets.Value("string"),
+                    "question": datasets.Value("string"),
+                    "answer_idx": datasets.Value("string"),
+                    "answer": datasets.Value("string"),
+                    "options": [
+                        {
+                            "key": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+        elif self.config.schema == "bigbio_qa":
+            features = qa_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+        lang_dict = {"en": "US", "zh": "Mainland", "tw": "Taiwan"}
+        base_dir = os.path.join(data_dir, "data_clean", "questions")
+        if self.config.subset_id in ["med_qa_en", "med_qa_zh", "med_qa_tw"]:
+            lang_path = lang_dict.get(self.config.subset_id.rsplit("_", 1)[1])
+            paths = {
+                "train": os.path.join(base_dir, lang_path, "train.jsonl"),
+                "test": os.path.join(base_dir, lang_path, "test.jsonl"),
+                "valid": os.path.join(base_dir, lang_path, "dev.jsonl"),
+            }
+        elif self.config.subset_id == "med_qa_tw_en":
+            paths = {
+                "train": os.path.join(
+                    base_dir, "Taiwan", "tw_translated_jsonl", "en", "train-2en.jsonl"
+                ),
+                "test": os.path.join(
+                    base_dir, "Taiwan", "tw_translated_jsonl", "en", "test-2en.jsonl"
+                ),
+                "valid": os.path.join(
+                    base_dir, "Taiwan", "tw_translated_jsonl", "en", "dev-2en.jsonl"
+                ),
+            }
+        elif self.config.subset_id == "med_qa_tw_zh":
+            paths = {
+                "train": os.path.join(
+                    base_dir, "Taiwan", "tw_translated_jsonl", "zh", "train-2zh.jsonl"
+                ),
+                "test": os.path.join(
+                    base_dir, "Taiwan", "tw_translated_jsonl", "zh", "test-2zh.jsonl"
+                ),
+                "valid": os.path.join(
+                    base_dir, "Taiwan", "tw_translated_jsonl", "zh", "dev-2zh.jsonl"
+                ),
+            }
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": paths["train"],
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": paths["test"],
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": paths["valid"],
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        print(filepath)
+        data = pd.read_json(filepath, lines=True)
+
+        if self.config.schema == "source":
+            for key, example in data.iterrows():
+                example = example.to_dict()
+                example["options"] = [
+                    {"key": key, "value": value}
+                    for key, value in example["options"].items()
+                ]
+                yield key, example
+
+        elif self.config.schema == "bigbio_qa":
+            for key, example in data.iterrows():
+                example = example.to_dict()
+                example_ = {}
+                example_["id"] = key
+                example_["question_id"] = key
+                example_["document_id"] = key
+                example_["question"] = example["question"]
+                example_["type"] = "multiple_choice"
+                example_["choices"] = [value for value in example["options"].values()]
+                example_["context"] = ""
+                example_["answer"] = [example["answer"]]
+                yield key, example_

--- a/hub/hubscripts/meddialog_hub.py
+++ b/hub/hubscripts/meddialog_hub.py
@@ -1,0 +1,222 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import re
+
+import datasets
+
+from .bigbiohub import text_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "meddialog"
+_DISPLAYNAME = "MedDialog"
+
+_LANGUAGES = ['English', 'Chinese']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """
+@article{DBLP:journals/corr/abs-2004-03329,
+  author    = {Shu Chen and
+               Zeqian Ju and
+               Xiangyu Dong and
+               Hongchao Fang and
+               Sicheng Wang and
+               Yue Yang and
+               Jiaqi Zeng and
+               Ruisi Zhang and
+               Ruoyu Zhang and
+               Meng Zhou and
+               Penghui Zhu and
+               Pengtao Xie},
+  title     = {MedDialog: {A} Large-scale Medical Dialogue Dataset},
+  journal   = {CoRR},
+  volume    = {abs/2004.03329},
+  year      = {2020},
+  url       = {https://arxiv.org/abs/2004.03329},
+  eprinttype = {arXiv},
+  eprint    = {2004.03329},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-2004-03329.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+"""
+
+_DESCRIPTION = """
+The MedDialog dataset (English) contains conversations (in English) between doctors and patients.\
+It has 0.26 million dialogues. The data is continuously growing and more dialogues will be added. \
+The raw dialogues are from healthcaremagic.com and icliniq.com.\
+
+All copyrights of the data belong to healthcaremagic.com and icliniq.com.
+"""
+
+_HOMEPAGE = "https://github.com/UCSD-AI4H/Medical-Dialogue-System"
+
+_LICENSE = 'License information unavailable'
+
+_URLs = {
+    "en": {
+        "train": "https://drive.google.com/file/d/1ria4E6IdTIPsikL4Glm3uy1tFKJKw0W8/view?usp=sharing",
+        "validation": "https://drive.google.com/file/d/1KAZneuwdfEVQQM6euCX4pMDP-9DQpiB5/view?usp=sharing",
+        "test": "https://drive.google.com/file/d/10izqL71kcgnteYsf87Vh6j_mZ8sZM2Rc/view?usp=sharing",
+    },
+    "zh": {
+        "train": "https://drive.google.com/file/d/1AaDJoHaiHAwEZwtskRH8oL1UP4FRgmgx/view?usp=sharing",
+        "validation": "https://drive.google.com/file/d/1TvfZCmQqP1kURIfEinOcj5VOPelTuGwI/view?usp=sharing",
+        "test": "https://drive.google.com/file/d/1pmmG95Yl6mMXRXDDSRb9-bYTxOE7ank5/view?usp=sharing",
+    },
+}
+
+_SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class MedDialog(datasets.GeneratorBasedBuilder):
+    """MedDialog: Large-scale Medical Dialogue Datasets in English and Chinese."""
+
+    DEFAULT_CONFIG_NAME = "meddialog_en_source"
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        # Source schemas
+        BigBioConfig(
+            name="meddialog_en_source",
+            version=SOURCE_VERSION,
+            description="MedDialog source schema",
+            schema="source",
+            subset_id="meddialog_en",
+        ),
+        BigBioConfig(
+            name="meddialog_zh_source",
+            version=SOURCE_VERSION,
+            description="MedDialog source schema",
+            schema="source",
+            subset_id="meddialog_zh",
+        ),
+        # BigBio schema: text classification
+        BigBioConfig(
+            name="meddialog_en_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="MedDialog simplified BigBio schema",
+            schema="bigbio_text",
+            subset_id="meddialog_en",
+        ),
+        BigBioConfig(
+            name="meddialog_zh_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="MedDialog simplified BigBio schema",
+            schema="bigbio_text",
+            subset_id="meddialog_zh",
+        ),
+    ]
+
+    def _get_gdrive_url(self, url):
+        """Converts URL from google drive shareable link to format used by dl_manager."""
+        fileid = re.match("https://drive\.google\.com/file/d/(.+)/view\?", url).group(1)
+        return f"https://drive.google.com/uc?id={fileid}"
+
+    def _info(self):
+        lang = self.config.name.split("_")[1]
+        if self.config.schema == "source":
+            if lang == "en":
+                features = datasets.Features(
+                    {
+                        "description": datasets.Value("string"),
+                        "utterances": datasets.Sequence(
+                            {
+                                "speaker": datasets.ClassLabel(
+                                    names=["patient", "doctor"]
+                                ),
+                                "utterance": datasets.Value("string"),
+                            }
+                        ),
+                    }
+                )
+            elif lang == "zh":
+                features = datasets.Features(
+                    {
+                        "utterances": datasets.Sequence(
+                            {
+                                "speaker": datasets.ClassLabel(names=["病人", "医生"]),
+                                "utterance": datasets.Value("string"),
+                            }
+                        ),
+                    }
+                )
+        elif self.config.schema == "bigbio_text":
+            features = text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            supervised_keys=None,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        lang = self.config.name.split("_")[1]
+        my_urls = {
+            split: self._get_gdrive_url(url) for split, url in _URLs[lang].items()
+        }
+        dl_dir = dl_manager.download_and_extract(my_urls)
+        return [
+            datasets.SplitGenerator(
+                name=split,
+                gen_kwargs={"filepath": dl_dir[split], "split": split, "lang": lang},
+            )
+            for split in _URLs[lang]
+        ]
+
+    def _generate_examples(self, filepath, split, lang):
+        with open(filepath, "r") as f:
+            data = json.load(f)
+
+        # delimiter symbol differs by language
+        delimiter = "：" if lang == "zh" else ":"
+        document_id = f"{lang}_{split}"
+
+        for i, d in enumerate(data):
+            out_utterances = []
+            utterances = d["utterances"] if lang == "en" else d
+            for j, utt in enumerate(utterances):
+                elements = utt.strip().split(delimiter)
+                speaker = elements[0]
+                text = delimiter.join(elements[1:]).strip()
+                if self.config.schema == "bigbio_text":
+                    # TODO - this ignores description
+                    id = f"{document_id}_{i}_{j}"
+                    yield id, {
+                        "id": id,
+                        "document_id": document_id,
+                        "text": text,
+                        "labels": [speaker],
+                    }
+                else:
+                    out_utterances.append({"speaker": speaker, "utterance": text})
+            if self.config.schema == "source":
+                id = f"{document_id}_{i}"
+                if lang == "en":
+                    yield id, {
+                        "description": d["description"],
+                        "utterances": out_utterances,
+                    }
+                else:
+                    yield id, {
+                        "utterances": out_utterances,
+                    }

--- a/hub/hubscripts/meddocan_hub.py
+++ b/hub/hubscripts/meddocan_hub.py
@@ -1,0 +1,249 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A dataset loading script for the MEDDOCAN corpus.
+The MEDDOCAN datset is a manually annotated collection of clinical case
+reports derived from the Spanish Clinical Case Corpus (SPACCC). It was designed
+for the Medical Document Anonymization Track, the first the first community
+challenge task specifically devoted to the anonymization of medical documents in Spanish
+"""
+
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['Spanish']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@inproceedings{marimon2019automatic,
+  title={Automatic De-identification of Medical Texts in Spanish: the MEDDOCAN Track, Corpus, Guidelines, Methods and Evaluation of Results.},
+  author={Marimon, Montserrat and Gonzalez-Agirre, Aitor and Intxaurrondo, Ander and Rodriguez, Heidy and Martin, Jose Lopez and Villegas, Marta and Krallinger, Martin},
+  booktitle={IberLEF@ SEPLN},
+  pages={618--638},
+  year={2019}
+}
+"""
+
+_DATASETNAME = "meddocan"
+_DISPLAYNAME = "MEDDOCAN"
+
+_DESCRIPTION = """\
+MEDDOCAN: Medical Document Anonymization Track
+
+This dataset is designed for the MEDDOCAN task, sponsored by Plan de Impulso de las Tecnologías del Lenguaje.
+
+It is a manually classified collection of 1,000 clinical case reports derived from the \
+Spanish Clinical Case Corpus (SPACCC), enriched with PHI expressions.
+
+The annotation of the entire set of entity mentions was carried out by experts annotators\
+and it includes 29 entity types relevant for the annonymiation of medical documents.\
+22 of these annotation types are actually present in the corpus: TERRITORIO, FECHAS, \
+EDAD_SUJETO_ASISTENCIA, NOMBRE_SUJETO_ASISTENCIA, NOMBRE_PERSONAL_SANITARIO, \
+SEXO_SUJETO_ASISTENCIA, CALLE, PAIS, ID_SUJETO_ASISTENCIA, CORREO, ID_TITULACION_PERSONAL_SANITARIO,\
+ID_ASEGURAMIENTO, HOSPITAL, FAMILIARES_SUJETO_ASISTENCIA, INSTITUCION, ID_CONTACTO ASISTENCIAL,\
+NUMERO_TELEFONO, PROFESION, NUMERO_FAX, OTROS_SUJETO_ASISTENCIA, CENTRO_SALUD, ID_EMPLEO_PERSONAL_SANITARIO
+    
+For further information, please visit https://temu.bsc.es/meddocan/ or send an email to encargo-pln-life@bsc.es
+"""
+
+
+_HOMEPAGE = "https://temu.bsc.es/meddocan/"
+
+_LICENSE = 'Creative Commons Attribution 4.0 International'
+
+_URLS = {
+    "meddocan": "https://zenodo.org/record/4279323/files/meddocan.zip?download=1",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class MeddocanDataset(datasets.GeneratorBasedBuilder):
+    """Manually annotated collection of clinical case studies from Spanish medical publications."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="meddocan_source",
+            version=SOURCE_VERSION,
+            description="Meddocan source schema",
+            schema="source",
+            subset_id="meddocan",
+        ),
+        BigBioConfig(
+            name="meddocan_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="Meddocan BigBio schema",
+            schema="bigbio_kb",
+            subset_id="meddocan",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "meddocan_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    # "labels": [datasets.Value("string")],
+                    "text_bound_annotations": [  # T line in brat
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "trigger": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arguments": datasets.Sequence(
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "attributes": [  # M or A lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value("string"),
+                            "cuid": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                        }
+                    ],
+                },
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """
+        Downloads/extracts the data to generate the train, validation and test splits.
+        Each split is created by instantiating a `datasets.SplitGenerator`, which will
+        call `this._generate_examples` with the keyword arguments in `gen_kwargs`.
+        """
+
+        data_dir = dl_manager.download_and_extract(_URLS["meddocan"])
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": Path(os.path.join(data_dir, "meddocan/train/brat")),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": Path(os.path.join(data_dir, "meddocan/test/brat")),
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": Path(os.path.join(data_dir, "meddocan/dev/brat")),
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+        """
+        This method handles input defined in _split_generators to yield (key, example) tuples from the dataset.
+        Method parameters are unpacked from `gen_kwargs` as given in `_split_generators`.
+        """
+
+        txt_files = sorted(list(filepath.glob("*txt")))
+        # tsv_files = sorted(list(filepaths[1].glob("*tsv")))
+
+        if self.config.schema == "source":
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.parse_brat_file(txt_file)
+
+                example["id"] = str(guid)
+                yield guid, example
+
+        elif self.config.schema == "bigbio_kb":
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.brat_parse_to_bigbio_kb(
+                    parsing.parse_brat_file(txt_file)
+                )
+                example["id"] = str(guid)
+                yield guid, example
+
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/hub/hubscripts/medhop_hub.py
+++ b/hub/hubscripts/medhop_hub.py
@@ -1,0 +1,212 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+
+import datasets
+
+from .bigbiohub import qa_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{welbl-etal-2018-constructing,
+title = Constructing Datasets for Multi-hop Reading Comprehension Across Documents,
+author = Welbl, Johannes and Stenetorp, Pontus and Riedel, Sebastian,
+journal = Transactions of the Association for Computational Linguistics,
+volume = 6,
+year = 2018,
+address = Cambridge, MA,
+publisher = MIT Press,
+url = https://aclanthology.org/Q18-1021,
+doi = 10.1162/tacl_a_00021,
+pages = 287--302,
+abstract = {
+    Most Reading Comprehension methods limit themselves to queries which
+    can be answered using a single sentence, paragraph, or document.
+    Enabling models to combine disjoint pieces of textual evidence would
+    extend the scope of machine comprehension methods, but currently no
+    resources exist to train and test this capability. We propose a novel
+    task to encourage the development of models for text understanding
+    across multiple documents and to investigate the limits of existing
+    methods. In our task, a model learns to seek and combine evidence
+    -- effectively performing multihop, alias multi-step, inference.
+    We devise a methodology to produce datasets for this task, given a
+    collection of query-answer pairs and thematically linked documents.
+    Two datasets from different domains are induced, and we identify
+    potential pitfalls and devise circumvention strategies. We evaluate
+    two previously proposed competitive models and find that one can
+    integrate information across documents. However, both models
+    struggle to select relevant information; and providing documents
+    guaranteed to be relevant greatly improves their performance. While
+    the models outperform several strong baselines, their best accuracy
+    reaches 54.5 % on an annotated test set, compared to human
+    performance at 85.0 %, leaving ample room for improvement.
+}
+"""
+
+_DESCRIPTION = """\
+With the same format as WikiHop, this dataset is based on research paper
+abstracts from PubMed, and the queries are about interactions between
+pairs of drugs. The correct answer has to be inferred by combining
+information from a chain of reactions of drugs and proteins.
+"""
+
+_DATASETNAME = "medhop"
+_DISPLAYNAME = "MedHop"
+
+_HOMEPAGE = "http://qangaroo.cs.ucl.ac.uk/"
+
+_LICENSE = 'Creative Commons Attribution Share Alike 3.0 Unported'
+
+_BASE_GDRIVE = "https://drive.google.com/uc?export=download&confirm=yTib&id="
+
+_URLs = {
+    "source": _BASE_GDRIVE + "1ytVZ4AhubFDOEL7o7XrIRIyhU8g9wvKA",
+    "bigbio_qa": _BASE_GDRIVE + "1ytVZ4AhubFDOEL7o7XrIRIyhU8g9wvKA",
+}
+
+_SUPPORTED_TASKS = [Tasks.QUESTION_ANSWERING]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class MedHopDataset(datasets.GeneratorBasedBuilder):
+    """MedHop"""
+
+    DEFAULT_CONFIG_NAME = "medhop_source"
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="medhop_source",
+            version=SOURCE_VERSION,
+            description="MedHop source schema",
+            schema="source",
+            subset_id="MedHop",
+        ),
+        BigBioConfig(
+            name="medhop_bigbio_qa",
+            version=BIGBIO_VERSION,
+            description="MedHop BigBio schema",
+            schema="bigbio_qa",
+            subset_id="MedHop",
+        ),
+    ]
+
+    def _info(self):
+
+        if self.config.schema == "source":
+
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "candidates": datasets.Sequence(datasets.Value("string")),
+                    "answer": datasets.Value("string"),
+                    "supports": datasets.Sequence(datasets.Value("string")),
+                    "query": datasets.Value("string"),
+                }
+            )
+
+        # simplified schema for QA tasks
+        elif self.config.schema == "bigbio_qa":
+
+            features = qa_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            supervised_keys=None,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+
+        my_urls = _URLs[self.config.schema]
+        data_dir = dl_manager.download_and_extract(my_urls)
+        data_dir += "/qangaroo_v1.1/medhop/"
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "train.json"),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "dev.json"),
+                    "split": "validation",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split):
+        """Yields examples as (key, example) tuples."""
+
+        if self.config.schema == "source":
+
+            with open(filepath, encoding="utf-8") as file:
+
+                uid = 0
+
+                data = json.load(file)
+
+                for i, record in enumerate(data):
+
+                    yield i, {
+                        "id": record["id"],
+                        "candidates": record["candidates"],
+                        "answer": record["answer"],
+                        "supports": record["supports"],
+                        "query": record["query"],
+                    }
+
+                    uid += 1
+
+        elif self.config.schema == "bigbio_qa":
+
+            with open(filepath, encoding="utf-8") as file:
+
+                uid = 0
+
+                data = json.load(file)
+
+                for record in data:
+
+                    record["type"] = "multiple_choice"
+
+                    yield uid, {
+                        "id": record["id"],
+                        "document_id": record["id"],
+                        "question_id": record["id"],
+                        "question": record["query"],
+                        "type": record["type"],
+                        "context": " ".join(record["supports"]),
+                        "answer": [record["answer"]],
+                        "choices": record["candidates"],
+                    }
+
+                    uid += 1

--- a/hub/hubscripts/medical_data_hub.py
+++ b/hub/hubscripts/medical_data_hub.py
@@ -1,0 +1,179 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import entailment_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = True
+_CITATION = """\
+@misc{ask9medicaldata,
+  author    = {Khan, Arbaaz},
+  title     = {Sentiment Analysis for Medical Drugs},
+  year      = {2019},
+  url       = {https://www.kaggle.com/datasets/arbazkhan971/analyticvidhyadatasetsentiment},
+}
+"""
+
+_DATASETNAME = "medical_data"
+_DISPLAYNAME = "Medical Data"
+
+_DESCRIPTION = """\
+    This dataset is designed to do multiclass classification on medical drugs
+"""
+
+_HOMEPAGE = ""
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {}
+
+_SUPPORTED_TASKS = [Tasks.TEXTUAL_ENTAILMENT]
+
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class MedicaldataDatatset(datasets.GeneratorBasedBuilder):
+    """This dataset contains comments about patients and the sentiment in those comments about a specific drug that's mentioned.
+    1 - Negative sentiment
+    2 - Positive sentiment
+    0 - Neutral"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name=f"{_DATASETNAME}_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=f"{_DATASETNAME}",
+        ),
+        BigBioConfig(
+            name=f"{_DATASETNAME}_bigbio_te",
+            version=BIGBIO_VERSION,
+            description=f"{_DATASETNAME} BigBio schema",
+            schema="bigbio_te",
+            subset_id=f"{_DATASETNAME}",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = f"{_DATASETNAME}_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+
+            features = datasets.Features(
+                {
+                    "hash": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "drug_name": datasets.Value("string"),
+                    "sentiment": datasets.Value("string"),
+                }
+            )
+
+        elif self.config.schema == "bigbio_te":
+            features = entailment_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
+        else:
+            data_dir = self.config.data_dir
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "train_F3WbcTw.csv"),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "test_tOlRoBf.csv"),
+                    "split": "test",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        if self.config.schema == "source":
+            csv_reader = pd.read_csv(filepath, dtype="object")
+            # Train and test splits handled differently as test split is missing values
+            if split == "train":
+                for _cols, line in csv_reader.iterrows():
+                    document = {}
+                    document["hash"] = line["unique_hash"]
+                    document["text"] = line["text"]
+                    document["drug_name"] = line["drug"]
+                    document["sentiment"] = line["sentiment"]
+                    yield document["hash"], document
+            else:
+                for _cols, line in csv_reader.iterrows():
+                    document = {}
+                    document["hash"] = line["unique_hash"]
+                    document["text"] = line["text"]
+                    document["drug_name"] = line["drug"]
+                    document["sentiment"] = None
+                    yield document["hash"], document
+
+        elif self.config.schema == "bigbio_te":
+            csv_reader = pd.read_csv(filepath, dtype="object")
+            # Train and test splits handled differently as test split is missing values
+            if split == "train":
+                for _cols, line in csv_reader.iterrows():
+                    document = {}
+                    document["id"] = line["unique_hash"]
+                    document["premise"] = line["text"]
+                    document["hypothesis"] = line["drug"]
+                    document["label"] = line["sentiment"]
+                    yield document["id"], document
+            else:
+                for _cols, line in csv_reader.iterrows():
+                    document = {}
+                    document["id"] = line["unique_hash"]
+                    document["premise"] = line["text"]
+                    document["hypothesis"] = line["drug"]
+                    document["label"] = None
+                    yield document["id"], document

--- a/hub/hubscripts/mediqa_nli_hub.py
+++ b/hub/hubscripts/mediqa_nli_hub.py
@@ -1,0 +1,200 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Natural Language Inference (NLI) is the task of determining whether a given hypothesis can be
+inferred from a given premise. Also known as Recognizing Textual Entailment (RTE), this task has
+enjoyed popularity among researchers for some time. However, almost all datasets for this task
+focused on open domain data such as as news texts, blogs, and so on. To address this gap, the MedNLI
+dataset was created for language inference in the medical domain. MedNLI is a derived dataset with
+data sourced from MIMIC-III v1.4. In order to stimulate research for this problem, a shared task on
+Medical Inference and Question Answering (MEDIQA) was organized at the workshop for biomedical
+natural language processing (BioNLP) 2019. The dataset provided herein is a test set of 405 premise
+hypothesis pairs for the NLI challenge in the MEDIQA shared task. Participants of the shared task
+are expected to use the MedNLI data for development of their models and this dataset was used as an
+unseen dataset for scoring each participant submission.
+
+The files comprising this dataset must be on the users local machine in a single directory that is
+passed to `datasets.load_datset` via the `data_dir` kwarg. This loader script will read the archive
+files directly (i.e. the user should not uncompress, untar or unzip any of the files). For example,
+if `data_dir` is `"mediqa_nli"` it should contain the following files:
+
+mediqa_nli
+├── mednli-for-shared-task-at-acl-bionlp-2019-1.0.1.zip
+"""
+
+import json
+import os
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import entailment_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = True
+_CITATION = """\
+@misc{https://doi.org/10.13026/gtv4-g455,
+    title        = {MedNLI for Shared Task at ACL BioNLP 2019},
+    author       = {Shivade,  Chaitanya},
+    year         = 2019,
+    publisher    = {physionet.org},
+    doi          = {10.13026/GTV4-G455},
+    url          = {https://physionet.org/content/mednli-bionlp19/}
+}
+
+"""
+
+_DATASETNAME = "mediqa_nli"
+_DISPLAYNAME = "MEDIQA NLI"
+
+_DESCRIPTION = """\
+Natural Language Inference (NLI) is the task of determining whether a given hypothesis can be
+inferred from a given premise. Also known as Recognizing Textual Entailment (RTE), this task has
+enjoyed popularity among researchers for some time. However, almost all datasets for this task
+focused on open domain data such as as news texts, blogs, and so on. To address this gap, the MedNLI
+dataset was created for language inference in the medical domain. MedNLI is a derived dataset with
+data sourced from MIMIC-III v1.4. In order to stimulate research for this problem, a shared task on
+Medical Inference and Question Answering (MEDIQA) was organized at the workshop for biomedical
+natural language processing (BioNLP) 2019. The dataset provided herein is a test set of 405 premise
+hypothesis pairs for the NLI challenge in the MEDIQA shared task. Participants of the shared task
+are expected to use the MedNLI data for development of their models and this dataset was used as an
+unseen dataset for scoring each participant submission.
+"""
+
+
+_HOMEPAGE = "https://physionet.org/content/mednli-bionlp19/1.0.1/"
+
+_LICENSE = 'PhysioNet Credentialed Health Data License'
+
+_URLS = {}
+
+_SUPPORTED_TASKS = [Tasks.TEXTUAL_ENTAILMENT]
+
+_SOURCE_VERSION = "1.0.1"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class MEDIQANLIDataset(datasets.GeneratorBasedBuilder):
+    """MEDIQA NLI"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="mediqa_nli_source",
+            version=SOURCE_VERSION,
+            description="MEDIQA NLI source schema",
+            schema="source",
+            subset_id="mediqa_nli",
+        ),
+        BigBioConfig(
+            name="mediqa_nli_bigbio_te",
+            version=BIGBIO_VERSION,
+            description="MEDIQA NLI BigBio schema",
+            schema="bigbio_te",
+            subset_id="mediqa_nli",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "mediqa_nli_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "pairID": datasets.Value("string"),
+                    "gold_label": datasets.Value("string"),
+                    "sentence1": datasets.Value("string"),
+                    "sentence2": datasets.Value("string"),
+                    "sentence1_parse": datasets.Value("string"),
+                    "sentence2_parse": datasets.Value("string"),
+                    "sentence1_binary_parse": datasets.Value("string"),
+                    "sentence2_binary_parse": datasets.Value("string"),
+                }
+            )
+
+        elif self.config.schema == "bigbio_te":
+            features = entailment_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
+        else:
+            extract_dir = dl_manager.extract(
+                os.path.join(
+                    self.config.data_dir,
+                    "mednli-for-shared-task-at-acl-bionlp-2019-1.0.1.zip",
+                )
+            )
+            data_dir = os.path.join(
+                extract_dir, "mednli-for-shared-task-at-acl-bionlp-2019-1.0.1"
+            )
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "examples_filepath": os.path.join(
+                        data_dir, "mednli_bionlp19_shared_task.jsonl"
+                    ),
+                    "ground_truth_filepath": os.path.join(
+                        data_dir, "mednli_bionlp19_shared_task_ground_truth.csv"
+                    ),
+                    "split": "test",
+                },
+            ),
+        ]
+
+    def _generate_examples(
+        self, examples_filepath: str, ground_truth_filepath: str, split: str
+    ) -> Tuple[int, Dict]:
+
+        ground_truth = pd.read_csv(
+            ground_truth_filepath, index_col=0, squeeze=True
+        ).to_dict()
+        with open(examples_filepath, "r") as f:
+            if self.config.schema == "source":
+                for line in f:
+                    json_line = json.loads(line)
+                    json_line["gold_label"] = ground_truth[json_line["pairID"]]
+                    yield json_line["pairID"], json_line
+
+            elif self.config.schema == "bigbio_te":
+                for line in f:
+                    json_line = json.loads(line)
+                    entailment_example = {
+                        "id": json_line["pairID"],
+                        "premise": json_line["sentence1"],
+                        "hypothesis": json_line["sentence2"],
+                        "label": ground_truth[json_line["pairID"]],
+                    }
+                    yield json_line["pairID"], entailment_example

--- a/hub/hubscripts/mediqa_qa_hub.py
+++ b/hub/hubscripts/mediqa_qa_hub.py
@@ -1,0 +1,227 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import glob
+import json
+import os
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterator, Tuple
+
+import datasets
+
+from .bigbiohub import qa_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@inproceedings{MEDIQA2019,
+  author    = {Asma {Ben Abacha} and Chaitanya Shivade and Dina Demner{-}Fushman},
+  title     = {Overview of the MEDIQA 2019 Shared Task on Textual Inference, Question Entailment and Question Answering},
+  booktitle = {ACL-BioNLP 2019},
+  year      = {2019}
+}
+"""
+
+_DATASETNAME = "mediqa_qa"
+_DISPLAYNAME = "MEDIQA QA"
+
+_DESCRIPTION = """\
+The MEDIQA challenge is an ACL-BioNLP 2019 shared task aiming to attract further research efforts in Natural Language Inference (NLI), Recognizing Question Entailment (RQE), and their applications in medical Question Answering (QA).
+Mailing List: https://groups.google.com/forum/#!forum/bionlp-mediqa
+
+In the QA task, participants are tasked to:
+- filter/classify the provided answers (1: correct, 0: incorrect).
+- re-rank the answers.
+"""
+
+_HOMEPAGE = "https://sites.google.com/view/mediqa2019"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: "https://github.com/abachaa/MEDIQA2019/archive/refs/heads/master.zip"
+}
+
+_SUPPORTED_TASKS = [Tasks.QUESTION_ANSWERING]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class MediqaQADataset(datasets.GeneratorBasedBuilder):
+    """MediqaQA Dataset"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        # Source Schema
+        BigBioConfig(
+            name="mediqa_qa_source",
+            version=SOURCE_VERSION,
+            description="MEDIQA QA labeled source schema",
+            schema="source",
+            subset_id="mediqa_qa_source",
+        ),
+        # BigBio Schema
+        BigBioConfig(
+            name="mediqa_qa_bigbio_qa",
+            version=BIGBIO_VERSION,
+            description="MEDIQA QA BigBio schema",
+            schema="bigbio_qa",
+            subset_id="mediqa_qa_bigbio_qa",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "mediqa_qa_source"
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "QUESTION": {
+                        "QID": datasets.Value("string"),
+                        "QuestionText": datasets.Value("string"),
+                        "AnswerList": [
+                            {
+                                "Answer": {
+                                    "AID": datasets.Value("string"),
+                                    "SystemRank": datasets.Value("int32"),
+                                    "ReferenceRank": datasets.Value("int32"),
+                                    "ReferenceScore": datasets.Value("int32"),
+                                    "AnswerURL": datasets.Value("string"),
+                                    "AnswerText": datasets.Value("string"),
+                                }
+                            }
+                        ],
+                    }
+                }
+            )
+        elif self.config.schema == "bigbio_qa":
+            features = qa_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        data_dir = Path(dl_manager.download_and_extract(_URLS[_DATASETNAME]))
+
+        return [
+            datasets.SplitGenerator(
+                name=f"train_live_qa_med",
+                gen_kwargs={
+                    "filepath": data_dir
+                    / "MEDIQA2019-master/MEDIQA_Task3_QA/MEDIQA2019-Task3-QA-TrainingSet1-LiveQAMed.xml"
+                },
+            ),
+            datasets.SplitGenerator(
+                name=f"train_alexa",
+                gen_kwargs={
+                    "filepath": data_dir
+                    / "MEDIQA2019-master/MEDIQA_Task3_QA/MEDIQA2019-Task3-QA-TrainingSet2-Alexa.xml"
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": data_dir
+                    / "MEDIQA2019-master/MEDIQA_Task3_QA/MEDIQA2019-Task3-QA-ValidationSet.xml"
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": data_dir
+                    / "MEDIQA2019-master/MEDIQA_Task3_QA/MEDIQA2019-Task3-QA-TestSet-wLabels.xml"
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path) -> Iterator[Tuple[str, Dict]]:
+        dom = ET.parse(filepath).getroot()
+        for row in dom.iterfind("Question"):
+            qid = row.attrib["QID"]
+            question_text = row.find("QuestionText").text
+
+            answer_list = row.find("AnswerList")
+            aids, sys_ranks, ref_ranks, ref_scores, answer_urls, answer_texts = (
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+            )
+            for answer in answer_list.findall("Answer"):
+                aids.append(answer.attrib["AID"])
+                sys_ranks.append(int(answer.attrib["SystemRank"]))
+                ref_ranks.append(int(answer.attrib["ReferenceRank"]))
+                ref_scores.append(int(answer.attrib["ReferenceScore"]))
+                answer_urls.append(answer.find("AnswerURL").text)
+                answer_texts.append(answer.find("AnswerText").text)
+
+            if self.config.schema == "source":
+                yield qid, {
+                    "QUESTION": {
+                        "QID": qid,
+                        "QuestionText": question_text,
+                        "AnswerList": [
+                            {
+                                "Answer": {
+                                    "AID": aid,
+                                    "SystemRank": sys_rank,
+                                    "ReferenceRank": ref_rank,
+                                    "ReferenceScore": ref_score,
+                                    "AnswerURL": ans_url,
+                                    "AnswerText": ans_text,
+                                }
+                            }
+                            for (
+                                aid,
+                                sys_rank,
+                                ref_rank,
+                                ref_score,
+                                ans_url,
+                                ans_text,
+                            ) in zip(
+                                aids,
+                                sys_ranks,
+                                ref_ranks,
+                                ref_scores,
+                                answer_urls,
+                                answer_texts,
+                            )
+                        ],
+                    }
+                }
+            elif self.config.schema == "bigbio_qa":
+                yield qid, {
+                    "id": qid,
+                    "question_id": qid,
+                    "document_id": qid,
+                    "question": question_text,
+                    "type": "factoid",
+                    "choices": [],
+                    "context": "",
+                    "answer": answer_texts,
+                }

--- a/hub/hubscripts/mediqa_rqe_hub.py
+++ b/hub/hubscripts/mediqa_rqe_hub.py
@@ -1,0 +1,155 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import glob
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterator, Tuple
+from xml.etree import ElementTree as ET
+
+import datasets
+
+from .bigbiohub import pairs_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@inproceedings{MEDIQA2019,
+  author    = {Asma {Ben Abacha} and Chaitanya Shivade and Dina Demner{-}Fushman},
+  title     = {Overview of the MEDIQA 2019 Shared Task on Textual Inference, Question Entailment and Question Answering},
+  booktitle = {ACL-BioNLP 2019},
+  year      = {2019}
+}
+"""
+
+_DATASETNAME = "mediqa_rqe"
+_DISPLAYNAME = "MEDIQA RQE"
+
+_DESCRIPTION = """\
+The MEDIQA challenge is an ACL-BioNLP 2019 shared task aiming to attract further research efforts in Natural Language Inference (NLI), Recognizing Question Entailment (RQE), and their applications in medical Question Answering (QA).
+Mailing List: https://groups.google.com/forum/#!forum/bionlp-mediqa
+
+The objective of the RQE task is to identify entailment between two questions in the context of QA. We use the following definition of question entailment: “a question A entails a question B if every answer to B is also a complete or partial answer to A” [1]
+    [1] A. Ben Abacha & D. Demner-Fushman. “Recognizing Question Entailment for Medical Question Answering”. AMIA 2016.
+"""
+
+_HOMEPAGE = "https://sites.google.com/view/mediqa2019"
+_LICENSE = 'License information unavailable'
+_URLS = {
+    _DATASETNAME: "https://github.com/abachaa/MEDIQA2019/archive/refs/heads/master.zip"
+}
+
+_SUPPORTED_TASKS = [Tasks.TEXT_PAIRS_CLASSIFICATION]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class MediqaRQEDataset(datasets.GeneratorBasedBuilder):
+    """MediqaRQE Dataset"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        # Source Schema
+        BigBioConfig(
+            name="mediqa_rqe_source",
+            version=SOURCE_VERSION,
+            description="MEDIQA RQE source schema",
+            schema="source",
+            subset_id="mediqa_rqe_source",
+        ),
+        # BigBio Schema
+        BigBioConfig(
+            name="mediqa_rqe_bigbio_pairs",
+            version=BIGBIO_VERSION,
+            description="MEDIQA RQE BigBio schema",
+            schema="bigbio_pairs",
+            subset_id="mediqa_rqe_bigbio_pairs",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "mediqa_rqe_source"
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "pid": datasets.Value("string"),
+                    "value": datasets.Value("string"),
+                    "chq": datasets.Value("string"),
+                    "faq": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == "bigbio_pairs":
+            features = pairs_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        data_dir = Path(dl_manager.download_and_extract(_URLS[_DATASETNAME]))
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_dir
+                    / "MEDIQA2019-master/MEDIQA_Task2_RQE/MEDIQA2019-Task2-RQE-TrainingSet-AMIA2016.xml"
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": data_dir
+                    / "MEDIQA2019-master/MEDIQA_Task2_RQE/MEDIQA2019-Task2-RQE-ValidationSet-AMIA2016.xml"
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": data_dir
+                    / "MEDIQA2019-master/MEDIQA_Task2_RQE/MEDIQA2019-Task2-RQE-TestSet-wLabels.xml"
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path) -> Iterator[Tuple[str, Dict]]:
+        dom = ET.parse(filepath).getroot()
+        for row in dom.iterfind("pair"):
+            pid = row.attrib["pid"]
+            value = row.attrib["value"]
+            chq = row.find("chq").text.strip()
+            faq = row.find("faq").text.strip()
+
+            if self.config.schema == "source":
+                yield pid, {"pid": pid, "value": value, "chq": chq, "faq": faq}
+            elif self.config.schema == "bigbio_pairs":
+                yield pid, {
+                    "id": pid,
+                    "document_id": pid,
+                    "text_1": chq,
+                    "text_2": faq,
+                    "label": value,
+                }

--- a/hub/hubscripts/medmentions_hub.py
+++ b/hub/hubscripts/medmentions_hub.py
@@ -1,0 +1,307 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and Simon Ott, github: nomisto
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+MedMentions is a new manually annotated resource for the recognition of biomedical concepts.
+What distinguishes MedMentions from other annotated biomedical corpora is its size (over 4,000
+abstracts and over 350,000 linked mentions), as well as the size of the concept ontology (over
+3 million concepts from UMLS 2017) and its broad coverage of biomedical disciplines.
+
+Corpus: The MedMentions corpus consists of 4,392 papers (Titles and Abstracts) randomly selected
+from among papers released on PubMed in 2016, that were in the biomedical field, published in
+the English language, and had both a Title and an Abstract.
+
+Annotators: We recruited a team of professional annotators with rich experience in biomedical
+content curation to exhaustively annotate all UMLS® (2017AA full version) entity mentions in
+these papers.
+
+Annotation quality: We did not collect stringent IAA (Inter-annotator agreement) data. To gain
+insight on the annotation quality of MedMentions, we randomly selected eight papers from the
+annotated corpus, containing a total of 469 concepts. Two biologists ('Reviewer') who did not
+participate in the annotation task then each reviewed four papers. The agreement between
+Reviewers and Annotators, an estimate of the Precision of the annotations, was 97.3%.
+
+For more information visit: https://github.com/chanzuckerberg/MedMentions
+"""
+
+import itertools as it
+from typing import List
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@misc{mohan2019medmentions,
+      title={MedMentions: A Large Biomedical Corpus Annotated with UMLS Concepts},
+      author={Sunil Mohan and Donghui Li},
+      year={2019},
+      eprint={1902.09476},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}
+"""
+
+_DATASETNAME = "medmentions"
+_DISPLAYNAME = "MedMentions"
+
+_DESCRIPTION = """\
+MedMentions is a new manually annotated resource for the recognition of biomedical concepts.
+What distinguishes MedMentions from other annotated biomedical corpora is its size (over 4,000
+abstracts and over 350,000 linked mentions), as well as the size of the concept ontology (over
+3 million concepts from UMLS 2017) and its broad coverage of biomedical disciplines.
+
+Corpus: The MedMentions corpus consists of 4,392 papers (Titles and Abstracts) randomly selected
+from among papers released on PubMed in 2016, that were in the biomedical field, published in
+the English language, and had both a Title and an Abstract.
+
+Annotators: We recruited a team of professional annotators with rich experience in biomedical
+content curation to exhaustively annotate all UMLS® (2017AA full version) entity mentions in
+these papers.
+
+Annotation quality: We did not collect stringent IAA (Inter-annotator agreement) data. To gain
+insight on the annotation quality of MedMentions, we randomly selected eight papers from the
+annotated corpus, containing a total of 469 concepts. Two biologists ('Reviewer') who did not
+participate in the annotation task then each reviewed four papers. The agreement between
+Reviewers and Annotators, an estimate of the Precision of the annotations, was 97.3%.
+"""
+
+_HOMEPAGE = "https://github.com/chanzuckerberg/MedMentions"
+
+_LICENSE = 'Creative Commons Zero v1.0 Universal'
+
+_URLS = {
+    "medmentions_full": [
+        "https://github.com/chanzuckerberg/MedMentions/raw/master/full/data/corpus_pubtator.txt.gz",
+        "https://github.com/chanzuckerberg/MedMentions/raw/master/full/data/corpus_pubtator_pmids_trng.txt",
+        "https://github.com/chanzuckerberg/MedMentions/raw/master/full/data/corpus_pubtator_pmids_dev.txt",
+        "https://github.com/chanzuckerberg/MedMentions/raw/master/full/data/corpus_pubtator_pmids_test.txt",
+    ],
+    "medmentions_st21pv": [
+        "https://github.com/chanzuckerberg/MedMentions/raw/master/st21pv/data/corpus_pubtator.txt.gz",
+        "https://github.com/chanzuckerberg/MedMentions/raw/master/full/data/corpus_pubtator_pmids_trng.txt",
+        "https://github.com/chanzuckerberg/MedMentions/raw/master/full/data/corpus_pubtator_pmids_dev.txt",
+        "https://github.com/chanzuckerberg/MedMentions/raw/master/full/data/corpus_pubtator_pmids_test.txt",
+    ],
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_DISAMBIGUATION, Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class MedMentionsDataset(datasets.GeneratorBasedBuilder):
+    """MedMentions dataset for named-entity disambiguation (NED)"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="medmentions_full_source",
+            version=SOURCE_VERSION,
+            description="MedMentions Full source schema",
+            schema="source",
+            subset_id="medmentions_full",
+        ),
+        BigBioConfig(
+            name="medmentions_full_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="MedMentions Full BigBio schema",
+            schema="bigbio_kb",
+            subset_id="medmentions_full",
+        ),
+        BigBioConfig(
+            name="medmentions_st21pv_source",
+            version=SOURCE_VERSION,
+            description="MedMentions ST21pv source schema",
+            schema="source",
+            subset_id="medmentions_st21pv",
+        ),
+        BigBioConfig(
+            name="medmentions_st21pv_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="MedMentions ST21pv BigBio schema",
+            schema="bigbio_kb",
+            subset_id="medmentions_st21pv",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "medmentions_full_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "pmid": datasets.Value("string"),
+                    "passages": [
+                        {
+                            "type": datasets.Value("string"),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                        }
+                    ],
+                    "entities": [
+                        {
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "concept_id": datasets.Value("string"),
+                            "semantic_type_id": datasets.Sequence(
+                                datasets.Value("string")
+                            ),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+
+        urls = _URLS[self.config.subset_id]
+        (
+            corpus_path,
+            pmids_train,
+            pmids_dev,
+            pmids_test,
+        ) = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"corpus_path": corpus_path, "pmids_path": pmids_train},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"corpus_path": corpus_path, "pmids_path": pmids_test},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"corpus_path": corpus_path, "pmids_path": pmids_dev},
+            ),
+        ]
+
+    def _generate_examples(self, corpus_path, pmids_path):
+        with open(pmids_path, encoding="utf8") as infile:
+            pmids = infile.readlines()
+        pmids = {int(x.strip()) for x in pmids}
+
+        if self.config.schema == "source":
+            with open(corpus_path, encoding="utf8") as corpus:
+                for document in self._generate_parsed_documents(corpus, pmids):
+                    yield document["pmid"], document
+
+        elif self.config.schema == "bigbio_kb":
+            uid = it.count(0)
+            with open(corpus_path, encoding="utf8") as corpus:
+                for document in self._generate_parsed_documents(corpus, pmids):
+                    document["id"] = next(uid)
+                    document["document_id"] = document.pop("pmid")
+
+                    entities_ = []
+                    for entity in document["entities"]:
+                        for type in entity["semantic_type_id"]:
+                            entities_.append(
+                                {
+                                    "id": next(uid),
+                                    "type": type,
+                                    "text": entity["text"],
+                                    "offsets": entity["offsets"],
+                                    "normalized": [
+                                        {
+                                            "db_name": "UMLS",
+                                            "db_id": entity["concept_id"],
+                                        }
+                                    ],
+                                }
+                            )
+                    document["entities"] = entities_
+
+                    for passage in document["passages"]:
+                        passage["id"] = next(uid)
+                    document["relations"] = []
+                    document["events"] = []
+                    document["coreferences"] = []
+                    yield document["document_id"], document
+
+    def _generate_parsed_documents(self, fstream, pmids):
+        for raw_document in self._generate_raw_documents(fstream):
+            if self._parse_pmid(raw_document) in pmids:
+                yield self._parse_document(raw_document)
+
+    def _generate_raw_documents(self, fstream):
+        raw_document = []
+        for line in fstream:
+            if line.strip():
+                raw_document.append(line.strip())
+            elif raw_document:
+                yield raw_document
+                raw_document = []
+        # needed for last document
+        if raw_document:
+            yield raw_document
+
+    def _parse_pmid(self, raw_document):
+        pmid, _ = raw_document[0].split("|", 1)
+        return int(pmid)
+
+    def _parse_document(self, raw_document):
+        pmid, type, title = raw_document[0].split("|", 2)
+        pmid_, type, abstract = raw_document[1].split("|", 2)
+        passages = [
+            {"type": "title", "text": [title], "offsets": [[0, len(title)]]},
+            {
+                "type": "abstract",
+                "text": [abstract],
+                "offsets": [[len(title) + 1, len(title) + len(abstract) + 1]],
+            },
+        ]
+
+        entities = []
+        for line in raw_document[2:]:
+            (
+                pmid_,
+                start_idx,
+                end_idx,
+                mention,
+                semantic_type_id,
+                entity_id,
+            ) = line.split("\t")
+            entity = {
+                "offsets": [[int(start_idx), int(end_idx)]],
+                "text": [mention],
+                "semantic_type_id": semantic_type_id.split(","),
+                "concept_id": entity_id,
+            }
+            entities.append(entity)
+
+        return {"pmid": int(pmid), "entities": entities, "passages": passages}

--- a/hub/hubscripts/mednli_hub.py
+++ b/hub/hubscripts/mednli_hub.py
@@ -1,0 +1,200 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+State of the art models using deep neural networks have become very good in learning an accurate
+mapping from inputs to outputs. However, they still lack generalization capabilities in conditions
+that differ from the ones encountered during training. This is even more challenging in specialized,
+and knowledge intensive domains, where training data is limited. To address this gap, we introduce
+MedNLI - a dataset annotated by doctors, performing a natural language inference task (NLI),
+grounded in the medical history of patients. As the source of premise sentences, we used the
+MIMIC-III. More specifically, to minimize the risks to patient privacy, we worked with clinical
+notes corresponding to the deceased patients. The clinicians in our team suggested the Past Medical
+History to be the most informative section of a clinical note, from which useful inferences can be
+drawn about the patient.
+
+The files comprising this dataset must be on the users local machine in a single directory that is
+passed to `datasets.load_datset` via the `data_dir` kwarg. This loader script will read the archive
+files directly (i.e. the user should not uncompress, untar or unzip any of the files). For example,
+if `data_dir` is `"mednli"` it should contain the following files:
+
+mednli
+├── mednli-a-natural-language-inference-dataset-for-the-clinical-domain-1.0.0.zip
+"""
+
+import json
+import os
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import entailment_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = True
+_CITATION = """\
+@misc{https://doi.org/10.13026/c2rs98,
+    title        = {MedNLI — A Natural Language Inference Dataset For The Clinical Domain},
+    author       = {Shivade,  Chaitanya},
+    year         = 2017,
+    publisher    = {physionet.org},
+    doi          = {10.13026/C2RS98},
+    url          = {https://physionet.org/content/mednli/}
+}
+"""
+
+
+_DATASETNAME = "mednli"
+_DISPLAYNAME = "MedNLI"
+
+_DESCRIPTION = """\
+State of the art models using deep neural networks have become very good in learning an accurate
+mapping from inputs to outputs. However, they still lack generalization capabilities in conditions
+that differ from the ones encountered during training. This is even more challenging in specialized,
+and knowledge intensive domains, where training data is limited. To address this gap, we introduce
+MedNLI - a dataset annotated by doctors, performing a natural language inference task (NLI),
+grounded in the medical history of patients. As the source of premise sentences, we used the
+MIMIC-III. More specifically, to minimize the risks to patient privacy, we worked with clinical
+notes corresponding to the deceased patients. The clinicians in our team suggested the Past Medical
+History to be the most informative section of a clinical note, from which useful inferences can be
+drawn about the patient.
+"""
+
+
+_HOMEPAGE = "https://physionet.org/content/mednli/1.0.0/"
+
+_LICENSE = 'PhysioNet Credentialed Health Data License'
+
+_URLS = {}
+
+_SUPPORTED_TASKS = [Tasks.TEXTUAL_ENTAILMENT]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class MedNLIDataset(datasets.GeneratorBasedBuilder):
+    """MedNLI"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="mednli_source",
+            version=SOURCE_VERSION,
+            description="MedNLI source schema",
+            schema="source",
+            subset_id="mednli",
+        ),
+        BigBioConfig(
+            name="mednli_bigbio_te",
+            version=BIGBIO_VERSION,
+            description="MedNLI BigBio schema",
+            schema="bigbio_te",
+            subset_id="mednli",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "mednli_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "pairID": datasets.Value("string"),
+                    "gold_label": datasets.Value("string"),
+                    "sentence1": datasets.Value("string"),
+                    "sentence2": datasets.Value("string"),
+                    "sentence1_parse": datasets.Value("string"),
+                    "sentence2_parse": datasets.Value("string"),
+                    "sentence1_binary_parse": datasets.Value("string"),
+                    "sentence2_binary_parse": datasets.Value("string"),
+                }
+            )
+
+        elif self.config.schema == "bigbio_te":
+            features = entailment_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
+        else:
+            extract_dir = dl_manager.extract(
+                os.path.join(
+                    self.config.data_dir,
+                    "mednli-a-natural-language-inference-dataset-for-the-clinical-domain-1.0.0.zip",
+                )
+            )
+            data_dir = os.path.join(
+                extract_dir,
+                "mednli-a-natural-language-inference-dataset-for-the-clinical-domain-1.0.0",
+            )
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "mli_train_v1.jsonl"),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "mli_test_v1.jsonl"),
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "mli_dev_v1.jsonl"),
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+        with open(filepath, "r") as f:
+            if self.config.schema == "source":
+                for line in f:
+                    json_line = json.loads(line)
+                    yield json_line["pairID"], json_line
+
+            elif self.config.schema == "bigbio_te":
+                for line in f:
+                    json_line = json.loads(line)
+                    entailment_example = {
+                        "id": json_line["pairID"],
+                        "premise": json_line["sentence1"],
+                        "hypothesis": json_line["sentence2"],
+                        "label": json_line["gold_label"],
+                    }
+                    yield json_line["pairID"], entailment_example

--- a/hub/hubscripts/meqsum_hub.py
+++ b/hub/hubscripts/meqsum_hub.py
@@ -1,0 +1,161 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Dataset for medical question summarization introduced in the ACL 2019 paper "On the Summarization of Consumer Health
+Questions". Question understanding is one of the main challenges in question answering. In real world applications,
+users often submit natural language questions that are longer than needed and include peripheral information that
+increases the complexity of the question, leading to substantially more false positives in answer retrieval. In this
+paper, we study neural abstractive models for medical question summarization. We introduce the MeQSum corpus of 1,000
+summarized consumer health questions.
+"""
+
+import os
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import text2text_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@inproceedings{ben-abacha-demner-fushman-2019-summarization,
+    title = "On the Summarization of Consumer Health Questions",
+    author = "Ben Abacha, Asma  and
+      Demner-Fushman, Dina",
+    booktitle = "Proceedings of the 57th Annual Meeting of the Association for Computational Linguistics",
+    month = jul,
+    year = "2019",
+    address = "Florence, Italy",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/P19-1215",
+    doi = "10.18653/v1/P19-1215",
+    pages = "2228--2234",
+    abstract = "Question understanding is one of the main challenges in question answering. In real world applications, users often submit natural language questions that are longer than needed and include peripheral information that increases the complexity of the question, leading to substantially more false positives in answer retrieval. In this paper, we study neural abstractive models for medical question summarization. We introduce the MeQSum corpus of 1,000 summarized consumer health questions. We explore data augmentation methods and evaluate state-of-the-art neural abstractive models on this new task. In particular, we show that semantic augmentation from question datasets improves the overall performance, and that pointer-generator networks outperform sequence-to-sequence attentional models on this task, with a ROUGE-1 score of 44.16{\%}. We also present a detailed error analysis and discuss directions for improvement that are specific to question summarization.",
+}
+"""
+
+_DATASETNAME = "meqsum"
+_DISPLAYNAME = "MeQSum"
+
+_DESCRIPTION = """\
+Dataset for medical question summarization introduced in the ACL 2019 paper "On the Summarization of Consumer Health
+Questions". Question understanding is one of the main challenges in question answering. In real world applications,
+users often submit natural language questions that are longer than needed and include peripheral information that
+increases the complexity of the question, leading to substantially more false positives in answer retrieval. In this
+paper, we study neural abstractive models for medical question summarization. We introduce the MeQSum corpus of 1,000
+summarized consumer health questions.
+"""
+
+_HOMEPAGE = "https://github.com/abachaa/MeQSum"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: "https://github.com/abachaa/MeQSum/raw/master/MeQSum_ACL2019_BenAbacha_Demner-Fushman.xlsx",
+}
+
+_SUPPORTED_TASKS = [Tasks.SUMMARIZATION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class MeQSumDataset(datasets.GeneratorBasedBuilder):
+    """Dataset containing 1000 summarized consumer health questions."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="meqsum_source",
+            version=SOURCE_VERSION,
+            description="MeQSum source schema",
+            schema="source",
+            subset_id="meqsum",
+        ),
+        BigBioConfig(
+            name="meqsum_bigbio_t2t",
+            version=BIGBIO_VERSION,
+            description="MeQSum BigBio schema",
+            schema="bigbio_t2t",
+            subset_id="meqsum",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "meqsum_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "File": datasets.Value("string"),
+                    "CHQ": datasets.Value("string"),
+                    "Summary": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == "bigbio_t2t":
+            features = text2text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[_DATASETNAME]
+        file_path = dl_manager.download(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(file_path),
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        corpus = pd.read_excel(filepath)
+
+        if self.config.schema == "source":
+            for idx, example in corpus.iterrows():
+                yield idx, example.to_dict()
+
+        elif self.config.schema == "bigbio_t2t":
+            corpus["id"] = corpus.index
+            corpus.rename(
+                columns={"File": "document_id", "CHQ": "text_1", "Summary": "text_2"},
+                inplace=True,
+            )
+            corpus["text_1_name"] = ""
+            corpus["text_2_name"] = ""
+            for idx, example in corpus.iterrows():
+                yield example["id"], example.to_dict()

--- a/hub/hubscripts/minimayosrs_hub.py
+++ b/hub/hubscripts/minimayosrs_hub.py
@@ -1,0 +1,164 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+MayoSRS consists of 101 clinical term pairs whose relatedness was determined by
+nine medical coders and three physicians from the Mayo Clinic.
+"""
+
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import pairs_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@article{pedersen2007measures,
+  title={Measures of semantic similarity and relatedness in the biomedical domain},
+  author={Pedersen, Ted and Pakhomov, Serguei VS and Patwardhan, Siddharth and Chute, Christopher G},
+  journal={Journal of biomedical informatics},
+  volume={40},
+  number={3},
+  pages={288--299},
+  year={2007},
+  publisher={Elsevier}
+}
+"""
+
+_DATASETNAME = "minimayosrs"
+_DISPLAYNAME = "MiniMayoSRS"
+
+_DESCRIPTION = """\
+MiniMayoSRS is a subset of the MayoSRS and consists of 30 term pairs on which a higher inter-annotator agreement was
+achieved. The average correlation between physicians is 0.68. The average correlation between medical coders is 0.78.
+"""
+
+_HOMEPAGE = "https://conservancy.umn.edu/handle/11299/196265"
+
+_LICENSE = 'Creative Commons Zero v1.0 Universal'
+
+_URLS = {
+    _DATASETNAME: "https://conservancy.umn.edu/bitstream/handle/11299/196265/MiniMayoSRS.csv?sequence=2&isAllowed=y"
+}
+
+_SUPPORTED_TASKS = [Tasks.SEMANTIC_SIMILARITY]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class MinimayosrsDataset(datasets.GeneratorBasedBuilder):
+    """MiniMayoSRS is a subset of the MayoSRS and consists of 30 term pairs on which a higher inter-annotator agreement
+    was achieved. The average correlation between physicians is 0.68. The average correlation between medical coders
+    is 0.78.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="minimayosrs_source",
+            version=SOURCE_VERSION,
+            description="MiniMayoSRS source schema",
+            schema="source",
+            subset_id="minimayosrs",
+        ),
+        BigBioConfig(
+            name="minimayosrs_bigbio_pairs",
+            version=BIGBIO_VERSION,
+            description="MiniMayoSRS BigBio schema",
+            schema="bigbio_pairs",
+            subset_id="minimayosrs",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "minimayosrs_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "text_1": datasets.Value("string"),
+                    "text_2": datasets.Value("string"),
+                    "code_1": datasets.Value("string"),
+                    "code_2": datasets.Value("string"),
+                    "label_physicians": datasets.Value("float32"),
+                    "label_coders": datasets.Value("float32"),
+                }
+            )
+
+        elif self.config.schema == "bigbio_pairs":
+            features = pairs_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[_DATASETNAME]
+        filepath = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"filepath": filepath},
+            )
+        ]
+
+    def _generate_examples(self, filepath) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        data = pd.read_csv(
+            filepath,
+            sep=",",
+            header=0,
+            names=[
+                "label_physicians",
+                "label_coders",
+                "code_1",
+                "code_2",
+                "text_1",
+                "text_2",
+            ],
+        )
+
+        if self.config.schema == "source":
+            for id_, row in data.iterrows():
+                yield id_, row.to_dict()
+
+        elif self.config.schema == "bigbio_pairs":
+            for id_, row in data.iterrows():
+                yield id_, {
+                    "id": id_,
+                    "document_id": id_,
+                    "text_1": row["text_1"],
+                    "text_2": row["text_2"],
+                    "label": str((row["label_physicians"] + row["label_coders"]) / 2),
+                }

--- a/hub/hubscripts/mirna_hub.py
+++ b/hub/hubscripts/mirna_hub.py
@@ -1,0 +1,383 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import xml.etree.ElementTree as ET
+from typing import Dict, Iterator, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@Article{Bagewadi2014,
+author={Bagewadi, Shweta
+and Bobi{\'{c}}, Tamara
+and Hofmann-Apitius, Martin
+and Fluck, Juliane
+and Klinger, Roman},
+title={Detecting miRNA Mentions and Relations in Biomedical Literature},
+journal={F1000Research},
+year={2014},
+month={Aug},
+day={28},
+publisher={F1000Research},
+volume={3},
+pages={205-205},
+keywords={MicroRNAs; corpus; prediction algorithms},
+abstract={
+    INTRODUCTION: MicroRNAs (miRNAs) have demonstrated their potential as post-transcriptional
+    gene expression regulators, participating in a wide spectrum of regulatory events such as
+    apoptosis, differentiation, and stress response. Apart from the role of miRNAs in normal
+    physiology, their dysregulation is implicated in a vast array of diseases. Dissection of
+    miRNA-related associations are valuable for contemplating their mechanism in diseases,
+    leading to the discovery of novel miRNAs for disease prognosis, diagnosis, and therapy.
+    MOTIVATION: Apart from databases and prediction tools, miRNA-related information is largely
+    available as unstructured text. Manual retrieval of these associations can be labor-intensive
+    due to steadily growing number of publications. Additionally, most of the published miRNA
+    entity recognition methods are keyword based, further subjected to manual inspection for
+    retrieval of relations. Despite the fact that several databases host miRNA-associations
+    derived from text, lower sensitivity and lack of published details for miRNA entity
+    recognition and associated relations identification has motivated the need for developing
+    comprehensive methods that are freely available for the scientific community. Additionally,
+    the lack of a standard corpus for miRNA-relations has caused difficulty in evaluating the
+    available systems. We propose methods to automatically extract mentions of miRNAs, species,
+    genes/proteins, disease, and relations from scientific literature. Our generated corpora,
+    along with dictionaries, and miRNA regular expression are freely available for academic
+    purposes. To our knowledge, these resources are the most comprehensive developed so far.
+    RESULTS: The identification of specific miRNA mentions reaches a recall of 0.94 and
+    precision of 0.93. Extraction of miRNA-disease and miRNA-gene relations lead to an
+    F1 score of up to 0.76. A comparison of the information extracted by our approach to
+    the databases miR2Disease and miRSel for the extraction of Alzheimer's disease
+    related relations shows the capability of our proposed methods in identifying correct
+    relations with improved sensitivity. The published resources and described methods can
+    help the researchers for maximal retrieval of miRNA-relations and generation of
+    miRNA-regulatory networks. AVAILABILITY: The training and test corpora, annotation
+    guidelines, developed dictionaries, and supplementary files are available at
+    http://www.scai.fraunhofer.de/mirna-corpora.html.
+},
+note={26535109[pmid]},
+note={PMC4602280[pmcid]},
+issn={2046-1402},
+url={https://pubmed.ncbi.nlm.nih.gov/26535109},
+language={eng}
+}
+"""
+
+_DATASETNAME = "mirna"
+_DISPLAYNAME = "miRNA"
+
+_DESCRIPTION = """\
+The corpus consists of 301 Medline citations. The documents were screened for
+mentions of miRNA in the abstract text. Gene, disease and miRNA entities were manually
+annotated. The corpus comprises of two separate files, a train and a test set, coming
+from 201 and 100 documents respectively. 
+"""
+
+_HOMEPAGE = "https://www.scai.fraunhofer.de/en/business-research-areas/bioinformatics/downloads/download-mirna-test-corpus.html"
+
+_LICENSE = 'Creative Commons Attribution Non Commercial 3.0 Unported'
+
+_BASE = "https://www.scai.fraunhofer.de/content/dam/scai/de/downloads/bioinformatik/miRNA/miRNA-"
+
+_URLs = {
+    "source": {
+        "train": _BASE + "Train-Corpus.xml",
+        "test": _BASE + "Test-Corpus.xml",
+    },
+    "bigbio_kb": {
+        "train": _BASE + "Train-Corpus.xml",
+        "test": _BASE + "Test-Corpus.xml",
+    },
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class miRNADataset(datasets.GeneratorBasedBuilder):
+    """mirna"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="mirna_source",
+            version=SOURCE_VERSION,
+            description="mirna source schema",
+            schema="source",
+            subset_id="mirna",
+        ),
+        BigBioConfig(
+            name="mirna_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="mirna BigBio schema",
+            schema="bigbio_kb",
+            subset_id="mirna",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "mirna_source"
+
+    def _info(self):
+
+        if self.config.schema == "source":
+
+            features = datasets.Features(
+                {
+                    "passages": [
+                        {
+                            "document_id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                            "offset": datasets.Value("int32"),
+                            "entities": [
+                                {
+                                    "id": datasets.Value("string"),
+                                    "offsets": [[datasets.Value("int32")]],
+                                    "text": [datasets.Value("string")],
+                                    "type": datasets.Value("string"),
+                                    "normalized": [
+                                        {
+                                            "db_name": datasets.Value("string"),
+                                            "db_id": datasets.Value("string"),
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ]
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            supervised_keys=None,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+
+        my_urls = _URLs[self.config.schema]
+
+        path_xml_train = dl_manager.download(my_urls["train"])
+        path_xml_test = dl_manager.download(my_urls["test"])
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # These kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": path_xml_train,
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                # These kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": path_xml_test,
+                    "split": "test",
+                },
+            ),
+        ]
+
+    def _get_passages_and_entities(self, d) -> Tuple[List[Dict], List[List[Dict]]]:
+
+        sentences: List[Dict] = []
+        entities: List[List[Dict]] = []
+        relations: List[List[Dict]] = []
+
+        text_total_length = 0
+
+        po_start = 0
+
+        # Get sentences of the document
+        for _, s in enumerate(d):
+
+            # annotation used only for document indexing
+            if s.attrib["text"] is None or len(s.attrib["text"]) <= 0:
+                continue
+
+            # annotation used only for document indexing
+            if len(s) <= 0:
+                continue
+
+            text_total_length += len(s.attrib["text"]) + 1
+
+            po_end = po_start + len(s.attrib["text"])
+
+            start = po_start
+
+            dp = {
+                "text": s.attrib["text"],
+                "type": "title" if ".s0" in s.attrib["id"] else "abstract",
+                "offsets": [(po_start, po_end)],
+                "offset": 0,  # original offset
+            }
+
+            po_start = po_end + 1
+
+            sentences.append(dp)
+
+            pe = []  # entities
+            re = []  # relations
+
+            # For each entity
+            for a in s:
+
+                # If correspond to a entity
+                if a.tag == "entity":
+
+                    length = len(a.attrib["text"])
+
+                    if a.attrib["text"] is None or length <= 0:
+                        continue
+
+                    # no in-text annotation: only for document indexing
+                    if a.attrib["type"] in ["MeSH_Indexing_Chemical", "OTHER"]:
+                        continue
+
+                    startOffset, endOffset = a.attrib["charOffset"].split("-")
+                    startOffset, endOffset = int(startOffset), int(endOffset)
+
+                    pe.append(
+                        {
+                            "id": a.attrib["id"],
+                            "type": a.attrib["type"],
+                            "text": (a.attrib["text"],),
+                            "offsets": [(start + startOffset, start + endOffset + 1)],
+                            "normalized": [
+                                {"db_name": "miRNA-corpus", "db_id": a.attrib["id"]}
+                            ],
+                        }
+                    )
+
+                # If correspond to relation pair
+                elif a.tag == "pair":
+
+                    re.append(
+                        {
+                            "id": a.attrib["id"],
+                            "type": a.attrib["type"],
+                            "arg1_id": a.attrib["e1"],
+                            "arg2_id": a.attrib["e2"],
+                            "normalized": [],
+                        }
+                    )
+
+            entities.append(pe)
+            relations.append(re)
+
+        return sentences, entities, relations
+
+    def _generate_examples(
+        self,
+        filepath: str,
+        split: str,
+    ) -> Iterator[Tuple[int, Dict]]:
+        """Yields examples as (key, example) tuples."""
+
+        reader = ET.fromstring(open(str(filepath), "r").read())
+
+        if self.config.schema == "source":
+
+            for uid, doc in enumerate(reader):
+
+                (
+                    sentences,
+                    sentences_entities,
+                    relations,
+                ) = self._get_passages_and_entities(doc)
+
+                if (
+                    len(sentences) < 1
+                    or len(sentences_entities) < 1
+                    or len(sentences_entities) != len(sentences)
+                ):
+                    continue
+
+                for p, pe, re in zip(sentences, sentences_entities, relations):
+
+                    p.pop("offsets")  # BioC has only start for passages offsets
+
+                    p["document_id"] = doc.attrib["id"]
+                    p["entities"] = pe  # BioC has per passage entities
+
+                yield uid, {"passages": sentences}
+
+        elif self.config.schema == "bigbio_kb":
+
+            uid = 0
+
+            for idx, doc in enumerate(reader):
+
+                (
+                    sentences,
+                    sentences_entities,
+                    relations,
+                ) = self._get_passages_and_entities(doc)
+
+                if (
+                    len(sentences) < 1
+                    or len(sentences_entities) < 1
+                    or len(sentences_entities) != len(sentences)
+                ):
+                    continue
+
+                # global id
+                uid += 1
+
+                # unpack per-sentence entities
+                entities = [e for pe in sentences_entities for e in pe]
+
+                for p in sentences:
+                    p.pop("offset")  # drop original offset
+                    p["text"] = (p["text"],)  # text in sentence is Sequence
+                    p["id"] = uid
+                    uid += 1
+
+                for e in entities:
+                    e["id"] = uid
+                    uid += 1
+
+                # unpack per-sentence relations
+                relations = [r for re in relations for r in re]
+
+                for r in relations:
+                    r["id"] = uid
+                    uid += 1
+
+                yield idx, {
+                    "id": uid,
+                    "document_id": doc.attrib["id"],
+                    "passages": sentences,
+                    "entities": entities,
+                    "events": [],
+                    "coreferences": [],
+                    "relations": relations,
+                }

--- a/hub/hubscripts/mlee_hub.py
+++ b/hub/hubscripts/mlee_hub.py
@@ -1,0 +1,279 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+MLEE is an event extraction corpus consisting of manually annotated abstracts of papers
+on angiogenesis. It contains annotations for entities, relations, events and coreferences
+The annotations span molecular, cellular, tissue, and organ-level processes.
+"""
+from pathlib import Path
+from typing import Dict, List
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_SOURCE_VIEW_NAME = "source"
+_UNIFIED_VIEW_NAME = "bigbio"
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{pyysalo2012event,
+  title={Event extraction across multiple levels of biological organization},
+  author={Pyysalo, Sampo and Ohta, Tomoko and Miwa, Makoto and Cho, Han-Cheol and Tsujii, Jun'ichi and Ananiadou, Sophia},
+  journal={Bioinformatics},
+  volume={28},
+  number={18},
+  pages={i575--i581},
+  year={2012},
+  publisher={Oxford University Press}
+}
+"""
+
+_DESCRIPTION = """\
+MLEE is an event extraction corpus consisting of manually annotated abstracts of papers
+on angiogenesis. It contains annotations for entities, relations, events and coreferences
+The annotations span molecular, cellular, tissue, and organ-level processes.
+"""
+
+_DATASETNAME = "mlee"
+_DISPLAYNAME = "MLEE"
+
+_HOMEPAGE = "http://www.nactem.ac.uk/MLEE/"
+
+_LICENSE = 'Creative Commons Attribution Non Commercial Share Alike 3.0 Unported'
+_URLs = {
+    "source": "http://www.nactem.ac.uk/MLEE/MLEE-1.0.2-rev1.tar.gz",
+    "bigbio_kb": "http://www.nactem.ac.uk/MLEE/MLEE-1.0.2-rev1.tar.gz",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.EVENT_EXTRACTION,
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.RELATION_EXTRACTION,
+    Tasks.COREFERENCE_RESOLUTION,
+]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class MLEE(datasets.GeneratorBasedBuilder):
+    """Write a short docstring documenting what this dataset is"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="mlee_source",
+            version=SOURCE_VERSION,
+            description="MLEE source schema",
+            schema="source",
+            subset_id="mlee",
+        ),
+        BigBioConfig(
+            name="mlee_bigbio_kb",
+            version=SOURCE_VERSION,
+            description="MLEE BigBio schema",
+            schema="bigbio_kb",
+            subset_id="mlee",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "mlee_source"
+
+    _ROLE_MAPPING = {
+        "Theme2": "Theme",
+        "Instrument2": "Instrument",
+        "Participant2": "Participant",
+        "Participant3": "Participant",
+        "Participant4": "Participant",
+    }
+
+    def _info(self):
+        """
+        Provide information about MLEE:
+        - `features` defines the schema of the parsed data set. The schema depends on the
+        chosen `config`: If it is `_SOURCE_VIEW_NAME` the schema is the schema of the
+        original data. If `config` is `_UNIFIED_VIEW_NAME`, then the schema is the
+        canonical KB-task schema defined in `biomedical/schemas/kb.py`.
+
+        """
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "trigger": datasets.Value(
+                                "string"
+                            ),  # refers to the text_bound_annotation of the trigger,
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arguments": datasets.Sequence(
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "attributes": [  # M or A lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value(
+                                "string"
+                            ),  # Name of the resource, e.g. "Wikipedia"
+                            "cuid": datasets.Value(
+                                "string"
+                            ),  # ID in the resource, e.g. 534366
+                            "text": datasets.Value(
+                                "string"
+                            ),  # Human readable description/name of the entity, e.g. "Barack Obama"
+                        }
+                    ],
+                },
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            # This is the description that will appear on the datasets page.
+            description=_DESCRIPTION,
+            features=features,
+            # If there's a common (input, target) tuple from the features, uncomment supervised_keys line below and
+            # specify them. They'll be used if as_supervised=True in builder.as_dataset.
+            # This is not applicable for MLEE.
+            # supervised_keys=("sentence", "label"),
+            # Homepage of the dataset for documentation
+            homepage=_HOMEPAGE,
+            # License for the dataset if available
+            license=str(_LICENSE),
+            # Citation for the dataset
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+        """
+        Create the three splits provided by MLEE: train, validation and test.
+
+        Each split is created by instantiating a `datasets.SplitGenerator`, which will
+        call `this._generate_examples` with the keyword arguments in `gen_kwargs`.
+        """
+
+        my_urls = _URLs[self.config.schema]
+        data_dir = Path(dl_manager.download_and_extract(my_urls))
+        data_files = {
+            "train": data_dir
+            / "MLEE-1.0.2-rev1"
+            / "standoff"
+            / "development"
+            / "train",
+            "dev": data_dir / "MLEE-1.0.2-rev1" / "standoff" / "development" / "test",
+            "test": data_dir / "MLEE-1.0.2-rev1" / "standoff" / "test" / "test",
+        }
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"data_files": data_files["train"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"data_files": data_files["dev"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"data_files": data_files["test"]},
+            ),
+        ]
+
+    def _standardize_arguments_roles(self, kb_example: Dict) -> Dict:
+
+        for event in kb_example["events"]:
+            for argument in event["arguments"]:
+                role = argument["role"]
+                argument["role"] = self._ROLE_MAPPING.get(role, role)
+
+        return kb_example
+
+    def _generate_examples(self, data_files: Path):
+        """
+        Yield one `(guid, example)` pair per abstract in MLEE.
+        The contents of `example` will depend on the chosen configuration.
+        """
+        if self.config.schema == "source":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.parse_brat_file(txt_file)
+                example["id"] = str(guid)
+                yield guid, example
+        elif self.config.schema == "bigbio_kb":
+            txt_files = list(data_files.glob("*txt"))
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.brat_parse_to_bigbio_kb(
+                    parsing.parse_brat_file(txt_file)
+                )
+                example = self._standardize_arguments_roles(example)
+                example["id"] = str(guid)
+                yield guid, example
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/hub/hubscripts/mqp_hub.py
+++ b/hub/hubscripts/mqp_hub.py
@@ -1,0 +1,171 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Medical Question Pairs dataset by McCreery et al (2020) contains pairs of medical questions and paraphrased versions of
+the question prepared by medical professional.
+"""
+
+import csv
+import os
+from typing import Dict, Tuple
+
+import datasets
+from datasets import load_dataset
+
+from .bigbiohub import pairs_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@article{DBLP:journals/biodb/LiSJSWLDMWL16,
+  author    = {Krallinger, M., Rabal, O., Lourenço, A.},
+  title     = {Effective Transfer Learning for Identifying Similar Questions: Matching User Questions to COVID-19 FAQs},
+  journal   = {KDD '20: Proceedings of the 26th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining},
+  volume    = {3458–3465},
+  year      = {2020},
+  url       = {https://github.com/curai/medical-question-pair-dataset},
+  doi       = {},
+  biburl    = {},
+  bibsource = {}
+}
+"""
+
+_DATASETNAME = "mqp"
+_DISPLAYNAME = "MQP"
+
+_DESCRIPTION = """\
+Medical Question Pairs dataset by McCreery et al (2020) contains pairs of medical questions and paraphrased versions of 
+the question prepared by medical professional. Paraphrased versions were labelled as similar (syntactically dissimilar 
+but contextually similar ) or dissimilar (syntactically may look similar but contextually dissimilar). Labels 1: similar, 0: dissimilar
+"""
+
+_HOMEPAGE = "https://github.com/curai/medical-question-pair-dataset"
+
+_LICENSE = 'License information unavailable'
+_URLs = {
+    _DATASETNAME: "https://raw.githubusercontent.com/curai/medical-question-pair-dataset/master/mqp.csv",
+}
+
+_SUPPORTED_TASKS = [Tasks.SEMANTIC_SIMILARITY]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class MQPDataset(datasets.GeneratorBasedBuilder):
+    """Medical Question Pairing dataset"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="mqp_source",
+            version=SOURCE_VERSION,
+            description="MQP source schema",
+            schema="source",
+            subset_id="mqp",
+        ),
+        BigBioConfig(
+            name="mqp_bigbio_pairs",
+            version=BIGBIO_VERSION,
+            description="MQP BigBio schema",
+            schema="bigbio_pairs",
+            subset_id="mqp",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "mqp_source"
+
+    def _info(self):
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "text_1": datasets.Value("string"),
+                    "text_2": datasets.Value("string"),
+                    "label": datasets.Value("string"),
+                }
+            )
+
+        # Using in pairs schema
+        elif self.config.schema == "bigbio_pairs":
+            features = pairs_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+        my_urls = _URLs[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(my_urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_dir,
+                    "split": "train",
+                },
+            )
+        ]
+
+    def _generate_examples(self, filepath, split):
+        """Yields examples as (key, example) tuples."""
+
+        if split == "train":  # There's only training dataset available atm
+            with open(filepath, encoding="utf-8") as csv_file:
+                csv_reader = csv.reader(
+                    csv_file,
+                    quotechar='"',
+                    delimiter=",",
+                    quoting=csv.QUOTE_ALL,
+                    skipinitialspace=True,
+                )
+
+                if self.config.schema == "source":
+                    for id_, row in enumerate(csv_reader):
+                        document_id, text_1, text_2, label = row
+                        yield id_, {
+                            "document_id": document_id,
+                            "text_1": text_1,
+                            "text_2": text_2,
+                            "label": label,
+                        }
+
+                elif self.config.schema == "bigbio_pairs":
+                    # global id (uid) starts from 1
+                    uid = 0
+                    for id_, row in enumerate(csv_reader):
+                        uid += 1
+                        document_id, text_1, text_2, label = row
+                        yield id_, {
+                            "id": uid,  # uid is an unique identifier for every record that starts from 1
+                            "document_id": document_id,
+                            "text_1": text_1,
+                            "text_2": text_2,
+                            "label": label,
+                        }
+        else:
+            print("There's no test/val split available for the given dataset")
+            return

--- a/hub/hubscripts/msh_wsd_hub.py
+++ b/hub/hubscripts/msh_wsd_hub.py
@@ -1,0 +1,268 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Evaluation of Word Sense Disambiguation methods (WSD) in the biomedical domain is difficult because the available
+resources are either too small or too focused on specific types of entities (e.g. diseases or genes). We have
+developed a method that can be used to automatically develop a WSD test collection using the Unified Medical Language
+System (UMLS) Metathesaurus and the manual MeSH indexing of MEDLINE. The resulting dataset is called MSH WSD and
+consists of 106 ambiguous abbreviations, 88 ambiguous terms and 9 which are a combination of both, for a total of 203
+ambiguous words. Each instance containing the ambiguous word was assigned a CUI from the 2009AB version of the UMLS.
+For each ambiguous term/abbreviation, the data set contains a maximum of 100 instances per sense obtained from
+MEDLINE; totaling 37,888 ambiguity cases in 37,090 MEDLINE citations.
+
+Note from the Author how to load dataset:
+1) Download the file MSHCorpus.zip (Link "MSHWSD Data Set") from
+   https://lhncbc.nlm.nih.gov/ii/areas/WSD/collaboration.html
+2) Set kwarg data_dir to the directory containing MSHCorpus.zip
+"""
+
+import itertools as it
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = True
+_CITATION = """\
+@article{jimeno2011exploiting,
+  title={Exploiting MeSH indexing in MEDLINE to generate a data set for word sense disambiguation},
+  author={Jimeno-Yepes, Antonio J and McInnes, Bridget T and Aronson, Alan R},
+  journal={BMC bioinformatics},
+  volume={12},
+  number={1},
+  pages={1--14},
+  year={2011},
+  publisher={BioMed Central}
+}
+"""
+
+_DESCRIPTION = """\
+Evaluation of Word Sense Disambiguation methods (WSD) in the biomedical domain is difficult because the available
+resources are either too small or too focused on specific types of entities (e.g. diseases or genes). We have
+developed a method that can be used to automatically develop a WSD test collection using the Unified Medical Language
+System (UMLS) Metathesaurus and the manual MeSH indexing of MEDLINE. The resulting dataset is called MSH WSD and
+consists of 106 ambiguous abbreviations, 88 ambiguous terms and 9 which are a combination of both, for a total of 203
+ambiguous words. Each instance containing the ambiguous word was assigned a CUI from the 2009AB version of the UMLS.
+For each ambiguous term/abbreviation, the data set contains a maximum of 100 instances per sense obtained from
+MEDLINE; totaling 37,888 ambiguity cases in 37,090 MEDLINE citations.
+"""
+
+_DATASETNAME = "msh_wsd"
+_DISPLAYNAME = "MSH WSD"
+
+_HOMEPAGE = "https://lhncbc.nlm.nih.gov/ii/areas/WSD/collaboration.html"
+
+_LICENSE = 'UMLS - Metathesaurus License Agreement'
+
+_URLS = {_DATASETNAME: ""}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_DISAMBIGUATION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+@dataclass
+class MshWsdBigBioConfig(BigBioConfig):
+    schema: str = "source"
+    name: str = "msh_wsd_source"
+    version: datasets.Version = datasets.Version(_SOURCE_VERSION)
+    description: str = "MSH-WSD source schema"
+    subset_id: str = "msh_wsd"
+
+
+class MshWsdDataset(datasets.GeneratorBasedBuilder):
+    """Biomedical Word Sense Disambiguation (WSD)."""
+
+    uid = it.count(0)
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        MshWsdBigBioConfig(
+            name="msh_wsd_source",
+            version=SOURCE_VERSION,
+            description="MSH-WSD source schema",
+            schema="source",
+            subset_id="msh_wsd",
+        ),
+        MshWsdBigBioConfig(
+            name="msh_wsd_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="MSH-WSD BigBio schema",
+            schema="bigbio_kb",
+            subset_id="msh_wsd",
+        ),
+    ]
+
+    BUILDER_CONFIG_CLASS = MshWsdBigBioConfig
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "ambiguous_word": datasets.Value("string"),
+                    "sentences": [
+                        {
+                            "pmid": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                            "label": datasets.Value("string"),
+                        }
+                    ],
+                    "choices": [
+                        {
+                            "label": datasets.Value("string"),
+                            "concept": datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
+        else:
+            data_dir = dl_manager.download_and_extract(
+                os.path.join(self.config.data_dir, "MSHCorpus.zip")
+            )
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "data_dir": Path(data_dir),
+                },
+            ),
+        ]
+
+    def _generate_examples(self, data_dir: Path) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        data_dir = data_dir / "MSHCorpus"
+        concepts = data_dir / "benchmark_mesh.txt"
+        with concepts.open() as f:
+            concepts = f.readlines()
+        concepts = [x.strip().split("\t") for x in concepts]
+
+        concept_map = {
+            cuis[0]: {f"M{num}": cui for num, cui in enumerate(cuis[1:], 1)}
+            for cuis in concepts
+        }
+
+        files = list(data_dir.glob("*arff"))
+        for guid, file in enumerate(files):
+            if self.config.schema == "source":
+                for example in self._parse_document(concept_map, file):
+                    yield guid, example
+
+            elif self.config.schema == "bigbio_kb":
+                for document in self._parse_document(concept_map, file):
+                    for example in self._source_to_kb(document):
+                        yield example["id"], example
+
+    def _parse_document(self, concept_map, file: Path):
+        with file.open(mode="r", encoding="iso-8859-1") as f:
+            content = f.readlines()
+        content = [x.strip() for x in content]
+
+        # search line number of @DATA, sometimes 6 or 7
+        start_l = None
+        for number, line in enumerate(content):
+            if line.startswith("@DATA"):
+                start_l = number + 1
+                break
+        assert start_l is not None
+
+        amb_word = file.with_suffix("").name[: -len("_pmids_tagged")]
+
+        sentences = []
+        for line in content[start_l:]:
+            # cant use , or ," ", as seperator
+            m_pmid = re.search("[0-9]+(?=(,))", line)
+            pmid = m_pmid.group()
+            m_label = re.search("(?<=(,))M[0-9]+", line)
+            label = m_label.group()
+
+            citation = line[m_pmid.span()[1] + 1 : m_label.span()[0] - 1].strip('"')
+
+            sentences.append({"pmid": pmid, "text": citation, "label": label})
+
+        yield {
+            "ambiguous_word": amb_word,
+            "sentences": sentences,
+            "choices": [
+                {"label": key, "concept": value}
+                for key, value in concept_map[amb_word].items()
+            ],
+        }
+
+    def _source_to_kb(self, document):
+        choices = {x["label"]: x["concept"] for x in document["choices"]}
+        for sentence in document["sentences"]:
+            document_ = {}
+            document_["events"] = []
+            document_["relations"] = []
+            document_["coreferences"] = []
+            document_["id"] = next(self.uid)
+            document_["document_id"] = sentence["pmid"]
+            document_["passages"] = [
+                {
+                    "id": next(self.uid),
+                    "type": "",
+                    "text": [sentence["text"]],
+                    "offsets": [[0, len(sentence["text"])]],
+                }
+            ]
+            document_["entities"] = [
+                {
+                    "id": next(self.uid),
+                    "type": "ambiguous_word",
+                    "text": [document["ambiguous_word"]],
+                    "offsets": [self._parse_offset(sentence["text"])],
+                    "normalized": [
+                        {"db_name": "MeSH", "db_id": choices[sentence["label"]]}
+                    ],
+                }
+            ]
+            yield document_
+
+    def _parse_offset(self, sentence):
+        m = re.search("(?<=(<e>)).+(?=(</e>))", sentence)
+        return m.span()

--- a/hub/hubscripts/muchmore_hub.py
+++ b/hub/hubscripts/muchmore_hub.py
@@ -1,0 +1,738 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A dataset loader for the MuchMore Springer Bilingual Corpus
+
+homepage
+
+* https://muchmore.dfki.de/resources1.htm
+
+description of annotation format
+
+* https://muchmore.dfki.de/pubs/D4.1.pdf
+
+Four files are distributed
+
+* springer_english_train_plain.tar.gz (english plain text of abstracts)
+* springer_german_train_plain.tar.gz (german plain text of abstracts)
+* springer_english_train_V4.2.tar.gz (annotated xml in english)
+* springer_german_train_V4.2.tar.gz (annotated xml in german)
+
+Each tar file has one member file per abstract.
+There are keys to join the english and german files
+but there is not a 1-1 mapping between them (i.e. some
+english files have no german counterpart and some german
+files have no english counterpart). However, there is a 1-1
+mapping between plain text and annotations for a given language
+(i.e. an abstract in springer_english_train_plain.tar.gz will
+also be found in springer_english_train_V4.2.tar.gz)
+
+Counts,
+
+* 15,631 total abstracts
+* 7,823 english abstracts
+* 7,808 german abstracts
+* 6,374 matched (en/de) abstracts
+* 1,449 english abstracts with no german
+* 1,434 german abstracts with no english
+
+Notes
+
+* Arthroskopie.00130237.eng.abstr.chunkmorph.annotated.xml seems to be empty
+
+
+* entity spans can overlap. an example from the first sample:
+
+{'id': 'Arthroskopie.00130003.eng.abstr-s1-t1',
+  'type': 'umlsterm',
+  'text': ['posterior'],
+  'offsets': [[4, 13]],
+  'normalized': [{'db_name': 'UMLS', 'db_id': 'C0032009'}]},
+{'id': 'Arthroskopie.00130003.eng.abstr-s1-t8',
+  'type': 'umlsterm',
+  'text': ['posterior cruciate ligament'],
+  'offsets': [[4, 31]],
+  'normalized': [{'db_name': 'UMLS', 'db_id': 'C0080039'}]},
+{'id': 'Arthroskopie.00130003.eng.abstr-s1-t2',
+  'type': 'umlsterm',
+  'text': ['ligament'],
+  'offsets': [[23, 31]],
+  'normalized': [{'db_name': 'UMLS', 'db_id': 'C0023685'},
+   {'db_name': 'UMLS', 'db_id': 'C0023686'}]},
+
+
+* semantic relations are defined beween concepts but entities can
+  have multiple concpets associated with them. in the bigbio
+  schema we skip relations between multiple concept of the
+  same entity. an example of a relation that is kept from the
+  source schema is below,
+
+In [35]: dsd['train'][0]['sentences'][0]['tokens']
+Out[35]:
+[{'id': 'w1', 'pos': 'DT', 'lemma': 'the', 'text': 'The'},
+ {'id': 'w2', 'pos': 'JJ', 'lemma': 'posterior', 'text': 'posterior'},
+ {'id': 'w3', 'pos': 'JJ', 'lemma': 'cruciate', 'text': 'cruciate'},
+ {'id': 'w4', 'pos': 'NN', 'lemma': 'ligament', 'text': 'ligament'},
+ {'id': 'w5', 'pos': 'PUNCT', 'lemma': None, 'text': '('},
+ {'id': 'w6', 'pos': 'NN', 'lemma': None, 'text': 'PCL'},
+ {'id': 'w7', 'pos': 'PUNCT', 'lemma': None, 'text': ')'},
+ {'id': 'w8', 'pos': 'VBZ', 'lemma': 'be', 'text': 'is'},
+ {'id': 'w9', 'pos': 'DT', 'lemma': 'the', 'text': 'the'},
+ {'id': 'w10', 'pos': 'JJS', 'lemma': 'strong', 'text': 'strongest'},
+ {'id': 'w11', 'pos': 'NN', 'lemma': 'ligament', 'text': 'ligament'},
+ {'id': 'w12', 'pos': 'IN', 'lemma': 'of', 'text': 'of'},
+ {'id': 'w13', 'pos': 'DT', 'lemma': 'the', 'text': 'the'},
+ {'id': 'w14', 'pos': 'JJ', 'lemma': 'human', 'text': 'human'},
+ {'id': 'w15', 'pos': 'NN', 'lemma': 'knee', 'text': 'knee'},
+ {'id': 'w16', 'pos': 'JJ', 'lemma': 'joint', 'text': 'joint'},
+ {'id': 'w17', 'pos': 'PUNCT', 'lemma': None, 'text': '.'}]
+
+
+In [36]: dsd['train'][0]['sentences'][0]['semrels'][0]
+Out[36]: {'id': 'r1', 'term1': 't3.1', 'term2': 't6.1', 'reltype': 'surrounds'}
+
+In [37]: dsd['train'][0]['sentences'][0]['umlsterms'][2]
+Out[37]:
+{'id': 't3',
+ 'from': 'w11',
+ 'to': 'w11',
+ 'concepts': [{'id': 't3.1',
+   'cui': 'C0023685',
+   'preferred': 'Ligaments',
+   'tui': 'T024',
+   'mshs': [{'code': 'A2.513'}]},
+  {'id': 't3.2',
+   'cui': 'C0023686',
+   'preferred': 'Articular ligaments',
+   'tui': 'T023',
+   'mshs': [{'code': 'A2.513.514'}, {'code': 'A2.835.583.512'}]}]}
+
+In [38]: dsd['train'][0]['sentences'][0]['umlsterms'][5]
+Out[38]:
+{'id': 't6',
+ 'from': 'w16',
+ 'to': 'w16',
+ 'concepts': [{'id': 't6.1',
+   'cui': 'C0022417',
+   'preferred': 'Joints',
+   'tui': 'T030',
+   'mshs': [{'code': 'A2.835.583'}]}]}
+
+"""
+
+import itertools
+import os
+import re
+import tarfile
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from typing import Dict, List
+from xml.etree.ElementTree import Element
+
+import datasets
+from datasets import Features, Value
+
+# TODO: home page has a list of publications but its not clear which to choose
+# https://muchmore.dfki.de/papers1.htm
+# to start, chose the one below.
+# Buitelaar, Paul / Declerck, Thierry / Sacaleanu, Bogdan / Vintar, Spela / Raileanu, Diana / Crispi, Claudia: A Multi-Layered, XML-Based Approach to the Integration of Linguistic and Semantic Annotations. In: Proceedings of EACL 2003 Workshop on Language Technology and the Semantic Web (NLPXML’03), Budapest, Hungary, April 2003.
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English', 'German']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{buitelaar2003multi,
+  title={A multi-layered, xml-based approach to the integration of linguistic and semantic annotations},
+  author={Buitelaar, Paul and Declerck, Thierry and Sacaleanu, Bogdan and Vintar, {\v{S}}pela and Raileanu, Diana and Crispi, Claudia},
+  booktitle={Proceedings of EACL 2003 Workshop on Language Technology and the Semantic Web (NLPXML'03), Budapest, Hungary},
+  year={2003}
+}
+"""
+
+_DESCRIPTION = """\
+The corpus used in the MuchMore project is a parallel corpus of English-German scientific
+medical abstracts obtained from the Springer Link web site. The corpus consists
+approximately of 1 million tokens for each language. Abstracts are from 41 medical
+journals, each of which constitutes a relatively homogeneous medical sub-domain (e.g.
+Neurology, Radiology, etc.). The corpus of downloaded HTML documents is normalized in
+various ways, in order to produce a clean, plain text version, consisting of a title, abstract
+and keywords. Additionally, the corpus was aligned on the sentence level.
+
+Automatic (!) annotation includes: Part-of-Speech; Morphology (inflection and
+decomposition); Chunks; Semantic Classes (UMLS: Unified Medical Language System,
+MeSH: Medical Subject Headings, EuroWordNet); Semantic Relations from UMLS.
+"""
+
+_DATASETNAME = "muchmore"
+_DISPLAYNAME = "MuchMore"
+
+_HOMEPAGE = "https://muchmore.dfki.de/resources1.htm"
+
+# TODO: website says the following, but don't see a specific license
+# TODO: add to FAQs about what to do in this situation.
+
+# "The cross-lingual information access prototype system for the medical domain
+# will be made publicly accessible through the internet. It provides access to
+# multilingual information on the basis of a domain ontology and classification.
+# For the main task of multilingual domain modelling, the project will focus
+# on German and English. "
+_LICENSE = 'License information unavailable'
+_URLs = {
+    "muchmore_source": [
+        "https://muchmore.dfki.de/pubs/springer_english_train_plain.tar.gz",
+        "https://muchmore.dfki.de/pubs/springer_english_train_V4.2.tar.gz",
+        "https://muchmore.dfki.de/pubs/springer_german_train_plain.tar.gz",
+        "https://muchmore.dfki.de/pubs/springer_german_train_V4.2.tar.gz",
+    ],
+    "muchmore_bigbio_kb": [
+        "https://muchmore.dfki.de/pubs/springer_english_train_V4.2.tar.gz",
+        "https://muchmore.dfki.de/pubs/springer_german_train_V4.2.tar.gz",
+    ],
+    "muchmore_en_bigbio_kb": "https://muchmore.dfki.de/pubs/springer_english_train_V4.2.tar.gz",
+    "muchmore_de_bigbio_kb": "https://muchmore.dfki.de/pubs/springer_german_train_V4.2.tar.gz",
+    "plain": [
+        "https://muchmore.dfki.de/pubs/springer_english_train_plain.tar.gz",
+        "https://muchmore.dfki.de/pubs/springer_german_train_plain.tar.gz",
+    ],
+    "plain_en": "https://muchmore.dfki.de/pubs/springer_english_train_plain.tar.gz",
+    "plain_de": "https://muchmore.dfki.de/pubs/springer_german_train_plain.tar.gz",
+    "muchmore_bigbio_t2t": [
+        "https://muchmore.dfki.de/pubs/springer_english_train_plain.tar.gz",
+        "https://muchmore.dfki.de/pubs/springer_german_train_plain.tar.gz",
+    ],
+}
+
+# took version from annotated file names
+_SOURCE_VERSION = "4.2.0"
+_BIGBIO_VERSION = "1.0.0"
+_SUPPORTED_TASKS = [
+    Tasks.TRANSLATION,
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.NAMED_ENTITY_DISAMBIGUATION,
+    Tasks.RELATION_EXTRACTION,
+]
+
+NATIVE_ENCODING = "ISO-8859-1"
+FILE_NAME_PATTERN = r"^(.+?)\.(eng|ger)\.abstr(\.chunkmorph\.annotated\.xml)?$"
+LANG_MAP = {"eng": "en", "ger": "de"}
+
+
+class MuchMoreDataset(datasets.GeneratorBasedBuilder):
+    """MuchMore Springer Bilingual Corpus"""
+
+    DEFAULT_CONFIG_NAME = "muchmore_source"
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="muchmore_source",
+            version=SOURCE_VERSION,
+            description="MuchMore source schema",
+            schema="source",
+            subset_id="muchmore",
+        ),
+        BigBioConfig(
+            name="muchmore_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="MuchMore simplified BigBio kb schema",
+            schema="bigbio_kb",
+            subset_id="muchmore",
+        ),
+        BigBioConfig(
+            name="muchmore_en_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="MuchMore simplified BigBio kb schema",
+            schema="bigbio_kb",
+            subset_id="muchmore_en",
+        ),
+        BigBioConfig(
+            name="muchmore_de_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="MuchMore simplified BigBio kb schema",
+            schema="bigbio_kb",
+            subset_id="muchmore_de",
+        ),
+        BigBioConfig(
+            name="muchmore_bigbio_t2t",
+            version=BIGBIO_VERSION,
+            description="MuchMore simplified BigBio translation schema",
+            schema="bigbio_t2t",
+            subset_id="muchmore",
+        ),
+    ]
+
+    # default config produces english annotations at the moment
+    def _info(self):
+
+        if self.config.schema == "source":
+            features = Features(
+                {
+                    "sample_id": Value("string"),
+                    "corresp": Value("string"),
+                    "language": Value("string"),
+                    "abstract": Value("string"),
+                    "sentences": [
+                        {
+                            "id": Value("string"),
+                            "corresp": Value("string"),
+                            "umlsterms": [
+                                {
+                                    "id": Value("string"),
+                                    "from": Value("string"),
+                                    "to": Value("string"),
+                                    "concepts": [
+                                        {
+                                            "id": Value("string"),
+                                            "cui": Value("string"),
+                                            "preferred": Value("string"),
+                                            "tui": Value("string"),
+                                            "mshs": [
+                                                {
+                                                    "code": Value("string"),
+                                                }
+                                            ],
+                                        }
+                                    ],
+                                }
+                            ],
+                            "ewnterms": [
+                                {
+                                    "id": Value("string"),
+                                    "to": Value("string"),
+                                    "from": Value("string"),
+                                    "senses": [
+                                        {
+                                            "offset": Value("string"),
+                                        }
+                                    ],
+                                }
+                            ],
+                            "semrels": [
+                                {
+                                    "id": Value("string"),
+                                    "term1": Value("string"),
+                                    "term2": Value("string"),
+                                    "reltype": Value("string"),
+                                }
+                            ],
+                            "chunks": [
+                                {
+                                    "id": Value("string"),
+                                    "to": Value("string"),
+                                    "from": Value("string"),
+                                    "type": Value("string"),
+                                }
+                            ],
+                            "tokens": [
+                                {
+                                    "id": Value("string"),
+                                    "pos": Value("string"),
+                                    "lemma": Value("string"),
+                                    "text": Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        elif self.config.name in ("plain", "plain_en", "plain_de"):
+            features = Features(
+                {
+                    "sample_id": Value("string"),
+                    "sample_id_prefix": Value("string"),
+                    "language": Value("string"),
+                    "abstract": Value("string"),
+                }
+            )
+
+        elif self.config.schema == "bigbio_t2t":
+            features = text2text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            supervised_keys=None,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+        my_urls = _URLs[self.config.name]
+        data_dirs = dl_manager.download(my_urls)
+        # ensure that data_dirs is always a list of string paths
+        if isinstance(data_dirs, str):
+            data_dirs = [data_dirs]
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "file_names_and_pointers": itertools.chain(
+                        *[dl_manager.iter_archive(data_dir) for data_dir in data_dirs]
+                    ),
+                    "split": "train",
+                },
+            ),
+        ]
+
+    @staticmethod
+    def _get_umlsterms_from_xsent(xsent: Element) -> List:
+        xumlsterms = xsent.find("./umlsterms")
+
+        umlsterms = []
+        for xumlsterm in xumlsterms.findall("./umlsterm"):
+
+            concepts = []
+            for xconcept in xumlsterm.findall("./concept"):
+
+                mshs = [
+                    {"code": xmsh.get("code")} for xmsh in xconcept.findall("./msh")
+                ]
+
+                concept = {
+                    "id": xconcept.get("id"),
+                    "cui": xconcept.get("cui"),
+                    "preferred": xconcept.get("preferred"),
+                    "tui": xconcept.get("tui"),
+                    "mshs": mshs,
+                }
+                concepts.append(concept)
+
+            umlsterm = {
+                "id": xumlsterm.get("id"),
+                "from": xumlsterm.get("from"),
+                "to": xumlsterm.get("to"),
+                "concepts": concepts,
+            }
+            umlsterms.append(umlsterm)
+
+        return umlsterms
+
+    @staticmethod
+    def _get_ewnterms_from_xsent(xsent: Element) -> List:
+        xewnterms = xsent.find("./ewnterms")
+
+        ewnterms = []
+        for xewnterm in xewnterms.findall("./ewnterm"):
+
+            senses = [
+                {"offset": xsense.get("offset")}
+                for xsense in xewnterm.findall("./sense")
+            ]
+
+            ewnterm = {
+                "id": xewnterm.get("id"),
+                "from": xewnterm.get("from"),
+                "to": xewnterm.get("to"),
+                "senses": senses,
+            }
+            ewnterms.append(ewnterm)
+
+        return ewnterms
+
+    @staticmethod
+    def _get_semrels_from_xsent(xsent: Element) -> List[Dict[str, str]]:
+        xsemrels = xsent.find("./semrels")
+        return [
+            {
+                "id": xsemrel.get("id"),
+                "term1": xsemrel.get("term1"),
+                "term2": xsemrel.get("term2"),
+                "reltype": xsemrel.get("reltype"),
+            }
+            for xsemrel in xsemrels.findall("./semrel")
+        ]
+
+    @staticmethod
+    def _get_chunks_from_xsent(xsent: Element) -> List[Dict[str, str]]:
+        xchunks = xsent.find("./chunks")
+        return [
+            {
+                "id": xchunk.get("id"),
+                "to": xchunk.get("to"),
+                "from": xchunk.get("from"),
+                "type": xchunk.get("type"),
+            }
+            for xchunk in xchunks.findall("./chunk")
+        ]
+
+    @staticmethod
+    def _get_tokens_from_xsent(xsent: Element) -> List[Dict[str, str]]:
+        xtext = xsent.find("./text")
+        return [
+            {
+                "id": xtoken.get("id"),
+                "pos": xtoken.get("pos"),
+                "lemma": xtoken.get("lemma"),
+                "text": xtoken.text,
+            }
+            for xtoken in xtext.findall("./token")
+        ]
+
+    def _generate_original_examples(self, file_names_and_pointers):
+        """Generate something close to the original dataset.
+
+        This will yield one sample per abstract with the plaintext
+        and the annotations combined into one object. If an abstract
+        is available in both english and german each language version
+        will be a distinct example.
+        """
+        abstracts = {}
+        samples = {}
+        for file_name, fp in file_names_and_pointers:
+
+            if file_name.endswith(".abstr"):
+                sample_id = file_name
+                abstracts[sample_id] = fp.read().decode(NATIVE_ENCODING)
+
+            elif file_name.endswith(".abstr.chunkmorph.annotated.xml"):
+                content_bytes = fp.read()
+                content_str = content_bytes.decode(NATIVE_ENCODING)
+                if content_str == "":
+                    continue
+
+                xroot = ET.fromstring(content_str)
+
+                sentences = []
+                for xsent in xroot.findall("./"):
+                    sentence = {
+                        "id": xsent.get("id"),
+                        "corresp": xsent.get("corresp"),
+                        "umlsterms": self._get_umlsterms_from_xsent(xsent),
+                        "ewnterms": self._get_ewnterms_from_xsent(xsent),
+                        "semrels": self._get_semrels_from_xsent(xsent),
+                        "chunks": self._get_chunks_from_xsent(xsent),
+                        "tokens": self._get_tokens_from_xsent(xsent),
+                    }
+                    sentences.append(sentence)
+
+                sample_id = xroot.get("id")
+                samples[sample_id] = {
+                    "sample_id": sample_id,
+                    "corresp": xroot.get("corresp"),
+                    "language": xroot.get("lang"),
+                    "sentences": sentences,
+                }
+
+        for _id, (sample_id, sample) in enumerate(samples.items()):
+            sample["abstract"] = abstracts[sample_id]
+            yield _id, sample
+
+    def _generate_bigbio_kb_examples(self, file_names_and_pointers):
+        """Generate big science biomedical kb examples."""
+
+        def snippets_tokens_from_sents(sentences):
+            snippets = []
+            for sentence in sentences:
+                snippet = [el["text"] for el in sentence["tokens"]]
+                snippets.append(snippet)
+            return snippets
+
+        def sid_to_text_off(sid, snip_txts_lens):
+            ii_sid = int(sid[1:])
+            start = sum(snip_txts_lens[: ii_sid - 1]) + (ii_sid - 1)
+            end = start + snip_txts_lens[ii_sid - 1]
+            return start, end
+
+        def sid_wid_to_text_off(sid, wid, snip_txts_lens, snip_toks_lens):
+            s_start, s_end = sid_to_text_off(sid, snip_txts_lens)
+            ii_sid = int(sid[1:])
+            ii_wid = int(wid[1:])
+            w_start = sum(snip_toks_lens[ii_sid - 1][: ii_wid - 1]) + (ii_wid - 1)
+            start = s_start + w_start
+            end = start + snip_toks_lens[ii_sid - 1][ii_wid - 1]
+            return start, end
+
+        for _id, (file_name, fp) in enumerate(file_names_and_pointers):
+
+            content_bytes = fp.read()
+            content_str = content_bytes.decode(NATIVE_ENCODING)
+            if content_str == "":
+                continue
+
+            xroot = ET.fromstring(content_str)
+
+            sentences = []
+            for xsent in xroot.findall("./"):
+                sentence = {
+                    "id": xsent.get("id"),
+                    "corresp": xsent.get("corresp"),
+                    "umlsterms": self._get_umlsterms_from_xsent(xsent),
+                    "ewnterms": self._get_ewnterms_from_xsent(xsent),
+                    "semrels": self._get_semrels_from_xsent(xsent),
+                    "chunks": self._get_chunks_from_xsent(xsent),
+                    "tokens": self._get_tokens_from_xsent(xsent),
+                }
+                sentences.append(sentence)
+
+            snip_toks = snippets_tokens_from_sents(sentences)
+            snip_txts = [" ".join(snip_tok) for snip_tok in snip_toks]
+            snip_txts_lens = [len(el) for el in snip_txts]
+            snip_toks_lens = [[len(tok) for tok in snip] for snip in snip_toks]
+            text = " ".join(snip_txts)
+            passages = [
+                {
+                    "id": "{}-passage-0".format(xroot.get("id")),
+                    "type": "abstract",
+                    "text": [text],
+                    "offsets": [(0, len(text))],
+                }
+            ]
+
+            entities = []
+            rel_map = {}
+            for sentence in sentences:
+                sid = sentence["id"]
+                ii_sid = int(sid[1:])
+
+                for umlsterm in sentence["umlsterms"]:
+                    umlsterm_id = umlsterm["id"]
+                    entity_id = f"{sid}-{umlsterm_id}"
+                    wid_from = umlsterm["from"]
+                    wid_to = umlsterm["to"]
+                    ii_wid_from = int(wid_from[1:])
+                    ii_wid_to = int(wid_to[1:])
+
+                    tok_text = " ".join(
+                        snip_toks[ii_sid - 1][ii_wid_from - 1 : ii_wid_to]
+                    )
+                    w_from_start, w_from_end = sid_wid_to_text_off(
+                        sid, wid_from, snip_txts_lens, snip_toks_lens
+                    )
+                    w_to_start, w_to_end = sid_wid_to_text_off(
+                        sid, wid_to, snip_txts_lens, snip_toks_lens
+                    )
+
+                    offsets = [(w_from_start, w_to_end)]
+                    main_text = text[w_from_start:w_to_end]
+                    umls_cuis = [el["cui"] for el in umlsterm["concepts"]]
+                    for concept in umlsterm["concepts"]:
+                        rel_map[concept["id"]] = entity_id
+
+                    entity = {
+                        "id": "{}-{}".format(xroot.get("id"), entity_id),
+                        "offsets": offsets,
+                        "text": [tok_text],
+                        "type": "umlsterm",
+                        "normalized": [
+                            {"db_name": "UMLS", "db_id": cui} for cui in umls_cuis
+                        ],
+                    }
+                    entities.append(entity)
+
+            relations = []
+            for sentence in sentences:
+                sid = sentence["id"]
+                for semrel in sentence["semrels"]:
+                    semrel_id = semrel["id"]
+                    rel_id = "{}-{}-{}-{}".format(
+                        sid, semrel_id, semrel["term1"], semrel["term2"],
+                    )
+                    arg1_id = "{}-{}".format(xroot.get("id"), rel_map[semrel["term1"]])
+                    arg2_id = "{}-{}".format(xroot.get("id"), rel_map[semrel["term2"]])
+                    # some semrels are between multiple normalizations of
+                    # a single entity. we skip these. see docstring at top
+                    # of module for more complete description
+                    if arg1_id == arg2_id:
+                        continue
+                    relation = {
+                        "id": "{}-{}".format(xroot.get("id"), rel_id),
+                        "type": semrel["reltype"],
+                        "arg1_id": arg1_id,
+                        "arg2_id": arg2_id,
+                        "normalized": []
+                    }
+                    relations.append(relation)
+
+            yield _id, {
+                "id": xroot.get("id"),
+                "document_id": xroot.get("id"),
+                "passages": passages,
+                "entities": entities,
+                "coreferences": [],
+                "events": [],
+                "relations": relations,
+            }
+
+    def _generate_plain_examples(self, file_names_and_pointers):
+        """Generate plain text abstract examples."""
+        for _id, (file_name, fp) in enumerate(file_names_and_pointers):
+            match = re.match(FILE_NAME_PATTERN, file_name)
+            yield _id, {
+                "sample_id_prefix": match.group(1),
+                "sample_id": file_name,
+                "language": LANG_MAP[match.group(2)],
+                "abstract": fp.read().decode(NATIVE_ENCODING),
+            }
+
+    def _generate_translation_examples(self, file_names_and_pointers):
+        sample_map = defaultdict(list)
+        for file_name, fp in file_names_and_pointers:
+            if file_name.endswith("eng.abstr"):
+                language = "en"
+            elif file_name.endswith("ger.abstr"):
+                language = "de"
+            else:
+                raise ValueError()
+            sample_id_prefix = re.sub(".(eng|ger).abstr$", "", file_name)
+            sample_id = file_name
+            abstract = fp.read().decode(NATIVE_ENCODING)
+            sample_map[sample_id_prefix].append(
+                {"language": language, "sample_id": sample_id, "abstract": abstract}
+            )
+
+        _id = 0
+        for sample_id_prefix, sample_pair in sample_map.items():
+            if len(sample_pair) != 2:
+                continue
+            en_idx = 0 if sample_pair[0]["language"] == "en" else 1
+            de_idx = 0 if en_idx == 1 else 1
+            yield _id, {
+                "id": sample_id_prefix,
+                "document_id": sample_id_prefix,
+                "text_1": sample_pair[en_idx]["abstract"],
+                "text_2": sample_pair[de_idx]["abstract"],
+                "text_1_name": "en",
+                "text_2_name": "de",
+            }
+            _id += 1
+
+    def _generate_examples(self, file_names_and_pointers, split):
+
+        if self.config.schema == "source":
+            genny = self._generate_original_examples(file_names_and_pointers)
+
+        elif self.config.schema == "bigbio_kb":
+            genny = self._generate_bigbio_kb_examples(file_names_and_pointers)
+
+        elif self.config.name in ("plain", "plain_en", "plain_de"):
+            genny = self._generate_plain_examples(file_names_and_pointers)
+
+        elif self.config.schema == "bigbio_t2t":
+            genny = self._generate_translation_examples(file_names_and_pointers)
+
+        for _id, sample in genny:
+            yield _id, sample

--- a/hub/hubscripts/multi_xscience_hub.py
+++ b/hub/hubscripts/multi_xscience_hub.py
@@ -1,0 +1,205 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+from typing import List
+
+import datasets
+
+from .bigbiohub import text2text_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@misc{https://doi.org/10.48550/arxiv.2010.14235,
+  doi = {10.48550/ARXIV.2010.14235},
+  
+  url = {https://arxiv.org/abs/2010.14235},
+  
+  author = {Lu, Yao and Dong, Yue and Charlin, Laurent},
+  
+  keywords = {Computation and Language (cs.CL), Artificial Intelligence (cs.AI), FOS: Computer and information sciences, FOS: Computer and information sciences},
+  
+  title = {Multi-XScience: A Large-scale Dataset for Extreme Multi-document Summarization of Scientific Articles},
+  
+  publisher = {arXiv},
+  
+  year = {2020},
+  
+  copyright = {arXiv.org perpetual, non-exclusive license}
+}
+"""
+
+_DATASETNAME = "multi_xscience"
+_DISPLAYNAME = "Multi-XScience"
+
+_DESCRIPTION = """\
+Multi-document summarization is a challenging task for which there exists little large-scale datasets. 
+We propose Multi-XScience, a large-scale multi-document summarization dataset created from scientific articles. 
+Multi-XScience introduces a challenging multi-document summarization task: writing the related-work section 
+of a paper based on its abstract and the articles it references. Our work is inspired by extreme summarization, 
+a dataset construction protocol that favours abstractive modeling approaches. Descriptive statistics and 
+empirical results---using several state-of-the-art models trained on the Multi-XScience dataset---reveal t
+hat Multi-XScience is well suited for abstractive models.
+"""
+
+_HOMEPAGE = "https://github.com/yaolu/Multi-XScience"
+
+_LICENSE = 'MIT License'
+
+_URLS = {
+    _DATASETNAME: [
+        "https://github.com/yaolu/Multi-XScience/blob/master/data/train.json.gz?raw=true",
+        "https://github.com/yaolu/Multi-XScience/blob/master/data/test.json.gz?raw=true",
+        "https://github.com/yaolu/Multi-XScience/blob/master/data/val.json.gz?raw=true",
+    ],
+}
+
+_SUPPORTED_TASKS = [Tasks.PARAPHRASING, Tasks.SUMMARIZATION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class MultiXScience(datasets.GeneratorBasedBuilder):
+    """
+    Dataset for the EMNLP 2020 paper, Multi-XScience:
+    A Large-scale Dataset for Extreme Multi-document Summarization
+    of Scientific Articles.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="multi_xscience_source",
+            version=SOURCE_VERSION,
+            description="multi_xscience source schema",
+            schema="source",
+            subset_id="multi_xscience",
+        ),
+        BigBioConfig(
+            name="multi_xscience_bigbio_t2t",
+            version=BIGBIO_VERSION,
+            description="multi_xscienceBigBio schema",
+            schema="bigbio_t2t",
+            subset_id="multi_xscience",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "multi_xscience_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "aid": datasets.Value("string"),
+                    "mid": datasets.Value("string"),
+                    "abstract": datasets.Value("string"),
+                    "ref_abstract": datasets.Sequence(
+                        {
+                            "mid": datasets.Value("string"),
+                            "abstract": datasets.Value("string"),
+                        }
+                    ),
+                }
+            )
+        elif self.config.schema == "bigbio_t2t":
+            features = text2text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir[0]).replace("\\", "/"),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir[1]).replace("\\", "/"),
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir[2]).replace("\\", "/"),
+                    "split": "val",
+                },
+            ),
+        ]
+
+    # method parameters are unpacked from `gen_kwargs` as given in `_split_generators`
+
+    def _generate_examples(self, filepath, split):
+        j_file = open(filepath, "r")
+        j_file.seek(0)
+        j_json = json.load(j_file)
+
+        if self.config.schema == "source":
+            for key, example in enumerate(j_json):
+                yield key, {
+                    "aid": example["aid"],
+                    "mid": example["mid"],
+                    "abstract": example["abstract"],
+                    "ref_abstract": [
+                        {
+                            "mid": example["ref_abstract"][key]["mid"],
+                            "abstract": example["ref_abstract"][key]["abstract"],
+                        }
+                        for key in example["ref_abstract"].keys()
+                    ],
+                }
+
+        elif self.config.schema == "bigbio_t2t":
+            uid = 0
+
+            for key, example in enumerate(j_json):
+                uid += 1
+                yield key, {
+                    "id": str(uid),
+                    "document_id": str(key),
+                    "text_1": example["abstract"],
+                    "text_2": " ".join(
+                        [e["abstract"] for e in example["ref_abstract"].values()]
+                    ),
+                    "text_1_name": "Abstract of query paper",
+                    "text_2_name": "Cite abstracts",
+                }
+
+        j_file.close()

--- a/hub/hubscripts/n2c2_2006_deid_hub.py
+++ b/hub/hubscripts/n2c2_2006_deid_hub.py
@@ -1,0 +1,362 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+A dataset loader for the n2c2 2006 de-identification dataset.
+
+https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/
+
+The dataset consists of two archive files,
+
+* deid_surrogate_train_all_version2.zip
+* deid_surrogate_test_all_groundtruth_version2.zip
+
+The individual data files (inside the zip archives) come in just 1 type:
+
+* xml (*.xml files): contains the id and text of the patient records,
+and the corresponding tags for each one of the Patient Health information (PHI)
+categories: Patients, Doctors, Hospitals, IDs, Dates, Locations, Phone Numbers, and Ages
+
+
+The files comprising this dataset must be on the users local machine
+in a single directory that is passed to `datasets.load_datset` via
+the `data_dir` kwarg. This loader script will read the archive files
+directly (i.e. the user should not uncompress, untar or unzip any of
+the files). For example, if the following directory structure exists
+on the users local machine,
+
+
+n2c2_2006_deid
+├── deid_surrogate_train_all_version2.zip
+├── deid_surrogate_test_all_groundtruth_version2.zip
+
+
+Data Access
+
+from https://www.i2b2.org/NLP/DataSets/Main.php
+
+"As always, you must register AND submit a DUA for access. If you previously
+accessed the data sets here on i2b2.org, you will need to set a new password
+for your account on the Data Portal, but your original DUA will be retained."
+
+
+"""
+import itertools as it
+import os
+import re
+import xml.etree.ElementTree as et
+import zipfile
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "n2c2_2006"
+_DISPLAYNAME = "n2c2 2006 De-identification"
+
+# https://academic.oup.com/jamia/article/14/5/550/720189
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = True
+_CITATION = """\
+@article{uzuner2007evaluating,
+    author = {
+        Uzuner, Özlem and
+        Luo, Yuan and
+        Szolovits, Peter
+    },
+    title     = {Evaluating the State-of-the-Art in Automatic De-identification},
+    journal   = {Journal of the American Medical Informatics Association},
+    volume    = {14},
+    number    = {5},
+    pages     = {550-563},
+    year      = {2007},
+    month     = {09},
+    url       = {https://doi.org/10.1197/jamia.M2444},
+    doi       = {10.1197/jamia.M2444},
+    eprint    = {https://academic.oup.com/jamia/article-pdf/14/5/550/2136261/14-5-550.pdf}
+}
+"""
+
+_DESCRIPTION = """\
+The data for the de-identification challenge came from Partners Healthcare and
+included solely medical discharge summaries. We prepared the data for the
+challengeby annotating and by replacing all authentic PHI with realistic
+surrogates.
+
+Given the above definitions, we marked the authentic PHI in the records in two stages.
+In the first stage, we used an automatic system.31 In the second stage, we validated
+the output of the automatic system manually. Three annotators, including undergraduate
+and graduate students and a professor, serially made three manual passes over each record.
+They marked and discussed the PHI tags they disagreed on and finalized these tags
+after discussion.
+
+The original dataset does not have spans for each entity. The spans are
+computed in this loader and the final text that correspond with the
+tags is preserved  in the source format
+"""
+
+_HOMEPAGE = "https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/"
+
+_LICENSE = 'Data User Agreement'
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class N2C22006DeidDataset(datasets.GeneratorBasedBuilder):
+    """n2c2 2006 smoking status identification task"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="n2c2_2006_deid_source",
+            version=SOURCE_VERSION,
+            description="n2c2_2006 deid source schema",
+            schema="source",
+            subset_id="n2c2_2006_deid",
+        ),
+        BigBioConfig(
+            name="n2c2_2006_deid_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="n2c2_2006 Deid BigBio schema",
+            schema="bigbio_kb",
+            subset_id="n2c2_2006_deid",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "n2c2_2006_deid_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "record_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "phi": datasets.Sequence(datasets.Value("string")),
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
+        else:
+            data_dir = self.config.data_dir
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "corpus_fname": "deid_surrogate_train_all_version2.zip",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "corpus_fname": "deid_surrogate_test_all_groundtruth_version2.zip",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, data_dir: str, corpus_fname: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        fpath = os.path.join(data_dir, corpus_fname)
+        # samples = _read_zip(path)
+        if self.config.schema == "source":
+            for document in self._generate_parsed_documents(fpath):
+                yield document["record_id"], document
+
+        elif self.config.schema == "bigbio_kb":
+            uid = it.count(0)
+            for document in self._generate_parsed_documents(fpath):
+                document["id"] = next(uid)
+                document["document_id"] = document.pop("record_id")
+                entity_list = document.pop("phi")
+                full_text = document.pop("text")
+                entities_ = []
+                for entity in entity_list:
+                    entities_.append(
+                        {
+                            "id": next(uid),
+                            "type": entity["type"],
+                            "text": entity["text"],
+                            "offsets": entity["offsets"],
+                            "normalized": entity["normalized"],
+                        }
+                    )
+                document["entities"] = entities_
+
+                document["passages"] = [
+                    {
+                        "id": next(uid),
+                        "type": "full_text",
+                        "text": [full_text],
+                        "offsets": [[0, len(full_text)]],
+                    },
+                ]
+
+                # additional fields required that can be empty
+                document["relations"] = []
+                document["events"] = []
+                document["coreferences"] = []
+                yield document["document_id"], document
+
+    def _generate_parsed_documents(self, file_path):
+        _, filename = os.path.split(file_path)
+        zipped = zipfile.ZipFile(file_path, "r")
+        file = zipped.read(filename.split(".")[0] + ".xml")
+
+        # There is an issue with the train file. There is a bad tag in line 25722
+        if filename == "deid_surrogate_train_all_version2.zip":
+            bad_tag = """<PHI TYPE="DATE">25th of July<PHI TYPE="DOCTOR">""".encode(
+                "utf-8"
+            )
+            replacement_tag = """<PHI TYPE="DATE">25th of July</PHI>""".encode("utf-8")
+            file = file.replace(bad_tag, replacement_tag, 1)
+
+        root = et.fromstring(file)
+        documents = root.findall("./RECORD")
+        record_regex = r"<RECORD ID=|</RECORD>"
+        text_regex = r"<TEXT>|</TEXT>"
+        file_string = str(file)
+        record_matches = list(re.finditer(record_regex, file_string))
+        n_matches = len(record_matches)
+        if len(documents) != n_matches / 2:
+            raise ValueError(
+                """the records found thourgh regex are not the
+                                same as the ones found using xmltree"""
+            )
+
+        # counter for the documents in xml
+        k = 0
+        for i in range(0, n_matches, 2):
+
+            # find beginning and end of a section
+            record_start = record_matches[i].span()[1]
+            record_end = record_matches[i + 1].span()[0]
+            record_section = file_string[record_start:record_end]
+
+            # find only the text section
+            text_matches = list(re.finditer(text_regex, record_section))
+            if len(text_matches) > 2:
+                raise ValueError("It should only be one match for text within a record")
+            text_start = text_matches[0].span()[1]
+            text_end = text_matches[1].span()[0]
+
+            # remove new line at the beginning and the end
+            full_text_with_tags = record_section[text_start:text_end].strip("\\n")
+            # Remove special characters
+            full_text_with_tags = self._remove_special_characters(full_text_with_tags)
+
+            # find all the PHI tags to process them one by one
+            document = documents[k]
+            phi_xml_tags = document.findall("./TEXT/PHI")
+            k += 1
+
+            entities, clean_text = self._extract_tags_text_spans(
+                full_text_with_tags=full_text_with_tags, phi_list=phi_xml_tags
+            )
+
+            document_dict = {
+                "record_id": document.attrib["ID"],
+                "text": clean_text,
+                "phi": entities,
+            }
+
+            yield document_dict
+
+    def _extract_tags_text_spans(
+        self, full_text_with_tags: str, phi_list: List[et.Element]
+    ) -> List[Dict]:
+        """
+        Method to extract all PHI tags from within the XML
+        Note: There are entities with the same text but different tags.
+        Example "Head" Type Doctor/Patient
+        Because of this the method needs to check first for it and then assumes the retrieval order
+        by the xml library and get the proper spans for each one
+        """
+
+        entities = []
+        for phi in phi_list:
+            entity_text = phi.text
+            entity_type = phi.attrib["TYPE"]
+            phi_regex = re.escape(f"""<PHI TYPE="{entity_type}">{entity_text}</PHI>""")
+            phi_match = re.search(phi_regex, full_text_with_tags)
+            if phi_match is None:
+                print(phi_regex)
+                raise ValueError(f"PHI tag {phi_regex} not found")
+
+            entity_start = phi_match.span()[0]
+            entity_end = entity_start + len(entity_text)
+
+            # Substitute in the original text to eliminate the current tag
+            # only replace the first occurrence
+            full_text_with_tags = re.sub(
+                pattern=phi_regex, repl=entity_text, string=full_text_with_tags, count=1
+            )
+
+            # check that the text within the span is the same as the entity text
+            if entity_text != full_text_with_tags[entity_start:entity_end]:
+                raise ValueError("Entity text does not have the correct span")
+
+            # save the entities
+            entities.append(
+                {
+                    "text": [entity_text],
+                    "type": entity_type,
+                    "offsets": [[entity_start, entity_end]],
+                    "normalized": [],
+                }
+            )
+
+        # clean the last remaining tag
+        clean_text = re.sub(r"\\n\[ report_end \]", "", full_text_with_tags)
+        return entities, clean_text
+
+    def _remove_special_characters(self, text: str) -> str:
+        result = text.replace("&gt;", ">")
+        result = result.replace("&lt;", "<")
+        result = result.replace("&quot;", '"')
+        result = result.replace("&apos;", "'")
+        return result

--- a/hub/hubscripts/n2c2_2006_smokers_hub.py
+++ b/hub/hubscripts/n2c2_2006_smokers_hub.py
@@ -1,0 +1,257 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+A dataset loader for the n2c2 2006 smoking status dataset.
+
+https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/
+
+The dataset consists of two archive files,
+
+* smokers_surrogate_train_all_version2.zip
+* smokers_surrogate_test_all_groundtruth_version2.zip
+
+The individual data files (inside the zip archives) come in just 1 type:
+
+* xml (*.xml files): contains the id and text of the patient records,
+and corresponding smoking status labels
+
+
+The files comprising this dataset must be on the users local machine
+in a single directory that is passed to `datasets.load_datset` via
+the `data_dir` kwarg. This loader script will read the archive files
+directly (i.e. the user should not uncompress, untar or unzip any of
+the files). For example, if the following directory structure exists
+on the users local machine,
+
+
+n2c2_2006
+├── smokers_surrogate_train_all_version2.zip
+├── smokers_surrogate_test_all_groundtruth_version2.zip
+
+
+Data Access
+
+from https://www.i2b2.org/NLP/DataSets/Main.php
+
+"As always, you must register AND submit a DUA for access. If you previously
+accessed the data sets here on i2b2.org, you will need to set a new password
+for your account on the Data Portal, but your original DUA will be retained."
+
+
+"""
+
+import os
+import xml.etree.ElementTree as et
+import zipfile
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import text_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "n2c2_2006"
+_DISPLAYNAME = "n2c2 2006 Smoking Status"
+
+# https://academic.oup.com/jamia/article/15/1/14/779738
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = True
+_CITATION = """\
+@article{uzuner2008identifying,
+    author = {
+        Uzuner, Ozlem and
+        Goldstein, Ira and
+        Luo, Yuan and
+        Kohane, Isaac
+    },
+    title     = {Identifying Patient Smoking Status from Medical Discharge Records},
+    journal   = {Journal of the American Medical Informatics Association},
+    volume    = {15},
+    number    = {1},
+    pages     = {14-24},
+    year      = {2008},
+    month     = {01},
+    url       = {https://doi.org/10.1197/jamia.M2408},
+    doi       = {10.1136/amiajnl-2011-000784},
+    eprint    = {https://academic.oup.com/jamia/article-pdf/15/1/14/2339646/15-1-14.pdf}
+}
+"""
+
+_DESCRIPTION = """\
+The data for the n2c2 2006 smoking challenge consisted of discharge summaries
+from Partners HealthCare, which were then de-identified, tokenized, broken into
+sentences, converted into XML format, and separated into training and test sets.
+
+Two pulmonologists annotated each record with the smoking status of patients based
+strictly on the explicitly stated smoking-related facts in the records. These
+annotations constitute the textual judgments of the annotators. The annotators
+were asked to classify patient records into five possible smoking status categories:
+a past smoker, a current smoker, a smoker, a non-smoker and an unknown. A total of
+502 de-identified medical discharge records were used for the smoking challenge.
+"""
+
+_HOMEPAGE = "https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/"
+
+_LICENSE = 'Data User Agreement'
+
+_SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+_CLASS_NAMES = ["current smoker", "non-smoker", "past smoker", "smoker", "unknown"]
+
+
+def _read_zip(file_path):
+    _, filename = os.path.split(file_path)
+    zipped = zipfile.ZipFile(file_path, "r")
+    file = zipped.read(filename.split(".")[0] + ".xml")
+
+    root = et.fromstring(file)
+    ids = []
+    notes = []
+    labels = []
+    documents = root.findall("./RECORD")
+    for document in documents:
+        ids.append(document.attrib["ID"])
+        notes.append(document.findall("./TEXT")[0].text)
+        labels.append(document.findall("./SMOKING")[0].attrib["STATUS"].lower())
+    return [(id, note, label) for id, note, label in zip(ids, notes, labels)]
+
+
+class N2C22006SmokingDataset(datasets.GeneratorBasedBuilder):
+    """n2c2 2006 smoking status identification task"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="n2c2_2006_smokers_source",
+            version=SOURCE_VERSION,
+            description="n2c2_2006_smokers source schema",
+            schema="source",
+            subset_id="n2c2_2006_smokers",
+        ),
+        BigBioConfig(
+            name="n2c2_2006_smokers_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="n2c2_2006_smokers BigBio schema",
+            schema="bigbio_text",
+            subset_id="n2c2_2006_smokers",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "n2c2_2006_smokers_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "label": datasets.ClassLabel(names=_CLASS_NAMES),
+                }
+            )
+
+        elif self.config.schema == "bigbio_text":
+            features = text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
+        else:
+            data_dir = self.config.data_dir
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "split": "test",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, data_dir, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        if split == "train":
+            _id = 0
+            path = os.path.join(data_dir, "smokers_surrogate_train_all_version2.zip")
+            samples = _read_zip(path)
+            for sample in samples:
+                if self.config.schema == "source":
+                    yield _id, {
+                        "document_id": sample[0],
+                        "text": sample[1],
+                        "label": sample[-1],
+                    }
+                elif self.config.schema == "bigbio_text":
+                    yield _id, {
+                        "id": sample[0],
+                        "document_id": sample[0],
+                        "text": sample[1],
+                        "labels": [sample[-1]],
+                    }
+                _id += 1
+
+        elif split == "test":
+            _id = 0
+            path = os.path.join(
+                data_dir, "smokers_surrogate_test_all_groundtruth_version2.zip"
+            )
+            samples = _read_zip(path)
+            for sample in samples:
+                if self.config.schema == "source":
+                    yield _id, {
+                        "document_id": sample[0],
+                        "text": sample[1],
+                        "label": sample[-1],
+                    }
+                elif self.config.schema == "bigbio_text":
+                    yield _id, {
+                        "id": sample[0],
+                        "document_id": sample[0],
+                        "text": sample[1],
+                        "labels": [sample[-1]],
+                    }
+                _id += 1

--- a/hub/hubscripts/n2c2_2008_hub.py
+++ b/hub/hubscripts/n2c2_2008_hub.py
@@ -1,0 +1,424 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+A dataset loader for the n2c2 2008 obesity and comorbidities dataset.
+
+https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/
+
+The dataset consists of eight xml files,
+
+* obesity_patient_records_training.xml
+* obesity_patient_records_training2.xml
+* obesity_standoff_annotations_training.xml
+* obesity_standoff_annotations_training_addendum.xml
+* obesity_standoff_annotations_training_addendum2.xml
+* obesity_standoff_annotations_training_addendum3.xml
+* obesity_patient_records_test.xml
+* obesity_standoff_annotations_test.xml
+
+containing patient records as well as textual and intuitive annotations.
+
+
+The files comprising this dataset must be on the users local machine
+in a single directory that is passed to `datasets.load_datset` via
+the `data_dir` kwarg. This loader script will read the xml files
+directly. For example, if the following directory structure exists
+on the users local machine,
+
+
+n2c2_2008
+├── obesity_patient_records_training.xml
+├── obesity_patient_records_training2.xml
+├── obesity_standoff_annotations_training.xml
+├── obesity_standoff_annotations_training_addendum.xml
+├── obesity_standoff_annotations_training_addendum2.xml
+├── obesity_standoff_annotations_training_addendum3.xml
+├── obesity_patient_records_test.xml
+├── obesity_standoff_annotations_test.xml
+
+
+Data Access
+
+from https://www.i2b2.org/NLP/DataSets/Main.php
+
+"As always, you must register AND submit a DUA for access. If you previously
+accessed the data sets here on i2b2.org, you will need to set a new password
+for your account on the Data Portal, but your original DUA will be retained."
+
+
+"""
+
+import os
+import xml.etree.ElementTree as et
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import text_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "n2c2_2008"
+_DISPLAYNAME = "n2c2 2008 Obesity"
+
+# https://academic.oup.com/jamia/article/16/4/561/766997
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = True
+_CITATION = """\
+@article{uzuner2009recognizing,
+    author = {
+        Uzuner, Ozlem
+    },
+    title     = {Recognizing Obesity and Comorbidities in Sparse Data},
+    journal   = {Journal of the American Medical Informatics Association},
+    volume    = {16},
+    number    = {4},
+    pages     = {561-570},
+    year      = {2009},
+    month     = {07},
+    url       = {https://doi.org/10.1197/jamia.M3115},
+    doi       = {10.1197/jamia.M3115},
+    eprint    = {https://academic.oup.com/jamia/article-pdf/16/4/561/2302602/16-4-561.pdf}
+}
+"""
+
+_DESCRIPTION = """\
+The data for the n2c2 2008 obesity challenge consisted of discharge summaries from
+the Partners HealthCare Research Patient Data Repository. These data were chosen 
+from the discharge summaries of patients who were overweight or diabetic and had 
+been hospitalized for obesity or diabetes sometime since 12/1/04. De-identification
+was performed semi-automatically. All private health information was replaced with
+synthetic identifiers.
+
+The data for the challenge were annotated by two obesity experts from the 
+Massachusetts General Hospital Weight Center. The experts were given a textual task, 
+which asked them to classify each disease (see list of diseases above) as Present, 
+Absent, Questionable, or Unmentioned based on explicitly documented information in 
+the discharge summaries, e.g., the statement “the patient is obese”. The experts were 
+also given an intuitive task, which asked them to classify each disease as Present, 
+Absent, or Questionable by applying their intuition and judgment to information in 
+the discharge summaries.
+"""
+
+_HOMEPAGE = "https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/"
+
+_LICENSE = 'Data User Agreement'
+
+_SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
+
+_CLASS_NAMES = ["present", "absent", "unmentioned", "questionable"]
+_disease_names = [
+    "Obesity",
+    "Asthma",
+    "CAD",
+    "CHF",
+    "Depression",
+    "Diabetes",
+    "Gallstones",
+    "GERD",
+    "Gout",
+    "Hypercholesterolemia",
+    "Hypertension",
+    "Hypertriglyceridemia",
+    "OA",
+    "OSA",
+    "PVD",
+    "Venous Insufficiency",
+]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+def _map_labels(doc, task):
+    """
+    Map obesity and comorbidity labels.
+    :param doc: a document indexde by id
+    :param task: textual or intuitive annotation task
+    """
+    lmap = {"Y": "present", "N": "absent", "U": "unmentioned", "Q": "questionable"}
+
+    def _map_label(doc, task, label_name):
+        if label_name in doc[task].keys():
+            return lmap[doc[task][label_name]]
+        else:
+            return None
+
+    if task in doc.keys():
+        return {
+            "Obesity": _map_label(doc, task, "Obesity"),
+            "Asthma": _map_label(doc, task, "Asthma"),
+            "CAD": _map_label(doc, task, "CAD"),
+            "CHF": _map_label(doc, task, "CHF"),
+            "Depression": _map_label(doc, task, "Depression"),
+            "Diabetes": _map_label(doc, task, "Diabetes"),
+            "Gallstones": _map_label(doc, task, "Gallstones"),
+            "GERD": _map_label(doc, task, "GERD"),
+            "Gout": _map_label(doc, task, "Gout"),
+            "Hypercholesterolemia": _map_label(doc, task, "Hypercholesterolemia"),
+            "Hypertension": _map_label(doc, task, "Hypertension"),
+            "Hypertriglyceridemia": _map_label(doc, task, "Hypertriglyceridemia"),
+            "OA": _map_label(doc, task, "OA"),
+            "OSA": _map_label(doc, task, "OSA"),
+            "PVD": _map_label(doc, task, "PVD"),
+            "Venous Insufficiency": _map_label(doc, task, "Venous Insufficiency"),
+        }
+    else:
+        return {task: None}
+
+
+def _read_xml(partition, data_dir):
+    """
+    Load the data split.
+    :param partition: train/test
+    :param data_dir: train and test data directory
+    """
+    documents = {}
+    all_diseases = set()
+    notes = tuple()
+    if partition == "train":
+        with open(data_dir / "obesity_patient_records_training.xml") as t1, open(
+            data_dir / "obesity_patient_records_training2.xml"
+        ) as t2:
+            notes1 = t1.read().strip()
+            notes2 = t2.read().strip()
+        notes = (notes1, notes2)
+    elif partition == "test":
+        with open(data_dir / "obesity_patient_records_test.xml") as t1:
+            notes1 = t1.read().strip()
+        notes = (notes1,)
+
+    for file in notes:
+        root = et.fromstring(file)
+        root = root.findall("./docs")[0]
+        for document in root.findall("./doc"):
+            assert document.attrib["id"] not in documents
+            documents[document.attrib["id"]] = {}
+            documents[document.attrib["id"]]["text"] = document.findall("./text")[
+                0
+            ].text
+
+    annotation_files = tuple()
+    if partition == "train":
+        with open(data_dir / "obesity_standoff_annotations_training.xml") as t1, open(
+            data_dir / "obesity_standoff_annotations_training_addendum.xml"
+        ) as t2, open(
+            data_dir / "obesity_standoff_annotations_training_addendum2.xml"
+        ) as t3, open(
+            data_dir / "obesity_standoff_annotations_training_addendum3.xml"
+        ) as t4:
+            train1 = t1.read().strip()
+            train2 = t2.read().strip()
+            train3 = t3.read().strip()
+            train4 = t4.read().strip()
+        annotation_files = (train1, train2, train3, train4)
+    elif partition == "test":
+        with open(data_dir / "obesity_standoff_annotations_test.xml") as t1:
+            test1 = t1.read().strip()
+        annotation_files = (test1,)
+
+    for file in annotation_files:
+        root = et.fromstring(file)
+        for diseases_annotation in root.findall("./diseases"):
+
+            annotation_source = diseases_annotation.attrib["source"]
+            assert isinstance(annotation_source, str)
+            for disease in diseases_annotation.findall("./disease"):
+                disease_name = disease.attrib["name"]
+                all_diseases.add(disease_name)
+                for annotation in disease.findall("./doc"):
+                    doc_id = annotation.attrib["id"]
+                    if not annotation_source in documents[doc_id]:
+                        documents[doc_id][annotation_source] = {}
+                    assert doc_id in documents
+                    judgment = annotation.attrib["judgment"]
+                    documents[doc_id][annotation_source][disease_name] = judgment
+    return [
+        {
+            "document_id": str(id),
+            "text": documents[id]["text"],
+            "textual": _map_labels(documents[id], "textual"),
+            "intuitive": _map_labels(documents[id], "intuitive"),
+        }
+        for id in documents
+    ]
+
+
+class N2C22008ObesityDataset(datasets.GeneratorBasedBuilder):
+    """n2c2 2008 obesity and comorbidities recognition task"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="n2c2_2008_source",
+            version=SOURCE_VERSION,
+            description="n2c2_2008 source schema",
+            schema="source",
+            subset_id="n2c2_2008",
+        ),
+        BigBioConfig(
+            name="n2c2_2008_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="n2c2_2008 BigBio schema",
+            schema="bigbio_text",
+            subset_id="n2c2_2008",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "n2c2_2008_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "labels": [
+                        {
+                            "annotation": datasets.ClassLabel(
+                                names=["textual", "intuitive"]
+                            ),
+                            "disease_name": datasets.ClassLabel(names=_disease_names),
+                            "label": datasets.ClassLabel(names=_CLASS_NAMES),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_text":
+            features = text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
+        else:
+            data_dir = self.config.data_dir
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "split": "test",
+                },
+            ),
+        ]
+
+    @staticmethod
+    def _get_source_sample(sample):
+        textual_labels = [
+            ("textual", disease_name, sample["textual"][disease_name])
+            for disease_name in sample["textual"].keys()
+            if sample["textual"][disease_name]
+        ]
+        intuitive_labels = [
+            ("intuitive", disease_name, sample["intuitive"][disease_name])
+            for disease_name in sample["intuitive"].keys()
+            if sample["intuitive"][disease_name]
+        ]
+
+        return {
+            "document_id": sample["document_id"],
+            "text": sample["text"],
+            "labels": [
+                {
+                    "annotation": label[0],
+                    "disease_name": label[1],
+                    "label": label[2],
+                }
+                for label in textual_labels + intuitive_labels
+            ],
+        }
+
+    @staticmethod
+    def _get_bigbio_sample(sample_id, sample):
+        textual_labels = [
+            ("textual", disease_name, sample["textual"][disease_name])
+            for disease_name in sample["textual"].keys()
+            if sample["textual"][disease_name]
+        ]
+        intuitive_labels = [
+            ("intuitive", disease_name, sample["intuitive"][disease_name])
+            for disease_name in sample["intuitive"].keys()
+            if sample["intuitive"][disease_name]
+        ]
+
+        return {
+            "id": str(sample_id),
+            "document_id": sample["document_id"],
+            "text": sample["text"],
+            "labels": [
+                {
+                    "annotation": label[0],
+                    "disease_name": label[1],
+                    "label": label[2],
+                }
+                for label in textual_labels + intuitive_labels
+            ],
+        }
+
+    def _generate_examples(self, data_dir, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        data_dir = Path(data_dir).resolve()
+        if split == "train":
+            _id = 0
+            samples = _read_xml(split, data_dir)
+            for sample in samples:
+                if self.config.schema == "source":
+                    yield _id, self._get_source_sample(sample)
+
+                elif self.config.schema == "bigbio_text":
+                    yield _id, self._get_bigbio_sample(_id, sample)
+                _id += 1
+
+        elif split == "test":
+            _id = 0
+            samples = _read_xml(split, data_dir)
+            for sample in samples:
+                if self.config.schema == "source":
+                    yield _id, self._get_source_sample(sample)
+
+                elif self.config.schema == "bigbio_text":
+                    yield _id, self._get_bigbio_sample(_id, sample)
+                _id += 1

--- a/hub/hubscripts/n2c2_2009_hub.py
+++ b/hub/hubscripts/n2c2_2009_hub.py
@@ -1,0 +1,684 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and
+#
+# * Ayush Singh (singhay)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A dataset loader for the n2c2 2009 medication dataset.
+
+The dataset consists of three archive files,
+├── annotations_ground_truth.tar.gz
+├── train.test.released.8.17.09.tar.gz
+├── TeamSubmissions.zip
+└── training.sets.released.tar.gz
+
+The individual data files (inside the zip and tar archives) come in 4 types,
+
+* entries (*.entries / no extension files): text of a patient record
+* medications (*.m files): entities along with offsets used as input to a named entity recognition model
+
+The files comprising this dataset must be on the users local machine
+in a single directory that is passed to `datasets.load_dataset` via
+the `data_dir` kwarg. This loader script will read the archive files
+directly (i.e. the user should not uncompress, untar or unzip any of
+the files).
+
+Data Access from https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/
+
+Steps taken to build datasets:
+1. Read all data files from train.test.released.8.17.09
+2. Get IDs of all train files from training.sets.released
+3. Intersect 2 with 1 to get train set
+4. Difference 1 with 2 to get test set
+5. Enrich train set with training.ground.truth.01.06.11.2009
+6. Enrich test set with annotations_ground_truth
+"""
+
+import os
+import re
+import tarfile
+import zipfile
+from collections import defaultdict
+from typing import Dict, List, Match, Tuple, Union
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = True
+_CITATION = """\
+@article{DBLP:journals/jamia/UzunerSC10,
+  author    = {
+                Ozlem Uzuner and
+                Imre Solti and
+                Eithon Cadag
+               },
+  title     = {Extracting medication information from clinical text},
+  journal   = {J. Am. Medical Informatics Assoc.},
+  volume    = {17},
+  number    = {5},
+  pages     = {514--518},
+  year      = {2010},
+  url       = {https://doi.org/10.1136/jamia.2010.003947},
+  doi       = {10.1136/jamia.2010.003947},
+  timestamp = {Mon, 11 May 2020 22:59:55 +0200},
+  biburl    = {https://dblp.org/rec/journals/jamia/UzunerSC10.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+"""
+
+_DATASETNAME = "n2c2_2009"
+_DISPLAYNAME = "n2c2 2009 Medications"
+
+_DESCRIPTION = """\
+The Third i2b2 Workshop on Natural Language Processing Challenges for Clinical Records
+focused on the identification of medications, their dosages, modes (routes) of administration,
+frequencies, durations, and reasons for administration in discharge summaries.
+The third i2b2 challenge—that is, the medication challenge—extends information
+extraction to relation extraction; it requires extraction of medications and
+medication-related information followed by determination of which medication
+belongs to which medication-related details.
+
+The medication challenge was designed as an information extraction task.
+The goal, for each discharge summary, was to extract the following information
+on medications experienced by the patient:
+1. Medications (m): including names, brand names, generics, and collective names of prescription substances,
+over the counter medications, and other biological substances for which the patient is the experiencer.
+2. Dosages (do): indicating the amount of a medication used in each administration.
+3. Modes (mo): indicating the route for administering the medication.
+4. Frequencies (f): indicating how often each dose of the medication should be taken.
+5. Durations (du): indicating how long the medication is to be administered.
+6. Reasons (r): stating the medical reason for which the medication is given.
+7. Certainty (c): stating whether the event occurs. Certainty can be expressed by uncertainty words,
+e.g., “suggested”, or via modals, e.g., “should” indicates suggestion.
+8. Event (e): stating on whether the medication is started, stopped, or continued.
+9. Temporal (t): stating whether the medication was administered in the past,
+is being administered currently, or will be administered in the future, to the extent
+that this information is expressed in the tense of the verbs and auxiliary verbs used to express events.
+10. List/narrative (ln): indicating whether the medication information appears in a
+list structure or in narrative running text in the discharge summary.
+
+The medication challenge asked that systems extract the text corresponding to each of the fields
+for each of the mentions of the medications that were experienced by the patients.
+
+The values for the set of fields related to a medication mention, if presented within a
+two-line window of the mention, were linked in order to create what we defined as an ‘entry’.
+If the value of a field for a mention were not specified within a two-line window,
+then the value ‘nm’ for ‘not mentioned’ was entered and the offsets were left unspecified.
+
+Since the dataset annotations were crowd-sourced, it contains various violations that are handled
+throughout the data loader via means of exception catching or conditional statements. e.g.
+annotation: anticoagulation, while in text all words are to be separated by space which
+means words at end of sentence will always contain `.` and hence won't be an exact match
+i.e. `anticoagulation` != `anticoagulation.` from doc_id: 818404
+"""
+
+_HOMEPAGE = "https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/"
+
+_LICENSE = 'Data User Agreement'
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.0.0"  # 18-Aug-2009
+_BIGBIO_VERSION = "1.0.0"
+
+DELIMITER = "||"
+SOURCE = "source"
+BIGBIO_KB = "bigbio_kb"
+
+TEXT_DATA_FIELDNAME = "txt"
+MEDICATIONS_DATA_FIELDNAME = "med"
+OFFSET_PATTERN = (
+    r"(.+?)=\"(.+?)\"( .+)?"  # captures -> do="500" 102:6 102:6 and mo="nm"
+)
+BINARY_PATTERN = r"(.+?)=\"(.+?)\""
+ENTITY_ID = "entity_id"
+MEDICATION = "m"
+DOSAGE = "do"
+MODE_OF_ADMIN = "mo"
+FREQUENCY = "f"
+DURATION = "du"
+REASON = "r"
+EVENT = "e"
+TEMPORAL = "t"
+CERTAINTY = "c"
+IS_FOUND_IN_LIST_OR_NARRATIVE = "ln"
+NOT_MENTIONED = "nm"
+
+
+def _read_train_test_data_from_tar_gz(data_dir):
+    samples = defaultdict(dict)
+
+    with tarfile.open(
+        os.path.join(data_dir, "train.test.released.8.17.09.tar.gz"), "r:gz"
+    ) as tf:
+        for member in tf.getmembers():
+            if member.name != "train.test.released.8.17.09":
+                _, sample_id = os.path.split(member.name)
+
+                with tf.extractfile(member) as fp:
+                    content_bytes = fp.read()
+                content = content_bytes.decode("utf-8")
+                samples[sample_id][TEXT_DATA_FIELDNAME] = content
+
+    return samples
+
+
+def _get_train_set(data_dir, train_test_set):
+    train_sample_ids = set()
+
+    # Read training set IDs
+    with tarfile.open(
+        os.path.join(data_dir, "training.sets.released.tar.gz"), "r:gz"
+    ) as tf:
+        for member in tf.getmembers():
+            if member.name not in list(map(str, range(1, 11))):
+                _, sample_id = os.path.split(member.name)
+                train_sample_ids.add(sample_id)
+
+    # Extract training set samples using above IDs from combined dataset
+    training_set = {}
+    for sample_id in train_sample_ids:
+        training_set[sample_id] = train_test_set[sample_id]
+
+    return training_set
+
+
+def _get_test_set(train_set, train_test_set):
+    test_set = {}
+    for sample_id, sample in train_test_set.items():
+        if sample_id not in train_set:
+            test_set[sample_id] = sample
+
+    return test_set
+
+
+def _add_entities_to_train_set(data_dir, train_set):
+    with zipfile.ZipFile(
+        os.path.join(data_dir, "training.ground.truth.01.06.11.2009.zip")
+    ) as zf:
+        for info in zf.infolist():
+            base, filename = os.path.split(info.filename)
+            _, ext = os.path.splitext(filename)
+            ext = ext[1:]  # get rid of dot
+
+            # Extract sample id from filename pattern `379569_gold.entries`
+            sample_id = filename.split(".")[0].split("_")[0]
+            if ext == "entries":
+                train_set[sample_id][MEDICATIONS_DATA_FIELDNAME] = zf.read(info).decode(
+                    "utf-8"
+                )
+
+
+def _add_entities_to_test_set(data_dir, test_set):
+    with tarfile.open(
+        os.path.join(data_dir, "annotations_ground_truth.tar.gz"), "r:gz"
+    ) as tf:
+        for member in tf.getmembers():
+            if "converted.noduplicates.sorted" in member.name:
+                base, filename = os.path.split(member.name)
+                _, ext = os.path.splitext(filename)
+                ext = ext[1:]  # get rid of dot
+
+                sample_id = filename.split(".")[0]
+                if ext == "m":
+                    with tf.extractfile(member) as fp:
+                        content_bytes = fp.read()
+                    test_set[sample_id][
+                        MEDICATIONS_DATA_FIELDNAME
+                    ] = content_bytes.decode("utf-8")
+
+
+def _make_empty_schema_dict_with_text(text):
+    return {
+        "text": text,
+        "offsets": [{"start_line": 0, "start_token": 0, "end_line": 0, "end_token": 0}],
+    }
+
+
+def _ct_match_to_dict(c_match: Match) -> dict:
+    """Return a dictionary with groups from concept and type regex matches."""
+    key = c_match.group(1)
+    text = c_match.group(2)
+    offsets = c_match.group(3)
+    if offsets:
+        offsets = offsets.strip()
+        offsets_formatted = []
+        # Pattern: f="monday-wednesday-friday...before hemodialysis...p.r.n." 15:7 15:7,16:0 16:1,16:5 16:5
+        if "," in offsets:
+            line_offsets = offsets.split(",")
+            for offset in line_offsets:
+                start, end = offset.split(" ")
+                start_line, start_token = start.split(":")
+                end_line, end_token = end.split(":")
+                offsets_formatted.append(
+                    {
+                        "start_line": int(start_line),
+                        "start_token": int(start_token),
+                        "end_line": int(end_line),
+                        "end_token": int(end_token),
+                    }
+                )
+        else:
+            """Handle another edge annotations.ground.truth>984424 which has discontinuous
+            annotation as 23:4 23:4 23:10 23:10 which violates annotation guideline that
+            discontinuous spans should be separated by comma -> 23:4 23:4,23:10 23:10
+            """
+            offset = offsets.split(" ")
+            for i in range(0, len(offset), 2):
+                start, end = offset[i : i + 2]
+                start_line, start_token = start.split(":")
+                end_line, end_token = end.split(":")
+
+                offsets_formatted.append(
+                    {
+                        "start_line": int(start_line),
+                        "start_token": int(start_token),
+                        "end_line": int(end_line),
+                        "end_token": int(end_token),
+                    }
+                )
+
+        return {"text": text, "offsets": offsets_formatted}
+    elif key in {CERTAINTY, EVENT, TEMPORAL, IS_FOUND_IN_LIST_OR_NARRATIVE}:
+        return text
+    else:
+        return _make_empty_schema_dict_with_text(text)
+
+
+def _tokoff_from_line(text: str) -> List[Tuple[int, int]]:
+    """Produce character offsets for each token (whitespace split)
+    For example,
+      text = " one  two three ."
+      tokoff = [(1,4), (6,9), (10,15), (16,17)]
+    """
+    tokoff = []
+    start = None
+    end = None
+    for ii, char in enumerate(text):
+        if (char != " " or char != "\t") and start is None:
+            start = ii
+        if (char == " " or char == "\t") and start is not None:
+            end = ii
+            tokoff.append((start, end))
+            start = None
+    if start is not None:
+        end = ii + 1
+        tokoff.append((start, end))
+    return tokoff
+
+
+def _parse_line(line: str) -> dict:
+    """Parse one line from a *.m file.
+
+    A typical line has the form,
+      'm="<string>" <start_line>:<start_token> <end_line>:<end_token>||...||e="<string>"||...'
+
+    This represents one medication.
+    It can be interpreted as follows,
+        Medication name & offset||dosage & offset||mode & offset||frequency & offset||...
+        ...duration & offset||reason & offset||event||temporal marker||certainty||list/narrative
+
+    If there is no information then each field will simply contain "nm" (not mentioned)
+
+    Anomalies:
+    1. Files 683679 and 974209 annotations do not have 'c', 'e', 't' keys in them
+    2. Some files have discontinuous annotations violating guidelines i.e. using space insead of comma as delimiter
+    """
+    entity = {
+        MEDICATION: _make_empty_schema_dict_with_text(""),
+        DOSAGE: _make_empty_schema_dict_with_text(""),
+        MODE_OF_ADMIN: _make_empty_schema_dict_with_text(""),
+        FREQUENCY: _make_empty_schema_dict_with_text(""),
+        DURATION: _make_empty_schema_dict_with_text(""),
+        REASON: _make_empty_schema_dict_with_text(""),
+        EVENT: "",
+        TEMPORAL: "",
+        CERTAINTY: "",
+        IS_FOUND_IN_LIST_OR_NARRATIVE: "",
+    }
+    for i, pattern in enumerate(line.split(DELIMITER)):
+        # Handle edge case of triple pipe as delimiter in 18563_gold.entries: ...7,16:0 16:1,16:5 16:5||| du="nm"...
+        if pattern[0] == "|":
+            pattern = pattern[1:]
+
+        pattern = pattern.strip()
+        match = re.match(OFFSET_PATTERN, pattern)
+        key = match.group(1)
+        entity[key] = _ct_match_to_dict(match)
+
+    return entity
+
+
+def _form_entity_id(sample_id, split, start_line, start_token, end_line, end_token):
+    return "{}-entity-{}-{}-{}-{}-{}".format(
+        sample_id,
+        split,
+        start_line,
+        start_token,
+        end_line,
+        end_token,
+    )
+
+
+def _get_entities_from_sample(sample_id, sample, split):
+    entities = []
+    if MEDICATIONS_DATA_FIELDNAME not in sample:
+        return entities
+
+    text = sample[TEXT_DATA_FIELDNAME]
+    text_lines = text.splitlines()
+    text_line_lengths = [len(el) for el in text_lines]
+    med_lines = sample[MEDICATIONS_DATA_FIELDNAME].splitlines()
+    # parsed concepts (sort is just a convenience)
+    med_parsed = sorted(
+        [_parse_line(line) for line in med_lines],
+        key=lambda x: (
+            x[MEDICATION]["offsets"][0]["start_line"],
+            x[MEDICATION]["offsets"][0]["start_token"],
+        ),
+    )
+
+    for ii_cp, cp in enumerate(med_parsed):
+        for entity_type in {
+            MEDICATION,
+            DOSAGE,
+            DURATION,
+            REASON,
+            FREQUENCY,
+            MODE_OF_ADMIN,
+        }:
+            offsets, texts = [], []
+            for txt, offset in zip(
+                cp[entity_type]["text"].split("..."), cp[entity_type]["offsets"]
+            ):
+                # annotations can span multiple lines
+                # we loop over all lines and build up the character offsets
+                for ii_line in range(offset["start_line"], offset["end_line"] + 1):
+
+                    # character offset to the beginning of the line
+                    # line length of each line + 1 new line character for each line
+                    # need to subtract 1 from offset["start_line"] because line index starts at 1 in dataset
+                    start_line_off = sum(text_line_lengths[: ii_line - 1]) + (
+                        ii_line - 1
+                    )
+
+                    # offsets for each token relative to the beginning of the line
+                    # "one two" -> [(0,3), (4,6)]
+                    tokoff = _tokoff_from_line(text_lines[ii_line - 1])
+                    try:
+                        # if this is a single line annotation
+                        if ii_line == offset["start_line"] == offset["end_line"]:
+                            start_off = (
+                                start_line_off + tokoff[offset["start_token"]][0]
+                            )
+                            end_off = start_line_off + tokoff[offset["end_token"]][1]
+
+                        # if multi-line and on first line
+                        # end_off gets a +1 for new line character
+                        elif (ii_line == offset["start_line"]) and (
+                            ii_line != offset["end_line"]
+                        ):
+                            start_off = (
+                                start_line_off + tokoff[offset["start_token"]][0]
+                            )
+                            end_off = (
+                                start_line_off + text_line_lengths[ii_line - 1] + 1
+                            )
+
+                        # if multi-line and on last line
+                        elif (ii_line != offset["start_line"]) and (
+                            ii_line == offset["end_line"]
+                        ):
+                            end_off += tokoff[offset["end_token"]][1]
+
+                        # if mult-line and not on first or last line
+                        # (this does not seem to occur in this corpus)
+                        else:
+                            end_off += text_line_lengths[ii_line - 1] + 1
+
+                    except IndexError:
+                        """This is to handle an erroneous annotation in files #974209 line 51
+                        line is 'the PACU in stable condition. Her pain was well controlled with PCA'
+                        whereas the annotation says 'pca analgesia' where 'analgesia' is missing from
+                        the end of the line. This results in token not being found in `tokoff` array
+                        and raises IndexError
+
+                        similar files:
+                         * 5091 - amputation beginning two weeks ago associated with throbbing
+                         * 944118 - dysuria , joint pain. Reported small rash on penis for which was taking
+                         * 918321 - endarterectomy. The patient was started on enteric coated aspirin
+                        """
+                        continue
+
+                offsets.append((start_off, end_off))
+
+                text_slice = text[start_off:end_off]
+                text_slice_norm_1 = text_slice.replace("\n", "").lower()
+                text_slice_norm_2 = text_slice.replace("\n", " ").lower()
+                text_slice_norm_3 = text_slice.replace(".", "").lower()
+                match = (
+                    text_slice_norm_1 == txt.lower()
+                    or text_slice_norm_2 == txt.lower()
+                    or text_slice_norm_3 == txt.lower()
+                )
+                if not match:
+                    continue
+
+                texts.append(text_slice)
+
+            entity_id = _form_entity_id(
+                sample_id,
+                split,
+                cp[entity_type]["offsets"][0]["start_line"],
+                cp[entity_type]["offsets"][0]["start_token"],
+                cp[entity_type]["offsets"][-1]["end_line"],
+                cp[entity_type]["offsets"][-1]["end_token"],
+            )
+            entity = {
+                "id": entity_id,
+                "offsets": offsets if texts else [],
+                "text": texts,
+                "type": entity_type,
+                "normalized": [],
+            }
+            entities.append(entity)
+
+    # IDs are constructed such that duplicate IDs indicate duplicate (i.e. redundant) entities
+    dedupe_entities = []
+    dedupe_entity_ids = set()
+    for entity in entities:
+        if entity["id"] in dedupe_entity_ids:
+            continue
+        else:
+            dedupe_entity_ids.add(entity["id"])
+            dedupe_entities.append(entity)
+
+    return dedupe_entities
+
+
+class N2C22009MedicationDataset(datasets.GeneratorBasedBuilder):
+    """n2c2 2009 Medications NER task"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+    SOURCE_CONFIG_NAME = _DATASETNAME + "_" + SOURCE
+    BIGBIO_CONFIG_NAME = _DATASETNAME + "_" + BIGBIO_KB
+
+    # You will be able to load the "source" or "bigbio" configurations with
+    # ds_source = datasets.load_dataset('my_dataset', name='source')
+    # ds_bigbio = datasets.load_dataset('my_dataset', name='bigbio')
+
+    # For local datasets you can make use of the `data_dir` and `data_files` kwargs
+    # https://huggingface.co/docs/datasets/add_dataset.html#downloading-data-files-and-organizing-splits
+    # ds_source = datasets.load_dataset('my_dataset', name='source', data_dir="/path/to/data/files")
+    # ds_bigbio = datasets.load_dataset('my_dataset', name='bigbio', data_dir="/path/to/data/files")
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name=SOURCE_CONFIG_NAME,
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema=SOURCE,
+            subset_id=_DATASETNAME,
+        ),
+        BigBioConfig(
+            name=BIGBIO_CONFIG_NAME,
+            version=BIGBIO_VERSION,
+            description=f"{_DATASETNAME} BigBio schema",
+            schema=BIGBIO_KB,
+            subset_id=_DATASETNAME,
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = SOURCE_CONFIG_NAME
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == SOURCE:
+            offset_text_schema = {
+                "text": datasets.Value("string"),
+                "offsets": [
+                    {
+                        "start_line": datasets.Value("int64"),
+                        "start_token": datasets.Value("int64"),
+                        "end_line": datasets.Value("int64"),
+                        "end_token": datasets.Value("int64"),
+                    }
+                ],
+            }
+            features = datasets.Features(
+                {
+                    "doc_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "entities": [
+                        {
+                            MEDICATION: offset_text_schema,
+                            DOSAGE: offset_text_schema,
+                            MODE_OF_ADMIN: offset_text_schema,
+                            FREQUENCY: offset_text_schema,
+                            DURATION: offset_text_schema,
+                            REASON: offset_text_schema,
+                            EVENT: datasets.Value("string"),
+                            TEMPORAL: datasets.Value("string"),
+                            CERTAINTY: datasets.Value("string"),
+                            IS_FOUND_IN_LIST_OR_NARRATIVE: datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == BIGBIO_KB:
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        if self.config.data_dir is None or self.config.name is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir and name kwarg to load_dataset."
+            )
+        else:
+            data_dir = self.config.data_dir
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "split": str(datasets.Split.TRAIN),
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "split": str(datasets.Split.TEST),
+                },
+            ),
+        ]
+
+    @staticmethod
+    def _get_source_sample(
+        sample_id, sample
+    ) -> Dict[str, Union[str, List[Dict[str, str]]]]:
+        entities = []
+        if MEDICATIONS_DATA_FIELDNAME in sample:
+            entities = list(
+                map(_parse_line, sample[MEDICATIONS_DATA_FIELDNAME].splitlines())
+            )
+        return {
+            "doc_id": sample_id,
+            "text": sample.get(TEXT_DATA_FIELDNAME, ""),
+            "entities": entities,
+        }
+
+    @staticmethod
+    def _get_bigbio_sample(
+        sample_id, sample, split
+    ) -> Dict[str, Union[str, List[Dict[str, Union[str, List[Tuple]]]]]]:
+
+        passage_text = sample.get(TEXT_DATA_FIELDNAME, "")
+        entities = _get_entities_from_sample(sample_id, sample, split)
+        return {
+            "id": sample_id,
+            "document_id": sample_id,
+            "passages": [
+                {
+                    "id": f"{sample_id}-passage-0",
+                    "type": "discharge summary",
+                    "text": [passage_text],
+                    "offsets": [(0, len(passage_text))],
+                }
+            ],
+            "entities": entities,
+            "relations": [],
+            "events": [],
+            "coreferences": [],
+        }
+
+    def _generate_examples(self, data_dir, split):
+        train_test_set = _read_train_test_data_from_tar_gz(data_dir)
+        train_set = _get_train_set(data_dir, train_test_set)
+        test_set = _get_test_set(train_set, train_test_set)
+
+        if split == "train":
+            _add_entities_to_train_set(data_dir, train_set)
+            samples = train_set
+        elif split == "test":
+            _add_entities_to_test_set(data_dir, test_set)
+            samples = test_set
+
+        _id = 0
+        for sample_id, sample in samples.items():
+
+            if self.config.name == N2C22009MedicationDataset.SOURCE_CONFIG_NAME:
+                yield _id, self._get_source_sample(sample_id, sample)
+            elif self.config.name == N2C22009MedicationDataset.BIGBIO_CONFIG_NAME:
+                yield _id, self._get_bigbio_sample(sample_id, sample, split)
+
+            _id += 1

--- a/hub/hubscripts/n2c2_2010_hub.py
+++ b/hub/hubscripts/n2c2_2010_hub.py
@@ -1,0 +1,609 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and
+#
+# * Ayush Singh (singhay)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A dataset loader for the n2c2 2010 relations dataset.
+
+The dataset consists of three archive files,
+├── concept_assertion_relation_training_data.tar.gz
+├── reference_standard_for_test_data.tar.gz
+└── test_data.tar.gz
+
+The individual data files (inside the zip and tar archives) come in 4 types,
+
+* docs (*.txt files): text of a patient record
+* concepts (*.con files): entities along with offsets used as input to a named entity recognition model
+* assertions (*.ast files): entities, offsets and their assertion used as input to a named entity recognition model
+* relations (*.rel files): pairs of entities related by relation type used as input to a relation extraction model
+
+
+The files comprising this dataset must be on the users local machine
+in a single directory that is passed to `datasets.load_dataset` via
+the `data_dir` kwarg. This loader script will read the archive files
+directly (i.e. the user should not uncompress, untar or unzip any of
+the files).
+
+Data Access from https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/
+"""
+
+import os
+import re
+import tarfile
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import datasets
+from datasets import Version
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = True
+_CITATION = """\
+@article{DBLP:journals/jamia/UzunerSSD11,
+  author    = {
+                Ozlem Uzuner and
+                Brett R. South and
+                Shuying Shen and
+                Scott L. DuVall
+               },
+  title     = {2010 i2b2/VA challenge on concepts, assertions, and relations in clinical
+               text},
+  journal   = {J. Am. Medical Informatics Assoc.},
+  volume    = {18},
+  number    = {5},
+  pages     = {552--556},
+  year      = {2011},
+  url       = {https://doi.org/10.1136/amiajnl-2011-000203},
+  doi       = {10.1136/amiajnl-2011-000203},
+  timestamp = {Mon, 11 May 2020 23:00:20 +0200},
+  biburl    = {https://dblp.org/rec/journals/jamia/UzunerSSD11.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+"""
+
+_DATASETNAME = "n2c2_2010"
+_DISPLAYNAME = "n2c2 2010 Concepts, Assertions, and Relations"
+
+_DESCRIPTION = """\
+The i2b2/VA corpus contained de-identified discharge summaries from Beth Israel
+Deaconess Medical Center, Partners Healthcare, and University of Pittsburgh Medical
+Center (UPMC). In addition, UPMC contributed de-identified progress notes to the
+i2b2/VA corpus. This dataset contains the records from Beth Israel and Partners.
+
+The 2010 i2b2/VA Workshop on Natural Language Processing Challenges for Clinical Records comprises three tasks:
+1) a concept extraction task focused on the extraction of medical concepts from patient reports;
+2) an assertion classification task focused on assigning assertion types for medical problem concepts;
+3) a relation classification task focused on assigning relation types that hold between medical problems,
+tests, and treatments.
+
+i2b2 and the VA provided an annotated reference standard corpus for the three tasks.
+Using this reference standard, 22 systems were developed for concept extraction,
+21 for assertion classification, and 16 for relation classification.
+"""
+
+_HOMEPAGE = "https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/"
+
+_LICENSE = 'Data User Agreement'
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+def _read_tar_gz(file_path: str, samples=None):
+    if samples is None:
+        samples = defaultdict(dict)
+    with tarfile.open(file_path, "r:gz") as tf:
+
+        for member in tf.getmembers():
+            base, filename = os.path.split(member.name)
+            _, ext = os.path.splitext(filename)
+            ext = ext[1:]  # get rid of dot
+            sample_id = filename.split(".")[0]
+
+            if ext in ["txt", "ast", "con", "rel"]:
+                samples[sample_id][f"{ext}_source"] = (
+                    os.path.basename(file_path) + "|" + member.name
+                )
+
+                with tf.extractfile(member) as fp:
+                    content_bytes = fp.read()
+
+                content = content_bytes.decode("utf-8")
+                samples[sample_id][ext] = content
+
+    return samples
+
+
+C_PATTERN = r"c=\"(.+?)\" (\d+):(\d+) (\d+):(\d+)"
+T_PATTERN = r"t=\"(.+?)\""
+A_PATTERN = r"a=\"(.+?)\""
+R_PATTERN = r"r=\"(.+?)\""
+
+# Constants
+DELIMITER = "||"
+SOURCE = "source"
+BIGBIO_KB = "bigbio_kb"
+
+
+def _parse_con_line(line: str) -> dict:
+    """Parse one line from a *.con file.
+
+    A typical line has the form,
+      'c="angie cm johnson , m.d." 13:2 13:6||t="person"
+
+    This represents one concept to be placed into a coreference group.
+    It can be interpreted as follows,
+      'c="<string>" <start_line>:<start_token> <end_line>:<end_token>||t="<concept type>"'
+
+    """
+    c_part, t_part = line.split(DELIMITER)
+    c_match, t_match = re.match(C_PATTERN, c_part), re.match(T_PATTERN, t_part)
+    return {
+        "text": c_match.group(1),
+        "start_line": int(c_match.group(2)),
+        "start_token": int(c_match.group(3)),
+        "end_line": int(c_match.group(4)),
+        "end_token": int(c_match.group(5)),
+        "concept": t_match.group(1),
+    }
+
+
+def _parse_rel_line(line: str) -> dict:
+    """Parse one line from a *.rel file.
+
+    A typical line has the form,
+      'c="coronary artery bypass graft" 115:4 115:7||r="TrAP"||c="coronary artery disease" 115:0 115:2'
+
+    This represents two concepts related to one another.
+    It can be interpreted as follows,
+      'c="<string>" <start_line>:<start_token> <end_line>:<end_token>||r="<type>"||c="<string>"
+      <start_line>:<start_token> <end_line>:<end_token>'
+
+    """
+    c1_part, r_part, c2_part = line.split(DELIMITER)
+    c1_match, r_match, c2_match = (
+        re.match(C_PATTERN, c1_part),
+        re.match(R_PATTERN, r_part),
+        re.match(C_PATTERN, c2_part),
+    )
+    return {
+        "concept_1": {
+            "text": c1_match.group(1),
+            "start_line": int(c1_match.group(2)),
+            "start_token": int(c1_match.group(3)),
+            "end_line": int(c1_match.group(4)),
+            "end_token": int(c1_match.group(5)),
+        },
+        "concept_2": {
+            "text": c2_match.group(1),
+            "start_line": int(c2_match.group(2)),
+            "start_token": int(c2_match.group(3)),
+            "end_line": int(c2_match.group(4)),
+            "end_token": int(c2_match.group(5)),
+        },
+        "relation": r_match.group(1),
+    }
+
+
+def _parse_ast_line(line: str) -> dict:
+    """Parse one line from a *.ast file.
+
+    A typical line has the form,
+      'c="mild inferior wall hypokinesis" 42:2 42:5||t="problem"||a="present"'
+
+    This represents one concept along with it's assertion.
+    It can be interpreted as follows,
+      'c="<string>" <start_line>:<start_token> <end_line>:<end_token>||t="<concept type>"||a="<assertion type>"'
+
+    """
+    c_part, t_part, a_part = line.split(DELIMITER)
+    c_match, t_match, a_match = (
+        re.match(C_PATTERN, c_part),
+        re.match(T_PATTERN, t_part),
+        re.match(A_PATTERN, a_part),
+    )
+    return {
+        "text": c_match.group(1),
+        "start_line": int(c_match.group(2)),
+        "start_token": int(c_match.group(3)),
+        "end_line": int(c_match.group(4)),
+        "end_token": int(c_match.group(5)),
+        "concept": t_match.group(1),
+        "assertion": a_match.group(1),
+    }
+
+
+def _tokoff_from_line(text: str) -> List[Tuple[int, int]]:
+    """Produce character offsets for each token (whitespace split)
+
+    For example,
+      text = " one  two three ."
+      tokoff = [(1,4), (6,9), (10,15), (16,17)]
+    """
+    tokoff = []
+    start = None
+    end = None
+    for ii, char in enumerate(text):
+        if char != " " and start is None:
+            start = ii
+        if char == " " and start is not None:
+            end = ii
+            tokoff.append((start, end))
+            start = None
+    if start is not None:
+        end = ii + 1
+        tokoff.append((start, end))
+    return tokoff
+
+
+def _form_entity_id(sample_id, split, start_line, start_token, end_line, end_token):
+    return "{}-entity-{}-{}-{}-{}-{}".format(
+        sample_id,
+        split,
+        start_line,
+        start_token,
+        end_line,
+        end_token,
+    )
+
+
+def _get_relations_from_sample(sample_id, sample, split):
+    rel_lines = sample["rel"].splitlines()
+
+    relations = []
+    for i, rel_line in enumerate(rel_lines):
+        a = {}
+        rel = _parse_rel_line(rel_line)
+        a["arg1_id"] = _form_entity_id(
+            sample_id,
+            split,
+            rel["concept_1"]["start_line"],
+            rel["concept_1"]["start_token"],
+            rel["concept_1"]["end_line"],
+            rel["concept_1"]["end_token"],
+        )
+        a["arg2_id"] = _form_entity_id(
+            sample_id,
+            split,
+            rel["concept_2"]["start_line"],
+            rel["concept_2"]["start_token"],
+            rel["concept_2"]["end_line"],
+            rel["concept_2"]["end_token"],
+        )
+        a["id"] = (
+            sample_id + "_" + a["arg1_id"] + "_" + rel["relation"] + "_" + a["arg2_id"]
+        )
+        a["normalized"] = []
+        a["type"] = rel["relation"]
+        relations.append(a)
+
+    return relations
+
+
+def _get_entities_from_sample(sample_id, sample, split):
+    """Parse the lines of a *.con concept file into entity objects"""
+    con_lines = sample["con"].splitlines()
+
+    text = sample["txt"]
+    text_lines = text.splitlines()
+    text_line_lengths = [len(el) for el in text_lines]
+
+    # parsed concepts (sort is just a convenience)
+    con_parsed = sorted(
+        [_parse_con_line(line) for line in con_lines],
+        key=lambda x: (x["start_line"], x["start_token"]),
+    )
+
+    entities = []
+    for ii_cp, cp in enumerate(con_parsed):
+
+        # annotations can span multiple lines
+        # we loop over all lines and build up the character offsets
+        for ii_line in range(cp["start_line"], cp["end_line"] + 1):
+
+            # character offset to the beginning of the line
+            # line length of each line + 1 new line character for each line
+            start_line_off = sum(text_line_lengths[: ii_line - 1]) + (ii_line - 1)
+
+            # offsets for each token relative to the beginning of the line
+            # "one two" -> [(0,3), (4,6)]
+            tokoff = _tokoff_from_line(text_lines[ii_line - 1])
+
+            # if this is a single line annotation
+            if ii_line == cp["start_line"] == cp["end_line"]:
+                start_off = start_line_off + tokoff[cp["start_token"]][0]
+                end_off = start_line_off + tokoff[cp["end_token"]][1]
+
+            # if multi-line and on first line
+            # end_off gets a +1 for new line character
+            elif (ii_line == cp["start_line"]) and (ii_line != cp["end_line"]):
+                start_off = start_line_off + tokoff[cp["start_token"]][0]
+                end_off = start_line_off + text_line_lengths[ii_line - 1] + 1
+
+            # if multi-line and on last line
+            elif (ii_line != cp["start_line"]) and (ii_line == cp["end_line"]):
+                end_off = end_off + tokoff[cp["end_token"]][1]
+
+            # if mult-line and not on first or last line
+            # (this does not seem to occur in this corpus)
+            else:
+                end_off += text_line_lengths[ii_line - 1] + 1
+
+        text_slice = text[start_off:end_off]
+        text_slice_norm_1 = text_slice.replace("\n", "").lower()
+        text_slice_norm_2 = text_slice.replace("\n", " ").lower()
+        match = text_slice_norm_1 == cp["text"] or text_slice_norm_2 == cp["text"]
+        if not match:
+            continue
+
+        entity_id = _form_entity_id(
+            sample_id,
+            split,
+            cp["start_line"],
+            cp["start_token"],
+            cp["end_line"],
+            cp["end_token"],
+        )
+        entity = {
+            "id": entity_id,
+            "offsets": [(start_off, end_off)],
+            # this is the difference between taking text from the entity
+            # or taking the text from the offsets. the differences are
+            # almost all casing with some small number of new line characters
+            # making up the rest
+            # "text": [cp["text"]],
+            "text": [text_slice],
+            "type": cp["concept"],
+            "normalized": [],
+        }
+        entities.append(entity)
+
+    # IDs are constructed such that duplicate IDs indicate duplicate (i.e. redundant) entities
+    # In practive this removes one duplicate sample from the test set
+    # {
+    #    'id': 'clinical-627-entity-test-122-9-122-9',
+    #    'offsets': [(5600, 5603)],
+    #    'text': ['her'],
+    #    'type': 'person'
+    # }
+    dedupe_entities = []
+    dedupe_entity_ids = set()
+    for entity in entities:
+        if entity["id"] in dedupe_entity_ids:
+            continue
+        else:
+            dedupe_entity_ids.add(entity["id"])
+            dedupe_entities.append(entity)
+
+    return dedupe_entities
+
+
+class N2C22010RelationsDataset(datasets.GeneratorBasedBuilder):
+    """i2b2 2010 task comprising concept, assertion and relation extraction"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    # You will be able to load the "source" or "bigbio" configurations with
+    # ds_source = datasets.load_dataset('my_dataset', name='source')
+    # ds_bigbio = datasets.load_dataset('my_dataset', name='bigbio')
+
+    # For local datasets you can make use of the `data_dir` and `data_files` kwargs
+    # https://huggingface.co/docs/datasets/add_dataset.html#downloading-data-files-and-organizing-splits
+    # ds_source = datasets.load_dataset('my_dataset', name='source', data_dir="/path/to/data/files")
+    # ds_bigbio = datasets.load_dataset('my_dataset', name='bigbio', data_dir="/path/to/data/files")
+
+    _SOURCE_CONFIG_NAME = _DATASETNAME + "_" + SOURCE
+    _BIGBIO_CONFIG_NAME = _DATASETNAME + "_" + BIGBIO_KB
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name=_SOURCE_CONFIG_NAME,
+            version=SOURCE_VERSION,
+            description=_DATASETNAME + " source schema",
+            schema=SOURCE,
+            subset_id=_DATASETNAME,
+        ),
+        BigBioConfig(
+            name=_BIGBIO_CONFIG_NAME,
+            version=BIGBIO_VERSION,
+            description=_DATASETNAME + " BigBio schema",
+            schema=BIGBIO_KB,
+            subset_id=_DATASETNAME,
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = _SOURCE_CONFIG_NAME
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == SOURCE:
+            features = datasets.Features(
+                {
+                    "doc_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "concepts": [
+                        {
+                            "start_line": datasets.Value("int64"),
+                            "start_token": datasets.Value("int64"),
+                            "end_line": datasets.Value("int64"),
+                            "end_token": datasets.Value("int64"),
+                            "text": datasets.Value("string"),
+                            "concept": datasets.Value("string"),
+                        }
+                    ],
+                    "assertions": [
+                        {
+                            "start_line": datasets.Value("int64"),
+                            "start_token": datasets.Value("int64"),
+                            "end_line": datasets.Value("int64"),
+                            "end_token": datasets.Value("int64"),
+                            "text": datasets.Value("string"),
+                            "concept": datasets.Value("string"),
+                            "assertion": datasets.Value("string"),
+                        }
+                    ],
+                    "relations": [
+                        {
+                            "concept_1": {
+                                "text": datasets.Value("string"),
+                                "start_line": datasets.Value("int64"),
+                                "start_token": datasets.Value("int64"),
+                                "end_line": datasets.Value("int64"),
+                                "end_token": datasets.Value("int64"),
+                            },
+                            "concept_2": {
+                                "text": datasets.Value("string"),
+                                "start_line": datasets.Value("int64"),
+                                "start_token": datasets.Value("int64"),
+                                "end_line": datasets.Value("int64"),
+                                "end_token": datasets.Value("int64"),
+                            },
+                            "relation": datasets.Value("string"),
+                        }
+                    ],
+                    "unannotated": [
+                        {
+                            "text": datasets.Value("string"),
+                        }
+                    ],
+                    "metadata": {
+                        "txt_source": datasets.Value("string"),
+                        "con_source": datasets.Value("string"),
+                        "ast_source": datasets.Value("string"),
+                        "rel_source": datasets.Value("string"),
+                        "unannotated_source": datasets.Value("string"),
+                    },
+                }
+            )
+
+        elif self.config.schema == BIGBIO_KB:
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+
+        if self.config.data_dir is None or self.config.name is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir and name kwarg to load_dataset."
+            )
+        else:
+            data_dir = self.config.data_dir
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "split": str(datasets.Split.TRAIN),
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "split": str(datasets.Split.TEST),
+                },
+            ),
+        ]
+
+    @staticmethod
+    def _get_source_sample(sample_id, sample):
+        return {
+            "doc_id": sample_id,
+            "text": sample.get("txt", ""),
+            "concepts": list(map(_parse_con_line, sample.get("con", "").splitlines())),
+            "assertions": list(
+                map(_parse_ast_line, sample.get("ast", "").splitlines())
+            ),
+            "relations": list(map(_parse_rel_line, sample.get("rel", "").splitlines())),
+            "unannotated": sample.get("unannotated", ""),
+            "metadata": {
+                "txt_source": sample.get("txt_source", ""),
+                "con_source": sample.get("con_source", ""),
+                "ast_source": sample.get("ast_source", ""),
+                "rel_source": sample.get("rel_source", ""),
+                "unannotated_source": sample.get("unannotated_source", ""),
+            },
+        }
+
+    @staticmethod
+    def _get_bigbio_sample(sample_id, sample, split) -> dict:
+
+        passage_text = sample.get("txt", "")
+        entities = _get_entities_from_sample(sample_id, sample, split)
+        relations = _get_relations_from_sample(sample_id, sample, split)
+        return {
+            "id": sample_id,
+            "document_id": sample_id,
+            "passages": [
+                {
+                    "id": f"{sample_id}-passage-0",
+                    "type": "discharge summary",
+                    "text": [passage_text],
+                    "offsets": [(0, len(passage_text))],
+                }
+            ],
+            "entities": entities,
+            "relations": relations,
+            "events": [],
+            "coreferences": [],
+        }
+
+    def _generate_examples(self, data_dir, split):
+        if split == "train":
+            samples = _read_tar_gz(
+                os.path.join(
+                    data_dir, "concept_assertion_relation_training_data.tar.gz"
+                )
+            )
+        elif split == "test":
+            # This file adds con, ast and rel
+            samples = _read_tar_gz(
+                os.path.join(data_dir, "reference_standard_for_test_data.tar.gz")
+            )
+            # This file adds txt to already existing samples
+            samples = _read_tar_gz(os.path.join(data_dir, "test_data.tar.gz"), samples)
+
+        _id = 0
+
+        for sample_id, sample in samples.items():
+
+            if self.config.name == N2C22010RelationsDataset._SOURCE_CONFIG_NAME:
+                yield _id, self._get_source_sample(sample_id, sample)
+            elif self.config.name == N2C22010RelationsDataset._BIGBIO_CONFIG_NAME:
+                # This is to make sure unannotated data does not end up in big bio
+                if "unannotated" not in sample["txt_source"]:
+                    yield _id, self._get_bigbio_sample(sample_id, sample, split)
+
+            _id += 1

--- a/hub/hubscripts/n2c2_2011_hub.py
+++ b/hub/hubscripts/n2c2_2011_hub.py
@@ -1,0 +1,562 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+A dataset loader for the n2c2 2011 coref dataset.
+
+https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/
+
+The dataset consists of four archive files,
+
+* Task_1C.zip
+* Task_1C_Test_groundtruth.zip
+* i2b2_Partners_Train_Release.tar.gz
+* i2b2_Beth_Train_Release.tar.gz
+
+The individual data files (inside the zip and tar archives) come in 4 types,
+
+* docs (*.txt files): text of a patient record
+* concepts (*.txt.con files): entities used as input to a coreference model
+* chains (*.txt.chains files): chains (i.e. one or more) coreferent entities
+* pairs (*.txt.pairs files): pairs of coreferent entities (not required)
+
+
+The files comprising this dataset must be on the users local machine
+in a single directory that is passed to `datasets.load_datset` via
+the `data_dir` kwarg. This loader script will read the archive files
+directly (i.e. the user should not uncompress, untar or unzip any of
+the files). For example, if the following directory structure exists
+on the users local machine,
+
+
+n2c2_2011_coref
+├── i2b2_Beth_Train_Release.tar.gz
+├── i2b2_Partners_Train_Release.tar.gz
+├── Task_1C_Test_groundtruth.zip
+└── Task_1C.zip
+
+
+Data Access
+
+from https://www.i2b2.org/NLP/DataSets/Main.php
+
+"As always, you must register AND submit a DUA for access. If you previously
+accessed the data sets here on i2b2.org, you will need to set a new password
+for your account on the Data Portal, but your original DUA will be retained."
+
+
+"""
+
+import os
+import re
+import tarfile
+import zipfile
+from collections import defaultdict
+from typing import Dict, List, Match, Tuple
+
+import datasets
+from datasets import Features, Value
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "n2c2_2011"
+_DISPLAYNAME = "n2c2 2011 Coreference"
+
+# https://academic.oup.com/jamia/article/19/5/786/716138
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = True
+_CITATION = """\
+@article{uzuner2012evaluating,
+    author = {
+        Uzuner, Ozlem and
+        Bodnari, Andreea and
+        Shen, Shuying and
+        Forbush, Tyler and
+        Pestian, John and
+        South, Brett R
+    },
+    title = "{Evaluating the state of the art in coreference resolution for electronic medical records}",
+    journal = {Journal of the American Medical Informatics Association},
+    volume = {19},
+    number = {5},
+    pages = {786-791},
+    year = {2012},
+    month = {02},
+    issn = {1067-5027},
+    doi = {10.1136/amiajnl-2011-000784},
+    url = {https://doi.org/10.1136/amiajnl-2011-000784},
+    eprint = {https://academic.oup.com/jamia/article-pdf/19/5/786/17374287/19-5-786.pdf},
+}
+"""
+
+_DESCRIPTION = """\
+The i2b2/VA corpus contained de-identified discharge summaries from Beth Israel
+Deaconess Medical Center, Partners Healthcare, and University of Pittsburgh Medical
+Center (UPMC). In addition, UPMC contributed de-identified progress notes to the
+i2b2/VA corpus. This dataset contains the records from Beth Israel and Partners.
+
+The i2b2/VA corpus contained five concept categories: problem, person, pronoun,
+test, and treatment. Each record in the i2b2/VA corpus was annotated by two
+independent annotators for coreference pairs. Then the pairs were post-processed
+in order to create coreference chains. These chains were presented to an adjudicator,
+who resolved the disagreements between the original annotations, and added or deleted
+annotations as necessary. The outputs of the adjudicators were then re-adjudicated, with
+particular attention being paid to duplicates and enforcing consistency in the annotations.
+
+"""
+
+_HOMEPAGE = "https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/"
+
+_LICENSE = 'Data User Agreement'
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+_SUPPORTED_TASKS = [Tasks.COREFERENCE_RESOLUTION]
+
+
+def _read_tar_gz(file_path, samples=None):
+    if samples is None:
+        samples = defaultdict(dict)
+    with tarfile.open(file_path, "r:gz") as tf:
+        for member in tf.getmembers():
+
+            base, filename = os.path.split(member.name)
+            _, ext = os.path.splitext(filename)
+            ext = ext[1:]  # get rid of dot
+            sample_id = filename.split(".")[0]
+
+            if ext in ["txt", "con", "pairs", "chains"]:
+                samples[sample_id][f"{ext}_source"] = (
+                    os.path.basename(file_path) + "|" + member.name
+                )
+                with tf.extractfile(member) as fp:
+                    content_bytes = fp.read()
+                content = content_bytes.decode("utf-8")
+                samples[sample_id][ext] = content
+
+    return samples
+
+
+def _read_zip(file_path, samples=None):
+    if samples is None:
+        samples = defaultdict(dict)
+    with zipfile.ZipFile(file_path) as zf:
+        for info in zf.infolist():
+
+            base, filename = os.path.split(info.filename)
+            _, ext = os.path.splitext(filename)
+            ext = ext[1:]  # get rid of dot
+            sample_id = filename.split(".")[0]
+
+            if ext in ["txt", "con", "pairs", "chains"] and not filename.startswith(
+                "."
+            ):
+                samples[sample_id][f"{ext}_source"] = (
+                    os.path.basename(file_path) + "|" + info.filename
+                )
+                content = zf.read(info).decode("utf-8")
+                samples[sample_id][ext] = content
+
+    return samples
+
+
+C_PATTERN = r"c=\"(.+?)\" (\d+):(\d+) (\d+):(\d+)"
+T_PATTERN = r"t=\"(.+?)\""
+
+
+def _ct_match_to_dict(c_match: Match, t_match: Match) -> dict:
+    """Return a dictionary with groups from concept and type regex matches."""
+    return {
+        "text": c_match.group(1),
+        "start_line": int(c_match.group(2)),
+        "start_token": int(c_match.group(3)),
+        "end_line": int(c_match.group(4)),
+        "end_token": int(c_match.group(5)),
+        "type": t_match.group(1),
+    }
+
+
+def _parse_con_line(line: str) -> dict:
+    """Parse one line from a *.con file.
+
+    A typical line has the form,
+      'c="angie cm johnson , m.d." 13:2 13:6||t="person"
+
+    This represents one concept to be placed into a coreference group.
+    It can be interpreted as follows,
+      'c="<string>" <start_line>:<start_token> <end_line>:<end_token>||t="<type>"'
+
+    """
+    c_part, t_part = line.split("||")
+    c_match, t_match = re.match(C_PATTERN, c_part), re.match(T_PATTERN, t_part)
+    return _ct_match_to_dict(c_match, t_match)
+
+
+def _parse_chains_line(line: str) -> List[Dict]:
+    """Parse one line from a *.chains file.
+
+    A typical line has a chain of concepts and then a type.
+      'c="patient" 12:0 12:0||c="mr. andersen" 19:0 19:1||...||t="coref person"'
+    """
+    pieces = line.split("||")
+    c_parts, t_part = pieces[:-1], pieces[-1]
+    c_matches, t_match = (
+        [re.match(C_PATTERN, c_part) for c_part in c_parts],
+        re.match(T_PATTERN, t_part),
+    )
+    return [_ct_match_to_dict(c_match, t_match) for c_match in c_matches]
+
+
+def _tokoff_from_line(text: str) -> List[Tuple[int, int]]:
+    """Produce character offsets for each token (whitespace split)
+
+    For example,
+      text = " one  two three ."
+      tokoff = [(1,4), (6,9), (10,15), (16,17)]
+    """
+    tokoff = []
+    start = None
+    end = None
+    for ii, char in enumerate(text):
+        if char != " " and start is None:
+            start = ii
+        if char == " " and start is not None:
+            end = ii
+            tokoff.append((start, end))
+            start = None
+    if start is not None:
+        end = ii + 1
+        tokoff.append((start, end))
+    return tokoff
+
+
+def _form_entity_id(sample_id, split, start_line, start_token, end_line, end_token):
+    return "{}-entity-{}-{}-{}-{}-{}".format(
+        sample_id,
+        split,
+        start_line,
+        start_token,
+        end_line,
+        end_token,
+    )
+
+
+def _get_corefs_from_sample(sample_id, sample, sample_entity_ids, split):
+    """Parse the lines of a *.chains file into coreference objects
+
+    A small number of concepts from the *.con files could not be
+    aligned with the text and were excluded. For this reason we
+    pass in the full set of matched entity IDs and ensure that
+    no coreference refers to an exlcluded entity.
+    """
+    chains_lines = sample["chains"].splitlines()
+    chains_parsed = [_parse_chains_line(line) for line in chains_lines]
+    corefs = []
+    for ii_cp, cp in enumerate(chains_parsed):
+        coref_id = f"{sample_id}-coref-{ii_cp}"
+        coref_entity_ids = [
+            _form_entity_id(
+                sample_id,
+                split,
+                entity["start_line"],
+                entity["start_token"],
+                entity["end_line"],
+                entity["end_token"],
+            )
+            for entity in cp
+        ]
+        coref_entity_ids = [
+            ent_id for ent_id in coref_entity_ids if ent_id in sample_entity_ids
+        ]
+        coref = {
+            "id": coref_id,
+            "entity_ids": coref_entity_ids,
+        }
+        corefs.append(coref)
+
+    return corefs
+
+
+def _get_entities_from_sample(sample_id, sample, split):
+    """Parse the lines of a *.con concept file into entity objects
+
+    Here we parse the *.con files and form entities. For a small
+    number of entities the text snippet in the concept file could not
+    be aligned with the slice from the full text produced by using
+    the line and token offsets. These entities are excluded from the
+    entities object and the coreferences object.
+    """
+    con_lines = sample["con"].splitlines()
+    text = sample["txt"]
+    text_lines = text.splitlines()
+    text_line_lengths = [len(el) for el in text_lines]
+
+    # parsed concepts (sort is just a convenience)
+    con_parsed = sorted(
+        [_parse_con_line(line) for line in con_lines],
+        key=lambda x: (x["start_line"], x["start_token"]),
+    )
+
+    entities = []
+    for ii_cp, cp in enumerate(con_parsed):
+
+        # annotations can span multiple lines
+        # we loop over all lines and build up the character offsets
+        for ii_line in range(cp["start_line"], cp["end_line"] + 1):
+
+            # character offset to the beginning of the line
+            # line length of each line + 1 new line character for each line
+            start_line_off = sum(text_line_lengths[: ii_line - 1]) + (ii_line - 1)
+
+            # offsets for each token relative to the beginning of the line
+            # "one two" -> [(0,3), (4,6)]
+            tokoff = _tokoff_from_line(text_lines[ii_line - 1])
+
+            # if this is a single line annotation
+            if ii_line == cp["start_line"] == cp["end_line"]:
+                start_off = start_line_off + tokoff[cp["start_token"]][0]
+                end_off = start_line_off + tokoff[cp["end_token"]][1]
+
+            # if multi-line and on first line
+            # end_off gets a +1 for new line character
+            elif (ii_line == cp["start_line"]) and (ii_line != cp["end_line"]):
+                start_off = start_line_off + tokoff[cp["start_token"]][0]
+                end_off = start_line_off + text_line_lengths[ii_line - 1] + 1
+
+            # if multi-line and on last line
+            elif (ii_line != cp["start_line"]) and (ii_line == cp["end_line"]):
+                end_off = end_off + tokoff[cp["end_token"]][1]
+
+            # if mult-line and not on first or last line
+            # (this does not seem to occur in this corpus)
+            else:
+                end_off += text_line_lengths[ii_line - 1] + 1
+
+        text_slice = text[start_off:end_off]
+        text_slice_norm_1 = text_slice.replace("\n", "").lower()
+        text_slice_norm_2 = text_slice.replace("\n", " ").lower()
+        match = text_slice_norm_1 == cp["text"] or text_slice_norm_2 == cp["text"]
+        if not match:
+            continue
+
+        entity_id = _form_entity_id(
+            sample_id,
+            split,
+            cp["start_line"],
+            cp["start_token"],
+            cp["end_line"],
+            cp["end_token"],
+        )
+        entity = {
+            "id": entity_id,
+            "offsets": [(start_off, end_off)],
+            # this is the difference between taking text from the entity
+            # or taking the text from the offsets. the differences are
+            # almost all casing with some small number of new line characters
+            # making up the rest
+            # "text": [cp["text"]],
+            "text": [text_slice],
+            "type": cp["type"],
+            "normalized": [],
+        }
+        entities.append(entity)
+
+    # IDs are constructed such that duplicate IDs indicate duplicate (i.e. redundant) entities
+    # In practive this removes one duplicate sample from the test set
+    # {
+    #    'id': 'clinical-627-entity-test-122-9-122-9',
+    #    'offsets': [(5600, 5603)],
+    #    'text': ['her'],
+    #    'type': 'person'
+    # }
+    dedupe_entities = []
+    dedupe_entity_ids = set()
+    for entity in entities:
+        if entity["id"] in dedupe_entity_ids:
+            continue
+        else:
+            dedupe_entity_ids.add(entity["id"])
+            dedupe_entities.append(entity)
+
+    return dedupe_entities
+
+
+class N2C22011CorefDataset(datasets.GeneratorBasedBuilder):
+    """n2c2 2011 coreference task"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="n2c2_2011_source",
+            version=SOURCE_VERSION,
+            description="n2c2_2011 source schema",
+            schema="source",
+            subset_id="n2c2_2011",
+        ),
+        BigBioConfig(
+            name="n2c2_2011_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="n2c2_2011 BigBio schema",
+            schema="bigbio_kb",
+            subset_id="n2c2_2011",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "n2c2_2011_source"
+
+    def _info(self):
+
+        if self.config.schema == "source":
+            features = Features(
+                {
+                    "sample_id": Value("string"),
+                    "txt": Value("string"),
+                    "con": Value("string"),
+                    "pairs": Value("string"),
+                    "chains": Value("string"),
+                    "metadata": {
+                        "txt_source": Value("string"),
+                        "con_source": Value("string"),
+                        "pairs_source": Value("string"),
+                        "chains_source": Value("string"),
+                    },
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            supervised_keys=None,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
+        else:
+            data_dir = self.config.data_dir
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "split": "train",
+                    "data_dir": data_dir,
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "split": "test",
+                    "data_dir": data_dir,
+                },
+            ),
+        ]
+
+    @staticmethod
+    def _get_source_sample(sample_id, sample):
+        return {
+            "sample_id": sample_id,
+            "txt": sample.get("txt", ""),
+            "con": sample.get("con", ""),
+            "pairs": sample.get("pairs", ""),
+            "chains": sample.get("chains", ""),
+            "metadata": {
+                "txt_source": sample.get("txt_source", ""),
+                "con_source": sample.get("con_source", ""),
+                "pairs_source": sample.get("pairs_source", ""),
+                "chains_source": sample.get("chains_source", ""),
+            },
+        }
+
+    @staticmethod
+    def _get_coref_sample(sample_id, sample, split):
+
+        passage_text = sample.get("txt", "")
+        entities = _get_entities_from_sample(sample_id, sample, split)
+        entity_ids = set([entity["id"] for entity in entities])
+        coreferences = _get_corefs_from_sample(sample_id, sample, entity_ids, split)
+        return {
+            "id": sample_id,
+            "document_id": sample_id,
+            "passages": [
+                {
+                    "id": f"{sample_id}-passage-0",
+                    "type": "discharge summary",
+                    "text": [passage_text],
+                    "offsets": [(0, len(passage_text))],
+                }
+            ],
+            "entities": entities,
+            "relations": [],
+            "events": [],
+            "coreferences": coreferences,
+        }
+
+    def _generate_examples(self, split, data_dir):
+        """Generate samples using the info passed in from _split_generators."""
+
+        if split == "train":
+            _id = 0
+            # These files have complete sample info
+            # (so we get a fresh `samples` defaultdict from each)
+            paths = [
+                os.path.join(data_dir, "i2b2_Beth_Train_Release.tar.gz"),
+                os.path.join(data_dir, "i2b2_Partners_Train_Release.tar.gz"),
+            ]
+            for path in paths:
+                samples = _read_tar_gz(path)
+                for sample_id, sample in samples.items():
+                    if self.config.schema == "source":
+                        yield _id, self._get_source_sample(sample_id, sample)
+                    elif self.config.schema == "bigbio_kb":
+                        yield _id, self._get_coref_sample(sample_id, sample, split)
+                    _id += 1
+
+        elif split == "test":
+            _id = 0
+            # Information from these files has to be combined to create a full sample
+            # (so we pass the `samples` defaultdict back to the `_read_zip` method)
+            paths = [
+                os.path.join(data_dir, "Task_1C.zip"),
+                os.path.join(data_dir, "Task_1C_Test_groundtruth.zip"),
+            ]
+            samples = defaultdict(dict)
+            for path in paths:
+                samples = _read_zip(path, samples=samples)
+
+            for sample_id, sample in samples.items():
+                if self.config.schema == "source":
+                    yield _id, self._get_source_sample(sample_id, sample)
+                elif self.config.schema == "bigbio_kb":
+                    yield _id, self._get_coref_sample(sample_id, sample, split)
+                _id += 1

--- a/hub/hubscripts/n2c2_2014_deid_hub.py
+++ b/hub/hubscripts/n2c2_2014_deid_hub.py
@@ -1,0 +1,295 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A dataset loader for the n2c2 2014  Deidentification & Heart Disease.
+https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/
+The dataset consists of 3  archive files,
+* 2014_training-PHI-Gold-Set1.tar.gz
+* training-PHI-Gold-Set2.tar.gz
+* testing-PHI-Gold-fixed.tar.gz
+Each tar.gz contain a set of .xml files. One .xml per clinical report.
+The file names follow a consistent pattern with the first set of digits identifying the
+patient and the last set of digits identifying the sequential record number
+ie: XXX-YY.xml
+where XXX is the patient number,  and YY is the record number.
+Example: 320-03.xml
+This is the third (03) record for patient 320
+Each file has a root level xml node which will contain a
+<TEXT> node that holds the medical annotation text and a <TAGS> node containing
+annotations for the document text.
+The files comprising this dataset must be on the users local machine
+in a single directory that is passed to `datasets.load_datset` via
+the `data_dir` kwarg. This loader script will read the archive files
+directly (i.e. the user should not uncompress, untar or unzip any of
+the files). For example, if the following directory structure exists
+on the users local machine,
+n2c2_2014
+├── 2014_training-PHI-Gold-Set1.tar.gz
+├── training-PHI-Gold-Set2.tar.gz
+├── testing-PHI-Gold-fixed.tar.gz
+Data Access
+from https://www.i2b2.org/NLP/DataSets/Main.php
+"As always, you must register AND submit a DUA for access. If you previously
+accessed the data sets here on i2b2.org, you will need to set a new password
+for your account on the Data Portal, but your original DUA will be retained."
+Made in collaboration with @JoaoRacedo
+"""
+
+import itertools as it
+import os
+import re
+import tarfile
+import xml.etree.ElementTree as et
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = True
+_CITATION = """\
+@article{stubbs2015automated,
+title = {Automated systems for the de-identification of longitudinal
+clinical narratives: Overview of 2014 i2b2/UTHealth shared task Track 1},
+journal = {Journal of Biomedical Informatics},
+volume = {58},
+pages = {S11-S19},
+year = {2015},
+issn = {1532-0464},
+doi = {https://doi.org/10.1016/j.jbi.2015.06.007},
+url = {https://www.sciencedirect.com/science/article/pii/S1532046415001173},
+author = {Amber Stubbs and Christopher Kotfila and Özlem Uzuner}
+}
+"""
+
+_DATASETNAME = "n2c2_2014_deid"
+_DISPLAYNAME = "n2c2 2014 De-identification"
+
+_DESCRIPTION = """\
+The 2014 i2b2/UTHealth Natural Language Processing (NLP) shared task featured two tracks.
+The first of these was the de-identification track focused on identifying protected health
+information (PHI) in longitudinal clinical narratives.
+
+TRACK 1: NER PHI\n
+HIPAA requires that patient medical records have all identifying information removed in order to
+protect patient privacy. There are 18 categories of Protected Health Information (PHI) identifiers of the
+patient or of relatives, employers, or household members of the patient that must be removed in order
+for a file to be considered de-identified.
+In order to de-identify the records, each file has PHI marked up. All PHI has an
+XML tag indicating its category and type, where applicable. For the purposes of this task,
+the 18 HIPAA categories have been grouped into 6 main categories and 25 sub categories
+"""
+
+_HOMEPAGE = "https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/"
+
+_LICENSE = 'Data User Agreement'
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class N2C22014DeidDataset(datasets.GeneratorBasedBuilder):
+    """n2c2 2014 Deidentification Challenge"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="n2c2_2014_source",
+            version=SOURCE_VERSION,
+            description="n2c2_2014 source schema",
+            schema="source",
+            subset_id="n2c2_2014_deid",
+        ),
+        BigBioConfig(
+            name="n2c2_2014_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="n2c2_2014 BigBio schema",
+            schema="bigbio_kb",
+            subset_id="n2c2_2014_deid",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "n2c2_2014_deid_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "phi": [
+                        {
+                            "id": datasets.Value("string"),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "type": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                            "comment": datasets.Value("string"),
+                        }
+                    ],
+                },
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
+        else:
+            data_dir = self.config.data_dir
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "file_names": [
+                        ("2014_training-PHI-Gold-Set1.tar.gz", "track1"),
+                        ("training-PHI-Gold-Set2.tar.gz", "track1"),
+                    ],
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "data_dir": data_dir,
+                    "file_names": [
+                        ("testing-PHI-Gold-fixed.tar.gz", "track1"),
+                    ],
+                },
+            ),
+        ]
+
+    def _generate_examples(self, data_dir, file_names: List[Tuple]) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        if self.config.schema == "source":
+            uid = it.count(0)
+            for fname, task in file_names:
+                full_path = os.path.join(data_dir, fname)
+                for x in self._read_tar_gz(full_path):
+                    xml_flag = x["xml_flag"]
+                    if xml_flag:
+                        document = self._read_task1_file(
+                            file_object=x["file_object"], file_name=x["file_name"]
+                        )
+                        document["id"] = next(uid)
+
+        elif self.config.schema == "bigbio_kb":
+            uid = it.count(0)
+            for fname, task in file_names:
+                full_path = os.path.join(data_dir, fname)
+                for x in self._read_tar_gz(full_path):
+                    xml_flag = x["xml_flag"]
+                    if xml_flag:
+                        document = self._read_task1_file(
+                            file_object=x["file_object"], file_name=x["file_name"]
+                        )
+                        document["id"] = next(uid)
+                        entity_list = document.pop("phi")
+                        full_text = document.pop("text")
+                        entities_ = []
+                        for entity in entity_list:
+                            entities_.append(
+                                {
+                                    "id": next(uid),
+                                    "type": entity["type"],
+                                    "text": entity["text"],
+                                    "offsets": entity["offsets"],
+                                    "normalized": entity["normalized"],
+                                }
+                            )
+                        document["entities"] = entities_
+
+                        document["passages"] = [
+                            {
+                                "id": next(uid),
+                                "type": "full_text",
+                                "text": [full_text],
+                                "offsets": [[0, len(full_text)]],
+                            },
+                        ]
+
+                        # additional fields required that can be empty
+                        document["relations"] = []
+                        document["events"] = []
+                        document["coreferences"] = []
+                        yield document["document_id"], document
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")
+
+    def _read_tar_gz(self, fpath: str) -> Dict:
+        """
+        Read .tar.gz file
+        """
+        # Open tar file
+        tf = tarfile.open(fpath, "r:gz")
+
+        for tf_member in tf.getmembers():
+            file_object = tf.extractfile(tf_member)
+            name = tf_member.name
+            file_name = os.path.basename(name).split(".")[0]
+            if re.search(r"\.xml", name) is not None:
+                xml_flag = True
+            else:
+                xml_flag = False
+            yield {
+                "file_object": file_object,
+                "file_name": file_name,
+                "xml_flag": xml_flag,
+            }
+
+    def _read_task1_file(self, file_object, file_name):
+        xmldoc = et.parse(file_object).getroot()
+        entities = xmldoc.findall("TAGS")[0]
+        text = xmldoc.findall("TEXT")[0].text
+        phi = []
+        for entity in entities:
+            phi.append(
+                {
+                    "id": entity.attrib["id"],
+                    "offsets": [[entity.attrib["start"], entity.attrib["end"]]],
+                    "type": entity.attrib["TYPE"],
+                    "text": [entity.attrib["text"]],
+                    "comment": entity.attrib["comment"],
+                    "normalized": [],
+                }
+            )
+
+        document = {"document_id": file_name, "text": text, "phi": phi}
+        return document

--- a/hub/hubscripts/n2c2_2018_track1_hub.py
+++ b/hub/hubscripts/n2c2_2018_track1_hub.py
@@ -1,0 +1,298 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A dataset loader for the n2c2 2018 cohort selection dataset.
+
+The dataset consists of three archive files,
+├── train.zip - 202 records
+└── n2c2-t1_gold_standard_test_data.zip - 86 records
+
+The individual data files (inside the zip and tar archives) come in
+xml files that contains text as well as labels.
+
+
+The files comprising this dataset must be on the users local machine
+in a single directory that is passed to `datasets.load_dataset` via
+the `data_dir` kwarg. This loader script will read the archive files
+directly (i.e. the user should not uncompress, untar or unzip any of
+the files).
+
+Data Access from https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/
+"""
+
+import os
+import zipfile
+from collections import defaultdict
+from typing import List
+
+import datasets
+from lxml import etree
+
+from .bigbiohub import text.features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = True
+_CITATION = """\
+@article{DBLP:journals/jamia/StubbsFSHU19,
+  author    = {
+                Amber Stubbs and
+                Michele Filannino and
+                Ergin Soysal and
+                Samuel Henry and
+                Ozlem Uzuner
+               },
+  title     = {Cohort selection for clinical trials: n2c2 2018 shared task track 1},
+  journal   = {J. Am. Medical Informatics Assoc.},
+  volume    = {26},
+  number    = {11},
+  pages     = {1163--1171},
+  year      = {2019},
+  url       = {https://doi.org/10.1093/jamia/ocz163},
+  doi       = {10.1093/jamia/ocz163},
+  timestamp = {Mon, 15 Jun 2020 16:56:11 +0200},
+  biburl    = {https://dblp.org/rec/journals/jamia/StubbsFSHU19.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+"""
+
+_DATASETNAME = "n2c2_2018_track1"
+_DISPLAYNAME = "n2c2 2018 Selection Criteria"
+
+_DESCRIPTION = """\
+Track 1 of the 2018 National NLP Clinical Challenges shared tasks focused
+on identifying which patients in a corpus of longitudinal medical records
+meet and do not meet identified selection criteria.
+
+This shared task aimed to determine whether NLP systems could be trained to identify if patients met or did not meet
+a set of selection criteria taken from real clinical trials. The selected criteria required measurement detection (
+“Any HbA1c value between 6.5 and 9.5%”), inference (“Use of aspirin to prevent myocardial infarction”),
+temporal reasoning (“Diagnosis of ketoacidosis in the past year”), and expert judgment to assess (“Major
+diabetes-related complication”). For the corpus, we used the dataset of American English, longitudinal clinical
+narratives from the 2014 i2b2/UTHealth shared task 4.
+
+The final selected 13 selection criteria are as follows:
+1. DRUG-ABUSE: Drug abuse, current or past
+2. ALCOHOL-ABUSE: Current alcohol use over weekly recommended limits
+3. ENGLISH: Patient must speak English
+4. MAKES-DECISIONS: Patient must make their own medical decisions
+5. ABDOMINAL: History of intra-abdominal surgery, small or large intestine
+resection, or small bowel obstruction.
+6. MAJOR-DIABETES: Major diabetes-related complication. For the purposes of
+this annotation, we define “major complication” (as opposed to “minor complication”)
+as any of the following that are a result of (or strongly correlated with) uncontrolled diabetes:
+    a. Amputation
+    b. Kidney damage
+    c. Skin conditions
+    d. Retinopathy
+    e. nephropathy
+    f. neuropathy
+7. ADVANCED-CAD: Advanced cardiovascular disease (CAD).
+For the purposes of this annotation, we define “advanced” as having 2 or more of the following:
+    a. Taking 2 or more medications to treat CAD
+    b. History of myocardial infarction (MI)
+    c. Currently experiencing angina
+    d. Ischemia, past or present
+8. MI-6MOS: MI in the past 6 months
+9. KETO-1YR: Diagnosis of ketoacidosis in the past year
+10. DIETSUPP-2MOS: Taken a dietary supplement (excluding vitamin D) in the past 2 months
+11. ASP-FOR-MI: Use of aspirin to prevent MI
+12. HBA1C: Any hemoglobin A1c (HbA1c) value between 6.5% and 9.5%
+13. CREATININE: Serum creatinine > upper limit of normal
+
+The training consists of 202 patient records with document-level annotations, 10 records
+with textual spans indicating annotator’s evidence for their annotations while test set contains 86.
+
+Note:
+* The inter-annotator average agreement is 84.9%
+* Whereabouts of 10 records with textual spans indicating annotator’s evidence are unknown.
+However, author did a simple script based validation to check if any of the tags contained any text
+in any of the training set and they do not, which confirms that atleast train and test do not
+ have any evidence tagged alongside corresponding tags.
+"""
+
+_HOMEPAGE = "https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/"
+
+_LICENSE = 'Data User Agreement'
+
+_SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+# Constants
+SOURCE = "source"
+BIGBIO_TEXT = "bigbio_text"
+
+
+def _read_zip(file_path):
+    samples = defaultdict(dict)
+    with zipfile.ZipFile(file_path) as zf:
+        for info in zf.infolist():
+
+            base, filename = os.path.split(info.filename)
+            _, ext = os.path.splitext(filename)
+            ext = ext[1:]  # get rid of dot
+            sample_id = filename.split(".")[0]
+
+            if ext == "xml" and not filename.startswith("."):
+                content = zf.read(info).decode("utf-8").encode()
+                root = etree.XML(content)
+                text, tags = root.getchildren()
+                samples[sample_id]["txt"] = text.text
+                samples[sample_id]["tags"] = {}
+                for child in tags:
+                    samples[sample_id]["tags"][child.tag] = child.get("met")
+
+    return samples
+
+
+class N2C22018CohortSelectionDataset(datasets.GeneratorBasedBuilder):
+    """i2b2 2018 track 1 cohort selection task"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    _SOURCE_CONFIG_NAME = _DATASETNAME + "_" + SOURCE
+    _BIGBIO_CONFIG_NAME = _DATASETNAME + "_" + BIGBIO_TEXT
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name=_SOURCE_CONFIG_NAME,
+            version=SOURCE_VERSION,
+            description=_DATASETNAME + " source schema",
+            schema=SOURCE,
+            subset_id=_DATASETNAME,
+        ),
+        BigBioConfig(
+            name=_BIGBIO_CONFIG_NAME,
+            version=BIGBIO_VERSION,
+            description=_DATASETNAME + " BigBio schema",
+            schema=BIGBIO_TEXT,
+            subset_id=_DATASETNAME,
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = _SOURCE_CONFIG_NAME
+    LABEL_CLASS_NAMES = [
+        "ABDOMINAL",
+        "ADVANCED-CAD",
+        "ALCOHOL-ABUSE",
+        "ASP-FOR-MI",
+        "CREATININE",
+        "DIETSUPP-2MOS",
+        "DRUG-ABUSE",
+        "ENGLISH",
+        "HBA1C",
+        "KETO-1YR",
+        "MAJOR-DIABETES",
+        "MAKES-DECISIONS",
+        "MI-6MOS",
+    ]
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == SOURCE:
+            labels = {
+                key: datasets.ClassLabel(names=["met", "not met"])
+                for key in self.LABEL_CLASS_NAMES
+            }
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "tags": labels,
+                }
+            )
+
+        elif self.config.schema == BIGBIO_TEXT:
+            features = text.features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+
+        if self.config.data_dir is None or self.config.name is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir and name kwarg to load_dataset."
+            )
+        else:
+            data_dir = self.config.data_dir
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "file_path": os.path.join(data_dir, "train.zip"),
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "file_path": os.path.join(
+                        data_dir, "n2c2-t1_gold_standard_test_data.zip"
+                    ),
+                },
+            ),
+        ]
+
+    @staticmethod
+    def _get_source_sample(sample_id, sample):
+        return {
+            "id": sample_id,
+            "document_id": sample_id,
+            "text": sample.get("txt", ""),
+            "tags": sample.get("tags", {}),
+        }
+
+    @staticmethod
+    def _get_bigbio_sample(sample_id, sample) -> dict:
+
+        tags = sample.get("tags", None)
+        if tags:
+            labels = [name for name, met_status in tags.items() if met_status == "met"]
+        else:
+            labels = []
+
+        return {
+            "id": sample_id,
+            "document_id": sample_id,
+            "text": sample.get("txt", ""),
+            "labels": labels,
+        }
+
+    def _generate_examples(self, file_path):
+        samples = _read_zip(file_path)
+
+        _id = 0
+        for sample_id, sample in samples.items():
+
+            if self.config.name == self._SOURCE_CONFIG_NAME:
+                yield _id, self._get_source_sample(sample_id, sample)
+            elif self.config.name == self._BIGBIO_CONFIG_NAME:
+                yield _id, self._get_bigbio_sample(sample_id, sample)
+
+            _id += 1

--- a/hub/hubscripts/n2c2_2018_track2_hub.py
+++ b/hub/hubscripts/n2c2_2018_track2_hub.py
@@ -1,0 +1,448 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+A dataset loader for the n2c2 2018 Adverse Drug Events and Medication Extraction dataset.
+
+The dataset consists of multiple archive files two of which are being used by the script,
+├── training_20180910.zip
+└── gold-standard-test-data.zip
+
+The individual data files (inside the zip and tar archives) come in 4 types,
+
+* docs (*.txt files): text of a patient record
+* annotations (*.ann files): entities and relations along with offsets used as input to a NER / RE model
+
+The files comprising this dataset must be on the users local machine
+in a single directory that is passed to `datasets.load_dataset` via
+the `data_dir` kwarg. This loader script will read the archive files
+directly (i.e. the user should not uncompress, untar or unzip any of
+the files).
+
+Data Access from https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/
+
+[bigbio_schema_name] = kb
+"""
+
+import os
+import zipfile
+from collections import defaultdict
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = True
+_CITATION = """\
+@article{DBLP:journals/jamia/HenryBFSU20,
+  author    = {
+                Sam Henry and
+                Kevin Buchan and
+                Michele Filannino and
+                Amber Stubbs and
+                Ozlem Uzuner
+               },
+  title     = {2018 n2c2 shared task on adverse drug events and medication extraction
+               in electronic health records},
+  journal   = {J. Am. Medical Informatics Assoc.},
+  volume    = {27},
+  number    = {1},
+  pages     = {3--12},
+  year      = {2020},
+  url       = {https://doi.org/10.1093/jamia/ocz166},
+  doi       = {10.1093/jamia/ocz166},
+  timestamp = {Sat, 30 May 2020 19:53:56 +0200},
+  biburl    = {https://dblp.org/rec/journals/jamia/HenryBFSU20.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+"""
+
+_DATASETNAME = "n2c2_2018_track2"
+_DISPLAYNAME = "n2c2 2018 ADE"
+
+_DESCRIPTION = """\
+The National NLP Clinical Challenges (n2c2), organized in 2018, continued the
+legacy of i2b2 (Informatics for Biology and the Bedside), adding 2 new tracks and 2
+new sets of data to the shared tasks organized since 2006. Track 2 of 2018
+n2c2 shared tasks focused on the extraction of medications, with their signature
+information, and adverse drug events (ADEs) from clinical narratives.
+This track built on our previous medication challenge, but added a special focus on ADEs.
+
+ADEs are injuries resulting from a medical intervention related to a drugs and
+can include allergic reactions, drug interactions, overdoses, and medication errors.
+Collectively, ADEs are estimated to account for 30% of all hospital adverse
+events; however, ADEs are preventable. Identifying potential drug interactions,
+overdoses, allergies, and errors at the point of care and alerting the caregivers of
+potential ADEs can improve health delivery, reduce the risk of ADEs, and improve health
+outcomes.
+
+A step in this direction requires processing narratives of clinical records
+that often elaborate on the medications given to a patient, as well as the known
+allergies, reactions, and adverse events of the patient. Extraction of this information
+from narratives complements the structured medication information that can be
+obtained from prescriptions, allowing a more thorough assessment of potential ADEs
+before they happen.
+
+The 2018 n2c2 shared task Track 2, hereon referred to as the ADE track,
+tackled these natural language processing tasks in 3 different steps,
+which we refer to as tasks:
+1. Concept Extraction: identification of concepts related to medications,
+their signature information, and ADEs
+2. Relation Classification: linking the previously mentioned concepts to
+their medication  by identifying relations on gold standard concepts
+3. End-to-End: building end-to-end systems that process raw narrative text
+to discover concepts and find relations of those concepts to their medications
+
+Shared tasks provide a venue for head-to-head comparison of systems developed
+for the same task and on the same data, allowing researchers to identify the state
+of the art in a particular task, learn from it, and build on it.
+"""
+
+_HOMEPAGE = "https://portal.dbmi.hms.harvard.edu/projects/n2c2-nlp/"
+
+_LICENSE = 'Data User Agreement'
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
+
+_SOURCE_VERSION = "1.0.0"  # 2018-09-10
+_BIGBIO_VERSION = "1.0.0"
+
+# Constants
+DELIMITER = "||"
+SOURCE = "source"
+BIGBIO_KB = "bigbio_kb"
+ID = "id"
+ANNOTATIONS_EXT = "ann"
+TEXT, TEXT_EXT = "text", "txt"
+TAG, TAGS = "tag", "tags"
+RELATION, RELATIONS = "relation", "relations"
+START, END = "start", "end"
+
+N2C2_2018_NER_LABELS = sorted(
+    [
+        "Drug",
+        "Frequency",
+        "Reason",
+        "ADE",
+        "Dosage",
+        "Duration",
+        "Form",
+        "Route",
+        "Strength",
+    ]
+)
+N2C2_2018_RELATION_LABELS = sorted(
+    [
+        "Frequency-Drug",
+        "Strength-Drug",
+        "Route-Drug",
+        "Dosage-Drug",
+        "ADE-Drug",
+        "Reason-Drug",
+        "Duration-Drug",
+        "Form-Drug",
+    ]
+)
+
+
+def _form_id(sample_id, entity_id, split):
+    return "{}-{}-{}".format(sample_id, entity_id, split)
+
+
+def _build_concept_dict(tag_id, tag_start, tag_end, tag_type, tag_text):
+    return {
+        ID: tag_id,
+        TEXT: tag_text,
+        START: int(tag_start),
+        END: int(tag_end),
+        TAG: tag_type,
+    }
+
+
+def _build_relation_dict(rel_id, arg1, arg2, rel_type):
+    return {
+        ID: rel_id,
+        "arg1_id": arg1,
+        "arg2_id": arg2,
+        RELATION: rel_type,
+    }
+
+
+def _get_annotations(annotation_file):
+    """Return a dictionary with all the annotations in the .ann file.
+
+    A typical line has either of the following form,
+        1. 'T41	Form 8977 8990	ophthalmology' -> '<ID> <CONCEPT> <START CHAR OFFSET> <END CHAR OFFSET> <TEXT>'
+        2. 'R22	Form-Drug Arg1:T41 Arg2:T40' -> '<ID> <RELATION> <CONCEPT_1_ID> <CONCEPT_2_ID>'
+
+    """
+    tags, relations = {}, {}
+    lines = annotation_file.splitlines()
+    for line_num, line in enumerate(filter(lambda l: l.strip().startswith("T"), lines)):
+        try:
+            tag_id, tag_m, tag_text = line.strip().split("\t")
+        except ValueError:
+            print(line)
+
+        if len(tag_m.split(" ")) == 3:
+            tag_type, tag_start, tag_end = tag_m.split(" ")
+        elif len(tag_m.split(" ")) == 4:
+            tag_type, tag_start, _, tag_end = tag_m.split(" ")
+        elif len(tag_m.split(" ")) == 5:
+            tag_type, tag_start, _, _, tag_end = tag_m.split(" ")
+        else:
+            print(line)
+        tags[tag_id] = _build_concept_dict(
+            tag_id, tag_start, tag_end, tag_type, tag_text
+        )
+
+    for line_num, line in enumerate(filter(lambda l: l.strip().startswith("R"), lines)):
+        rel_id, rel_m = line.strip().split("\t")
+        rel_type, rel_arg1, rel_arg2 = rel_m.split(" ")
+        rel_arg1 = rel_arg1.split(":")[1]
+        rel_arg2 = rel_arg2.split(":")[1]
+        arg1 = tags[rel_arg1][ID]
+        arg2 = tags[rel_arg2][ID]
+        relations[rel_id] = _build_relation_dict(rel_id, arg1, arg2, rel_type)
+
+    return tags.values(), relations.values()
+
+
+def _read_zip(file_path):
+    samples = defaultdict(dict)
+    with zipfile.ZipFile(file_path) as zf:
+        for info in zf.infolist():
+
+            base, filename = os.path.split(info.filename)
+            _, ext = os.path.splitext(filename)
+            ext = ext[1:]  # get rid of dot
+            sample_id = filename.split(".")[0]
+
+            if ext in [TEXT_EXT, ANNOTATIONS_EXT] and not filename.startswith("."):
+                content = zf.read(info).decode("utf-8")
+                if ext == TEXT_EXT:
+                    samples[sample_id][ext] = content
+                else:
+                    (
+                        samples[sample_id][TAGS],
+                        samples[sample_id][RELATIONS],
+                    ) = _get_annotations(content)
+
+    return samples
+
+
+def _get_entities_from_sample(sample_id, sample, split):
+    entities = []
+    entity_ids = set()
+    text = sample[TEXT_EXT]
+    for entity in sample[TAGS]:
+        text_slice = text[entity[START] : entity[END]]
+        text_slice_norm_1 = text_slice.replace("\n", "").lower()
+        text_slice_norm_2 = text_slice.replace("\n", " ").lower()
+        match = text_slice_norm_1 == entity[TEXT] or text_slice_norm_2 == entity[TEXT]
+        if not match:
+            continue
+
+        entity_id = _form_id(sample_id, entity[ID], split)
+        entity_ids.add(entity_id)
+        entities.append(
+            {
+                ID: entity_id,
+                "type": entity[TAG],
+                TEXT: [text_slice],
+                "offsets": [(entity[START], entity[END])],
+                "normalized": [],
+            }
+        )
+
+    return entities, entity_ids
+
+
+def _get_relations_from_sample(sample_id, sample, split, entity_ids):
+    """
+    A small number of relation from the *.ann files could not be
+    aligned with the text and were excluded. For this reason we
+    pass in the full set of matched entity IDs and ensure that
+    no relations refers to an excluded entity.
+    """
+    relations = []
+    for relation in sample[RELATIONS]:
+        arg1_id = _form_id(sample_id, relation["arg1_id"], split)
+        arg2_id = _form_id(sample_id, relation["arg2_id"], split)
+        if arg1_id in entity_ids and arg2_id in entity_ids:
+            relations.append(
+                {
+                    ID: _form_id(sample_id, relation[ID], split),
+                    "type": relation[RELATION],
+                    "arg1_id": _form_id(sample_id, relation["arg1_id"], split),
+                    "arg2_id": _form_id(sample_id, relation["arg2_id"], split),
+                    "normalized": [],
+                }
+            )
+
+    return relations
+
+
+class N2C2AdverseDrugEventsMedicationExtractionDataset(datasets.GeneratorBasedBuilder):
+    """n2c2 2018 Track 2 concept and relation task"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    SOURCE_CONFIG_NAME = _DATASETNAME + "_" + SOURCE
+    BIGBIO_CONFIG_NAME = _DATASETNAME + "_" + BIGBIO_KB
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name=SOURCE_CONFIG_NAME,
+            version=SOURCE_VERSION,
+            description=_DATASETNAME + " source schema",
+            schema=SOURCE,
+            subset_id=_DATASETNAME,
+        ),
+        BigBioConfig(
+            name=BIGBIO_CONFIG_NAME,
+            version=BIGBIO_VERSION,
+            description=_DATASETNAME + " BigBio schema",
+            schema=BIGBIO_KB,
+            subset_id=_DATASETNAME,
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = SOURCE_CONFIG_NAME
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == SOURCE:
+            features = datasets.Features(
+                {
+                    "doc_id": datasets.Value("string"),
+                    TEXT: datasets.Value("string"),
+                    TAGS: [
+                        {
+                            ID: datasets.Value("string"),
+                            TEXT: datasets.Value("string"),
+                            START: datasets.Value("int64"),
+                            END: datasets.Value("int64"),
+                            TAG: datasets.ClassLabel(names=N2C2_2018_NER_LABELS),
+                        }
+                    ],
+                    RELATIONS: [
+                        {
+                            ID: datasets.Value("string"),
+                            "arg1_id": datasets.Value("string"),
+                            "arg2_id": datasets.Value("string"),
+                            RELATION: datasets.ClassLabel(
+                                names=N2C2_2018_RELATION_LABELS
+                            ),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == BIGBIO_KB:
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        if self.config.data_dir is None or self.config.name is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir and name kwarg to load_dataset."
+            )
+        else:
+            data_dir = self.config.data_dir
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "file_path": os.path.join(data_dir, "training_20180910.zip"),
+                    "split": datasets.Split.TRAIN,
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "file_path": os.path.join(data_dir, "gold-standard-test-data.zip"),
+                    "split": datasets.Split.TEST,
+                },
+            ),
+        ]
+
+    @staticmethod
+    def _get_source_sample(sample_id, sample):
+        return {
+            "doc_id": sample_id,
+            TEXT: sample.get(TEXT_EXT, ""),
+            TAGS: sample.get(TAGS, []),
+            RELATIONS: sample.get(RELATIONS, []),
+        }
+
+    @staticmethod
+    def _get_bigbio_sample(sample_id, sample, split) -> dict:
+
+        passage_text = sample.get("txt", "")
+        entities, entity_ids = _get_entities_from_sample(sample_id, sample, split)
+        relations = _get_relations_from_sample(sample_id, sample, split, entity_ids)
+        return {
+            "id": sample_id,
+            "document_id": sample_id,
+            "passages": [
+                {
+                    "id": f"{sample_id}-passage-0",
+                    "type": "discharge summary",
+                    "text": [passage_text],
+                    "offsets": [(0, len(passage_text))],
+                }
+            ],
+            "entities": entities,
+            "relations": relations,
+            "events": [],
+            "coreferences": [],
+        }
+
+    def _generate_examples(self, file_path, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        samples = _read_zip(file_path)
+
+        _id = 0
+        for sample_id, sample in samples.items():
+
+            if (
+                self.config.name
+                == N2C2AdverseDrugEventsMedicationExtractionDataset.SOURCE_CONFIG_NAME
+            ):
+                yield _id, self._get_source_sample(sample_id, sample)
+            elif (
+                self.config.name
+                == N2C2AdverseDrugEventsMedicationExtractionDataset.BIGBIO_CONFIG_NAME
+            ):
+                yield _id, self._get_bigbio_sample(sample_id, sample, split)
+
+            _id += 1

--- a/hub/hubscripts/ncbi_disease_hub.py
+++ b/hub/hubscripts/ncbi_disease_hub.py
@@ -1,0 +1,249 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The NCBI disease corpus is fully annotated at the mention and concept level to serve as a research
+resource for the biomedical natural language processing community.
+"""
+
+import os
+from typing import Dict, Iterator, List, Tuple
+
+import datasets
+from bioc import pubtator
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{Dogan2014NCBIDC,
+    title        = {NCBI disease corpus: A resource for disease name recognition and concept normalization},
+    author       = {Rezarta Islamaj Dogan and Robert Leaman and Zhiyong Lu},
+    year         = 2014,
+    journal      = {Journal of biomedical informatics},
+    volume       = 47,
+    pages        = {1--10}
+}
+"""
+
+_DATASETNAME = "ncbi_disease"
+_DISPLAYNAME = "NCBI Disease"
+
+_DESCRIPTION = """\
+The NCBI disease corpus is fully annotated at the mention and concept level to serve as a research
+resource for the biomedical natural language processing community.
+"""
+
+_HOMEPAGE = "https://www.ncbi.nlm.nih.gov/CBBresearch/Dogan/DISEASE/"
+_LICENSE = 'Creative Commons Zero v1.0 Universal'
+
+_URLS = {
+    _DATASETNAME: {
+        datasets.Split.TRAIN: "https://www.ncbi.nlm.nih.gov/CBBresearch/Dogan/DISEASE/NCBItrainset_corpus.zip",
+        datasets.Split.TEST: "https://www.ncbi.nlm.nih.gov/CBBresearch/Dogan/DISEASE/NCBItestset_corpus.zip",
+        datasets.Split.VALIDATION: "https://www.ncbi.nlm.nih.gov/CBBresearch/Dogan/DISEASE/NCBIdevelopset_corpus.zip",
+    }
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class NCBIDiseaseDataset(datasets.GeneratorBasedBuilder):
+    """NCBI Disease"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="ncbi_disease_source",
+            version=SOURCE_VERSION,
+            description="NCBI Disease source schema",
+            schema="source",
+            subset_id="ncbi_disease",
+        ),
+        BigBioConfig(
+            name="ncbi_disease_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="NCBI Disease BigBio schema",
+            schema="bigbio_kb",
+            subset_id="ncbi_disease",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "ncbi_disease_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "pmid": datasets.Value("string"),
+                    "title": datasets.Value("string"),
+                    "abstract": datasets.Value("string"),
+                    "mentions": [
+                        {
+                            "concept_id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                            "offsets": datasets.Sequence(datasets.Value("int32")),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        train_filename = "NCBItrainset_corpus.txt"
+        test_filename = "NCBItestset_corpus.txt"
+        dev_filename = "NCBIdevelopset_corpus.txt"
+
+        train_filepath = os.path.join(data_dir[datasets.Split.TRAIN], train_filename)
+        test_filepath = os.path.join(data_dir[datasets.Split.TEST], test_filename)
+        dev_filepath = os.path.join(data_dir[datasets.Split.VALIDATION], dev_filename)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": train_filepath,
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": test_filepath,
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": dev_filepath,
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(
+        self, filepath: str, split: str
+    ) -> Iterator[Tuple[str, Dict]]:
+        if self.config.schema == "source":
+            for i, source_example in enumerate(self._pubtator_to_source(filepath)):
+                # Some examples are duplicated in NCBI Disease. We have to make them unique to
+                # avoid and error from datasets.
+                yield str(i) + "_" + source_example["pmid"], source_example
+
+        elif self.config.schema == "bigbio_kb":
+            seen = []
+            for kb_example in self._pubtator_to_bigbio_kb(filepath):
+                # Some examples are duplicated in NCBI Disease. Avoid yielding more than once.
+                if kb_example["id"] in seen:
+                    continue
+                yield kb_example["id"], kb_example
+                seen.append(kb_example["id"])
+
+    @staticmethod
+    def _pubtator_to_source(filepath: Dict) -> Iterator[Dict]:
+        with open(filepath, "r") as f:
+            for doc in pubtator.iterparse(f):
+                source_example = {
+                    "pmid": doc.pmid,
+                    "title": doc.title,
+                    "abstract": doc.abstract,
+                    "mentions": [
+                        {
+                            "concept_id": mention.id,
+                            "type": mention.type,
+                            "text": mention.text,
+                            "offsets": [mention.start, mention.end],
+                        }
+                        for mention in doc.annotations
+                    ],
+                }
+                yield source_example
+
+    @staticmethod
+    def _pubtator_to_bigbio_kb(filepath: Dict) -> Iterator[Dict]:
+        with open(filepath, "r") as f:
+            unified_example = {}
+            for doc in pubtator.iterparse(f):
+                unified_example["id"] = doc.pmid
+                unified_example["document_id"] = doc.pmid
+
+                unified_example["passages"] = [
+                    {
+                        "id": doc.pmid + "_title",
+                        "type": "title",
+                        "text": [doc.title],
+                        "offsets": [[0, len(doc.title)]],
+                    },
+                    {
+                        "id": doc.pmid + "_abstract",
+                        "type": "abstract",
+                        "text": [doc.abstract],
+                        "offsets": [
+                            [
+                                # +1 assumes the title and abstract will be joined by a space.
+                                len(doc.title) + 1,
+                                len(doc.title) + 1 + len(doc.abstract),
+                            ]
+                        ],
+                    },
+                ]
+
+                unified_entities = []
+                for i, entity in enumerate(doc.annotations):
+                    # We need a unique identifier for this entity, so build it from the document id and entity id
+                    unified_entity_id = "_".join([doc.pmid, entity.id, str(i)])
+                    # The user can provide a callable that returns the database name.
+                    db_name = "omim" if "OMIM" in entity.id else "mesh"
+                    unified_entities.append(
+                        {
+                            "id": unified_entity_id,
+                            "type": entity.type,
+                            "text": [entity.text],
+                            "offsets": [[entity.start, entity.end]],
+                            "normalized": [{"db_name": db_name, "db_id": entity.id}],
+                        }
+                    )
+
+                unified_example["entities"] = unified_entities
+                unified_example["relations"] = []
+                unified_example["events"] = []
+                unified_example["coreferences"] = []
+
+                yield unified_example

--- a/hub/hubscripts/nlm_gene_hub.py
+++ b/hub/hubscripts/nlm_gene_hub.py
@@ -1,0 +1,265 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import collections
+import itertools
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+from bioc import biocxml
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{islamaj2021nlm,
+  title        = {
+    NLM-Gene, a richly annotated gold standard dataset for gene entities that
+    addresses ambiguity and multi-species gene recognition
+  },
+  author       = {
+    Islamaj, Rezarta and Wei, Chih-Hsuan and Cissel, David and Miliaras,
+    Nicholas and Printseva, Olga and Rodionov, Oleg and Sekiya, Keiko and Ward,
+    Janice and Lu, Zhiyong
+  },
+  year         = 2021,
+  journal      = {Journal of Biomedical Informatics},
+  publisher    = {Elsevier},
+  volume       = 118,
+  pages        = 103779
+}
+"""
+
+_DATASETNAME = "nlm_gene"
+_DISPLAYNAME = "NLM-Gene"
+
+_DESCRIPTION = """\
+NLM-Gene consists of 550 PubMed articles, from 156 journals, and contains more \
+than 15 thousand unique gene names, corresponding to more than five thousand \
+gene identifiers (NCBI Gene taxonomy). This corpus contains gene annotation data \
+from 28 organisms. The annotated articles contain on average 29 gene names, and \
+10 gene identifiers per article. These characteristics demonstrate that this \
+article set is an important benchmark dataset to test the accuracy of gene \
+recognition algorithms both on multi-species and ambiguous data. The NLM-Gene \
+corpus will be invaluable for advancing text-mining techniques for gene \
+identification tasks in biomedical text.
+"""
+
+_HOMEPAGE = "https://zenodo.org/record/5089049"
+
+_LICENSE = 'Creative Commons Zero v1.0 Universal'
+
+_URLS = {
+    "source": "https://zenodo.org/record/5089049/files/NLM-Gene-Corpus.zip",
+    "bigbio_kb": "https://zenodo.org/record/5089049/files/NLM-Gene-Corpus.zip",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class NLMGeneDataset(datasets.GeneratorBasedBuilder):
+    """NLM-Gene Dataset for gene entities"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="nlm_gene_source",
+            version=SOURCE_VERSION,
+            description="NlM Gene source schema",
+            schema="source",
+            subset_id="nlm_gene",
+        ),
+        BigBioConfig(
+            name="nlm_gene_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="NlM Gene BigBio schema",
+            schema="bigbio_kb",
+            subset_id="nlm_gene",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "nlm_gene_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            if self.config.schema == "source":
+                # this is a variation on the BioC format
+                features = datasets.Features(
+                    {
+                        "passages": [
+                            {
+                                "document_id": datasets.Value("string"),
+                                "type": datasets.Value("string"),
+                                "text": datasets.Value("string"),
+                                "entities": [
+                                    {
+                                        "id": datasets.Value("string"),
+                                        "offsets": [[datasets.Value("int32")]],
+                                        "text": [datasets.Value("string")],
+                                        "type": datasets.Value("string"),
+                                        "normalized": [
+                                            {
+                                                "db_name": datasets.Value("string"),
+                                                "db_id": datasets.Value("string"),
+                                            }
+                                        ],
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[self.config.schema]
+        data_dir = Path(dl_manager.download_and_extract(urls))
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_dir / "Corpus",
+                    "file_name": "Pmidlist.Train.txt",
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": data_dir / "Corpus",
+                    "file_name": "Pmidlist.Test.txt",
+                    "split": "test",
+                },
+            ),
+        ]
+
+    @staticmethod
+    def _get_bioc_entity(
+        span, db_id_key="NCBI Gene identifier", splitters=",;|-"
+    ) -> dict:
+        """Parse BioC entity annotation."""
+        offsets, texts = get_texts_and_offsets_from_bioc_ann(span)
+        db_ids = span.infons.get(db_id_key, "-1")
+        # Find connector between db_ids for the normalization, if not found, use default
+        connector = "|"
+        for splitter in list(splitters):
+            if splitter in db_ids:
+                connector = splitter
+        normalized = [
+            {"db_name": db_id_key, "db_id": db_id} for db_id in db_ids.split(connector)
+        ]
+
+        return {
+            "id": span.id,
+            "offsets": offsets,
+            "text": texts,
+            "type": span.infons["type"],
+            "normalized": normalized,
+        }
+
+    def _generate_examples(
+        self, filepath: Path, file_name: str, split: str
+    ) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        if self.config.schema == "source":
+            with open(filepath / file_name, encoding="utf-8") as f:
+                contents = f.readlines()
+            for uid, content in enumerate(contents):
+                file_id = content.replace("\n", "")
+                file_path = filepath / "FINAL" / f"{file_id}.BioC.XML"
+                reader = biocxml.BioCXMLDocumentReader(file_path.as_posix())
+                for xdoc in reader:
+                    yield uid, {
+                        "passages": [
+                            {
+                                "document_id": xdoc.id,
+                                "type": passage.infons["type"],
+                                "text": passage.text,
+                                "entities": [
+                                    self._get_bioc_entity(span)
+                                    for span in passage.annotations
+                                ],
+                            }
+                            for passage in xdoc.passages
+                        ]
+                    }
+        elif self.config.schema == "bigbio_kb":
+            with open(filepath / file_name, encoding="utf-8") as f:
+                contents = f.readlines()
+            uid = 0  # global unique id
+            for i, content in enumerate(contents):
+                file_id = content.replace("\n", "")
+                file_path = filepath / "FINAL" / f"{file_id}.BioC.XML"
+                reader = biocxml.BioCXMLDocumentReader(file_path.as_posix())
+                for xdoc in reader:
+                    data = {
+                        "id": uid,
+                        "document_id": xdoc.id,
+                        "passages": [],
+                        "entities": [],
+                        "relations": [],
+                        "events": [],
+                        "coreferences": [],
+                    }
+                    uid += 1
+
+                    char_start = 0
+                    # passages must not overlap and spans must cover the entire document
+                    for passage in xdoc.passages:
+                        offsets = [[char_start, char_start + len(passage.text)]]
+                        char_start = char_start + len(passage.text) + 1
+                        data["passages"].append(
+                            {
+                                "id": uid,
+                                "type": passage.infons["type"],
+                                "text": [passage.text],
+                                "offsets": offsets,
+                            }
+                        )
+                        uid += 1
+                    # entities
+                    for passage in xdoc.passages:
+                        for span in passage.annotations:
+                            ent = self._get_bioc_entity(
+                                span, db_id_key="NCBI Gene identifier"
+                            )
+                            ent["id"] = uid  # override BioC default id
+                            data["entities"].append(ent)
+                            uid += 1
+
+                    yield i, data

--- a/hub/hubscripts/nlm_wsd_hub.py
+++ b/hub/hubscripts/nlm_wsd_hub.py
@@ -1,0 +1,362 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+In order to support research investigating the automatic resolution of word sense ambiguity using natural language
+processing techniques, we have constructed this test collection of medical text in which the ambiguities were resolved
+by hand. Evaluators were asked to examine instances of an ambiguous word and determine the sense intended by selecting
+the Metathesaurus concept (if any) that best represents the meaning of that sense. The test collection consists of 50
+highly frequent ambiguous UMLS concepts from 1998 MEDLINE. Each of the 50 ambiguous cases has 100 ambiguous instances
+randomly selected from the 1998 MEDLINE citations. For a total of 5,000 instances. We had a total of 11 evaluators of
+which 8 completed 100% of the 5,000 instances, 1 completed 56%, 1 completed 44%, and the final evaluator completed 12%
+of the instances. Evaluations were only used when the evaluators completed all 100 instances for a given ambiguity.
+
+Comment from author:
+BigBio schema fixes off by one error of end offset of entities. The source config remains unchanged.
+
+Instructions on how to load locally:
+1) Create directory
+2) Download one of the following annotation sets from https://lhncbc.nlm.nih.gov/restricted/ii/areas/WSD/index.html
+   and put it into the folder:
+   - Full Reviewed Set
+     https://lhncbc.nlm.nih.gov/restricted/ii/areas/WSD/downloads/full_reviewed_results.tar.gz
+     (Link "Full Reviewed Result Set (requires Common Files above)")
+     subset_id = nlm_wsd_reviewed
+   - Full Non-Reviewed Set
+     https://lhncbc.nlm.nih.gov/restricted/ii/areas/WSD/downloads/full_non_reviewed_results.tar.gz
+     (Link "Full Non-Reviewed Result Set (requires Common Files above)")
+     subset_id = nlm_wsd_non_reviewed
+3) Download https://lhncbc.nlm.nih.gov/restricted/ii/areas/WSD/downloads/UMLS1999.tar.gz (Link "1999 UMLS Data Files")
+   and put it into the folder
+4) Set kwarg data_dir of load_datasets to the path of the directory
+"""
+
+import itertools as it
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = True
+_CITATION = """\
+@article{weeber2001developing,
+  title    = "Developing a test collection for biomedical word sense
+              disambiguation",
+  author   = "Weeber, M and Mork, J G and Aronson, A R",
+  journal  = "Proc AMIA Symp",
+  pages    = "746--750",
+  year     =  2001,
+  language = "en"
+}
+"""
+
+_DATASETNAME = "nlm_wsd"
+_DISPLAYNAME = "NLM WSD"
+
+_DESCRIPTION = """\
+In order to support research investigating the automatic resolution of word sense ambiguity using natural language
+processing techniques, we have constructed this test collection of medical text in which the ambiguities were resolved
+by hand. Evaluators were asked to examine instances of an ambiguous word and determine the sense intended by selecting
+the Metathesaurus concept (if any) that best represents the meaning of that sense. The test collection consists of 50
+highly frequent ambiguous UMLS concepts from 1998 MEDLINE. Each of the 50 ambiguous cases has 100 ambiguous instances
+randomly selected from the 1998 MEDLINE citations. For a total of 5,000 instances. We had a total of 11 evaluators of
+which 8 completed 100% of the 5,000 instances, 1 completed 56%, 1 completed 44%, and the final evaluator completed 12%
+of the instances. Evaluations were only used when the evaluators completed all 100 instances for a given ambiguity.
+"""
+
+_HOMEPAGE = "https://lhncbc.nlm.nih.gov/restricted/ii/areas/WSD/index.html"
+
+_LICENSE = 'UMLS - Metathesaurus License Agreement'
+
+_URLS = {
+    "UMLS": "UMLS1999.tar.gz",
+    "reviewed": "full_reviewed_results.tar.gz",
+    "non_reviewed": "full_non_reviewed_results.tar.gz",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_DISAMBIGUATION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+@dataclass
+class NlmWsdBigBioConfig(BigBioConfig):
+    schema: str = "source"
+    name: str = "nlm_wsd_reviewed_source"
+    version: datasets.Version = datasets.Version(_SOURCE_VERSION)
+    description: str = "NLM-WSD basic reviewed source schema"
+    subset_id: str = "nlm_wsd_reviewed"
+
+
+class NlmWsdDataset(datasets.GeneratorBasedBuilder):
+    """Biomedical Word Sense Disambiguation (WSD)."""
+
+    uid = it.count(0)
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        NlmWsdBigBioConfig(
+            name="nlm_wsd_non_reviewed_source",
+            version=SOURCE_VERSION,
+            description="NLM-WSD basic non reviewed source schema",
+            schema="source",
+            subset_id="nlm_wsd_non_reviewed",
+        ),
+        NlmWsdBigBioConfig(
+            name="nlm_wsd_non_reviewed_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="NLM-WSD basic non reviewed BigBio schema",
+            schema="bigbio_kb",
+            subset_id="nlm_wsd_non_reviewed",
+        ),
+        NlmWsdBigBioConfig(
+            name="nlm_wsd_reviewed_source",
+            version=SOURCE_VERSION,
+            description="NLM-WSD basic reviewed source schema",
+            schema="source",
+            subset_id="nlm_wsd_reviewed",
+        ),
+        NlmWsdBigBioConfig(
+            name="nlm_wsd_reviewed_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="NLM-WSD basic reviewed BigBio schema",
+            schema="bigbio_kb",
+            subset_id="nlm_wsd_reviewed",
+        ),
+    ]
+
+    BUILDER_CONFIG_CLASS = NlmWsdBigBioConfig
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "sentence_id": datasets.Value("string"),
+                    "label": datasets.Value("string"),
+                    "sentence": {
+                        "text": datasets.Value("string"),
+                        "ambiguous_word": datasets.Value("string"),
+                        "ambiguous_word_alias": datasets.Value("string"),
+                        "offsets_context": datasets.Sequence(datasets.Value("int32")),
+                        "offsets_ambiguity": datasets.Sequence(datasets.Value("int32")),
+                        "context": datasets.Value("string"),
+                    },
+                    "citation": {
+                        "text": datasets.Value("string"),
+                        "ambiguous_word": datasets.Value("string"),
+                        "ambiguous_word_alias": datasets.Value("string"),
+                        "offsets_context": datasets.Sequence(datasets.Value("int32")),
+                        "offsets_ambiguity": datasets.Sequence(datasets.Value("int32")),
+                        "context": datasets.Value("string"),
+                    },
+                    "choices": [
+                        {
+                            "label": datasets.Value("string"),
+                            "concept": datasets.Value("string"),
+                            "cui": datasets.Value("string"),
+                            "type": [datasets.Value("string")],
+                        }
+                    ],
+                }
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
+        else:
+            data_dir = Path(self.config.data_dir)
+            umls_dir = dl_manager.download_and_extract(data_dir / _URLS["UMLS"])
+            mrcon_path = Path(umls_dir) / "META" / "MRCON"
+            if self.config.subset_id == "nlm_wsd_reviewed":
+                ann_dir = dl_manager.download_and_extract(data_dir / _URLS["reviewed"])
+                ann_dir = Path(ann_dir) / "Reviewed_Results"
+            else:
+                ann_dir = dl_manager.download_and_extract(
+                    data_dir / _URLS["non_reviewed"]
+                )
+                ann_dir = Path(ann_dir) / "Non-Reviewed_Results"
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "mrcon_path": mrcon_path,
+                    "ann_dir": ann_dir,
+                },
+            )
+        ]
+
+    def _generate_examples(self, mrcon_path: Path, ann_dir: Path) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        # read label->cui map
+        umls_map = {}
+        with mrcon_path.open() as f:
+            content = f.readlines()
+        content = [x.strip() for x in content]
+        for line in content:
+            fields = line.split("|")
+            assert len(fields) == 9, f"{len(fields)}"
+            assert fields[0][0] == "C"
+            umls_map[fields[6]] = fields[0]
+
+        for dir in ann_dir.iterdir():
+            if self.config.schema == "source" and dir.is_dir():
+                for example in self._generate_parsed_documents(dir, umls_map):
+                    yield next(self.uid), example
+
+            elif self.config.schema == "bigbio_kb" and dir.is_dir():
+                for example in self._generate_parsed_documents(dir, umls_map):
+                    yield next(self.uid), self._source_to_kb(example)
+
+    def _generate_parsed_documents(self, dir, umls_map):
+
+        # read choices
+        choices = []
+        choices_path = dir / "choices"
+        with choices_path.open() as f:
+            content = f.readlines()
+        content = [x.strip() for x in content]
+        for line in content:
+            label, concept, *type = line.split("|")
+            type = [x.split(", ")[1] for x in type]
+            m = re.search(r"(?<=\().+(?=\))", concept)
+            if m is None:
+                choices.append(
+                    {"label": label, "concept": concept, "type": type, "cui": ""}
+                )
+            else:
+                concept = m.group()
+                choices.append(
+                    {
+                        "label": label,
+                        "concept": concept,
+                        "type": type,
+                        "cui": umls_map[concept],
+                    }
+                )
+
+        file_path = dir / f"{dir.name}_set"
+        with file_path.open() as f:
+            for raw_document in self._generate_raw_documents(f):
+                document = {}
+                id, document_id, label = raw_document[0].strip().split("|")
+
+                info_sentence = self._parse_ambig_pos_info(raw_document[2].strip())
+                info_sentence["text"] = raw_document[1]
+
+                info_citation = self._parse_ambig_pos_info(raw_document[-1].strip())
+                n_cit = len(raw_document) - 3
+                info_citation["text"] = "".join(raw_document[3 : 3 + n_cit])
+
+                document = {
+                    "id": id,
+                    "sentence_id": document_id,
+                    "label": label,
+                    "sentence": info_sentence,
+                    "citation": info_citation,
+                    "choices": choices,
+                }
+                yield document
+
+    def _generate_raw_documents(self, fstream):
+        raw_document = []
+        for line in fstream:
+            if line.strip():
+                raw_document.append(line)
+            elif raw_document:
+                yield raw_document
+                raw_document = []
+        # needed for last document
+        if raw_document:
+            yield raw_document
+
+    def _parse_ambig_pos_info(self, line):
+        infos = line.split("|")
+        assert len(infos) == 8, f"{len(infos)}"
+        pos_info = {
+            "ambiguous_word": infos[0],
+            "ambiguous_word_alias": infos[1],
+            "offsets_context": [infos[2], infos[3]],
+            "offsets_ambiguity": [infos[4], infos[5]],
+            "context": infos[6],
+        }
+        return pos_info
+
+    def _source_to_kb(self, example):
+        document_ = {}
+        document_["events"] = []
+        document_["relations"] = []
+        document_["coreferences"] = []
+        document_["id"] = next(self.uid)
+        document_["document_id"] = example["sentence_id"].split(".")[0]
+
+        citation = example["citation"]
+        document_["passages"] = [
+            {
+                "id": next(self.uid),
+                "type": "",
+                "text": [citation["text"]],
+                "offsets": [[0, len(citation["text"])]],
+            }
+        ]
+        choices = {x["label"]: x["cui"] for x in example["choices"]}
+        types = {x["label"]: x["type"][0] for x in example["choices"]}
+
+        db_id = (
+            "" if example["label"] in ["None", "UNDEF"] else choices[example["label"]]
+        )
+        type = "" if example["label"] in ["None", "UNDEF"] else types[example["label"]]
+        document_["entities"] = [
+            {
+                "id": next(self.uid),
+                "type": type,
+                "text": [citation["ambiguous_word_alias"]],
+                "offsets": [
+                    [
+                        int(citation["offsets_ambiguity"][0]),
+                        int(citation["offsets_ambiguity"][1]) + 1,
+                    ]
+                ],
+                "normalized": [{"db_name": "UMLS", "db_id": db_id}],
+            }
+        ]
+        return document_

--- a/hub/hubscripts/nlmchem_hub.py
+++ b/hub/hubscripts/nlmchem_hub.py
@@ -1,0 +1,371 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+from typing import Dict, Iterator, List, Tuple
+
+import bioc
+import datasets
+from bioc import biocxml
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@Article{islamaj2021nlm,
+title={NLM-Chem, a new resource for chemical entity recognition in PubMed full text literature},
+author={Islamaj, Rezarta and Leaman, Robert and Kim, Sun and Kwon, Dongseop and Wei, Chih-Hsuan and Comeau, Donald C and Peng, Yifan and Cissel, David and Coss, Cathleen and Fisher, Carol and others},
+journal={Scientific Data},
+volume={8},
+number={1},
+pages={1--12},
+year={2021},
+publisher={Nature Publishing Group}
+}
+"""
+
+_DATASETNAME = "nlmchem"
+_DISPLAYNAME = "NLM-Chem"
+
+_DESCRIPTION = """\
+NLM-Chem corpus consists of 150 full-text articles from the PubMed Central Open Access dataset,
+comprising 67 different chemical journals, aiming to cover a general distribution of usage of chemical
+names in the biomedical literature.
+Articles were selected so that human annotation was most valuable (meaning that they were rich in bio-entities,
+and current state-of-the-art named entity recognition systems disagreed on bio-entity recognition.
+"""
+
+_HOMEPAGE = "https://biocreative.bioinformatics.udel.edu/tasks/biocreative-vii/track-2"
+_LICENSE = 'Creative Commons Zero v1.0 Universal'
+
+# files found here `https://ftp.ncbi.nlm.nih.gov/pub/lu/BC7-NLM-Chem-track/` have issues at extraction
+# _URLs = {"biocreative": "https://ftp.ncbi.nlm.nih.gov/pub/lu/NLMChem" }
+_URLs = {
+    "source": "https://ftp.ncbi.nlm.nih.gov/pub/lu/BC7-NLM-Chem-track/BC7T2-NLMChem-corpus_v2.BioC.xml.gz",
+    "bigbio_kb": "https://ftp.ncbi.nlm.nih.gov/pub/lu/BC7-NLM-Chem-track/BC7T2-NLMChem-corpus_v2.BioC.xml.gz",
+    "bigbio_text": "https://ftp.ncbi.nlm.nih.gov/pub/lu/BC7-NLM-Chem-track/BC7T2-NLMChem-corpus_v2.BioC.xml.gz",
+}
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.NAMED_ENTITY_DISAMBIGUATION,
+    Tasks.TEXT_CLASSIFICATION,
+]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class NLMChemDataset(datasets.GeneratorBasedBuilder):
+    """NLMChem"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="nlmchem_source",
+            version=SOURCE_VERSION,
+            description="NLM_Chem source schema",
+            schema="source",
+            subset_id="nlmchem",
+        ),
+        BigBioConfig(
+            name="nlmchem_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="NLM_Chem BigBio schema (KB)",
+            schema="bigbio_kb",
+            subset_id="nlmchem",
+        ),
+        BigBioConfig(
+            name="nlmchem_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="NLM_Chem BigBio schema (TEXT)",
+            schema="bigbio_text",
+            subset_id="nlmchem",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "nlmchem_source"  # It's not mandatory to have a default configuration. Just use one if it make sense.
+
+    def _info(self):
+
+        if self.config.schema == "source":
+            # this is a variation on the BioC format
+            features = datasets.Features(
+                {
+                    "passages": [
+                        {
+                            "document_id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                            "offset": datasets.Value("int32"),
+                            "entities": [
+                                {
+                                    "id": datasets.Value("string"),
+                                    "offsets": [[datasets.Value("int32")]],
+                                    "text": [datasets.Value("string")],
+                                    "type": datasets.Value("string"),
+                                    "normalized": [
+                                        {
+                                            "db_name": datasets.Value("string"),
+                                            "db_id": datasets.Value("string"),
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ]
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+        elif self.config.schema == "bigbio_text":
+            features = text_features
+
+        return datasets.DatasetInfo(
+            # This is the description that will appear on the datasets page.
+            description=_DESCRIPTION,
+            # This defines the different columns of the dataset and their types
+            features=features,  # Here we define them above because they are different between the two configurations
+            # If there's a common (input, target) tuple from the features,
+            # specify them here. They'll be used if as_supervised=True in
+            # builder.as_dataset.
+            supervised_keys=None,
+            # Homepage of the dataset for documentation
+            homepage=_HOMEPAGE,
+            # License for the dataset if available
+            license=str(_LICENSE),
+            # Citation for the dataset
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+        # TODO: This method is tasked with downloading/extracting the data and defining the splits depending on the configuration
+        # If several configurations are possible (listed in BUILDER_CONFIGS), the configuration selected by the user is in self.config.name
+
+        # dl_manager is a datasets.download.DownloadManager that can be used to download and extract URLs
+        # It can accept any type or nested list/dict and will give back the same structure with the url replaced with path to local files.
+        # By default the archives will be extracted and a path to a cached folder where they are extracted is returned instead of the archive
+        my_urls = _URLs[self.config.schema]
+        data_dir = dl_manager.download_and_extract(my_urls)
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # These kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "BC7T2-NLMChem-corpus-train.BioC.xml"
+                    ),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                # These kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "BC7T2-NLMChem-corpus-test.BioC.xml"
+                    ),
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                # These kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "BC7T2-NLMChem-corpus-dev.BioC.xml"
+                    ),
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _get_textcls_example(self, d: bioc.BioCDocument) -> Dict:
+
+        example = {"document_id": d.id, "text": [], "labels": []}
+
+        for p in d.passages:
+            example["text"].append(p.text)
+            for a in p.annotations:
+                if a.infons.get("type") == "MeSH_Indexing_Chemical":
+                    example["labels"].append(a.infons.get("identifier"))
+
+        example["text"] = " ".join(example["text"])
+
+        return example
+
+    def _get_passages_and_entities(
+        self, d: bioc.BioCDocument
+    ) -> Tuple[List[Dict], List[List[Dict]]]:
+
+        passages: List[Dict] = []
+        entities: List[List[Dict]] = []
+
+        text_total_length = 0
+
+        po_start = 0
+
+        for _, p in enumerate(d.passages):
+
+            eo = p.offset - text_total_length
+
+            text_total_length += len(p.text) + 1
+
+            po_end = po_start + len(p.text)
+
+            # annotation used only for document indexing
+            if p.text is None:
+                continue
+
+            dp = {
+                "text": p.text,
+                "type": p.infons.get("type"),
+                "offsets": [(po_start, po_end)],
+                "offset": p.offset,  # original offset
+            }
+
+            po_start = po_end + 1
+
+            passages.append(dp)
+
+            pe = []
+
+            for a in p.annotations:
+
+                a_type = a.infons.get("type")
+
+                # no in-text annotation: only for document indexing
+                if (
+                    self.config.schema == "bigbio_kb"
+                    and a_type == "MeSH_Indexing_Chemical"
+                ):
+                    continue
+
+                offsets, text = get_texts_and_offsets_from_bioc_ann(a)
+
+                da = {
+                    "type": a_type,
+                    "offsets": [(start - eo, end - eo) for (start, end) in offsets],
+                    "text": text,
+                    "id": a.id,
+                    "normalized": self._get_normalized(a),
+                }
+
+                pe.append(da)
+
+            entities.append(pe)
+
+        return passages, entities
+
+    def _get_normalized(self, a: bioc.BioCAnnotation) -> List[Dict]:
+        """
+        Get normalization DB and ID from annotation identifiers
+        """
+
+        identifiers = a.infons.get("identifier")
+
+        if identifiers is not None:
+
+            identifiers = re.split(r",|;", identifiers)
+
+            identifiers = [i for i in identifiers if i != "-"]
+
+            normalized = [i.split(":") for i in identifiers]
+
+            normalized = [
+                {"db_name": elems[0], "db_id": elems[1]} for elems in normalized
+            ]
+
+        else:
+
+            normalized = [{"db_name": "-1", "db_id": "-1"}]
+
+        return normalized
+
+    def _generate_examples(
+        self,
+        filepath: str,
+        split: str,  # method parameters are unpacked from `gen_kwargs` as given in `_split_generators`
+    ) -> Iterator[Tuple[int, Dict]]:
+        """Yields examples as (key, example) tuples."""
+
+        reader = biocxml.BioCXMLDocumentReader(str(filepath))
+
+        if self.config.schema == "source":
+
+            for uid, doc in enumerate(reader):
+
+                passages, passages_entities = self._get_passages_and_entities(doc)
+
+                for p, pe in zip(passages, passages_entities):
+
+                    p.pop("offsets")  # BioC has only start for passages offsets
+
+                    p["document_id"] = doc.id
+                    p["entities"] = pe  # BioC has per passage entities
+
+                yield uid, {"passages": passages}
+
+        elif self.config.schema == "bigbio_text":
+            uid = 0
+            for idx, doc in enumerate(reader):
+
+                example = self._get_textcls_example(doc)
+                example["id"] = uid
+                # global id
+                uid += 1
+
+                yield idx, example
+
+        elif self.config.schema == "bigbio_kb":
+            uid = 0
+            for idx, doc in enumerate(reader):
+
+                # global id
+                uid += 1
+
+                passages, passages_entities = self._get_passages_and_entities(doc)
+
+                # unpack per-passage entities
+                entities = [e for pe in passages_entities for e in pe]
+
+                for p in passages:
+                    p.pop("offset")  # drop original offset
+                    p["text"] = (p["text"],)  # text in passage is Sequence
+                    p["id"] = uid  # override BioC default id
+                    uid += 1
+
+                for e in entities:
+                    e["id"] = uid  # override BioC default id
+                    uid += 1
+
+                # if split == "validation" and uid == 6705:
+                #     breakpoint()
+
+                yield idx, {
+                    "id": uid,
+                    "document_id": doc.id,
+                    "passages": passages,
+                    "entities": entities,
+                    "events": [],
+                    "coreferences": [],
+                    "relations": [],
+                }

--- a/hub/hubscripts/ntcir_13_medweb_hub.py
+++ b/hub/hubscripts/ntcir_13_medweb_hub.py
@@ -1,0 +1,409 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+NTCIR-13 MedWeb (Medical Natural Language Processing for Web Document) task requires
+to perform a multi-label classification that labels for eight diseases/symptoms must
+be assigned to each tweet. Given pseudo-tweets, the output are Positive:p or Negative:n
+labels for eight diseases/symptoms. The achievements of this task can almost be
+directly applied to a fundamental engine for actual applications.
+
+This task provides pseudo-Twitter messages in a cross-language and multi-label corpus,
+covering three languages (Japanese, English, and Chinese), and annotated with eight
+labels such as influenza, diarrhea/stomachache, hay fever, cough/sore throat, headache,
+fever, runny nose, and cold.
+
+The dataset consists of a single archive file:
+    - ntcir13_MedWeb_taskdata.zip
+
+which can be obtained after filling out a form to provide information about the
+usage context under this URL: http://www.nii.ac.jp/dsc/idr/en/ntcir/ntcir.html
+
+The zip archive contains a folder with name 'MedWeb_TestCollection'.
+Inside this folder, there are the following individual data files:
+├── NTCIR-13_MedWeb_en_test.xlsx
+├── NTCIR-13_MedWeb_en_training.xlsx
+├── NTCIR-13_MedWeb_ja_test.xlsx
+├── NTCIR-13_MedWeb_ja_training.xlsx
+├── NTCIR-13_MedWeb_zh_test.xlsx
+└── NTCIR-13_MedWeb_zh_training.xlsx
+
+The excel sheets contain a training and test split for each of the languages
+('en' stands for 'english', 'ja' stands for 'japanese' and 'zh' stands for
+(simplified) chinese).
+
+The archive file containing this dataset must be on the users local machine
+in a single directory that is passed to `datasets.load_dataset` via
+the `data_dir` kwarg. This loader script will read this archive file
+directly (i.e. the user should not uncompress, untar or unzip any of
+the files).
+
+For more information on this dataset, see:
+http://research.nii.ac.jp/ntcir/permission/ntcir-13/perm-en-MedWeb.html
+"""
+
+import re
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import text_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English', 'Chinese', 'Japanese']
+_PUBMED = False
+_LOCAL = True
+_CITATION = """\
+@article{wakamiya2017overview,
+  author    = {Shoko Wakamiya, Mizuki Morita, Yoshinobu Kano, Tomoko Ohkuma and Eiji Aramaki},
+  title     = {Overview of the NTCIR-13 MedWeb Task},
+  journal   = {Proceedings of the 13th NTCIR Conference on Evaluation of Information Access Technologies (NTCIR-13)},
+  year      = {2017},
+  url       = {
+    http://research.nii.ac.jp/ntcir/workshop/OnlineProceedings13/pdf/ntcir/01-NTCIR13-OV-MEDWEB-WakamiyaS.pdf
+  },
+}
+"""
+
+_DATASETNAME = "ntcir_13_medweb"
+_DISPLAYNAME = "NTCIR-13 MedWeb"
+
+_DESCRIPTION = """\
+NTCIR-13 MedWeb (Medical Natural Language Processing for Web Document) task requires
+to perform a multi-label classification that labels for eight diseases/symptoms must
+be assigned to each tweet. Given pseudo-tweets, the output are Positive:p or Negative:n
+labels for eight diseases/symptoms. The achievements of this task can almost be
+directly applied to a fundamental engine for actual applications.
+
+This task provides pseudo-Twitter messages in a cross-language and multi-label corpus,
+covering three languages (Japanese, English, and Chinese), and annotated with eight
+labels such as influenza, diarrhea/stomachache, hay fever, cough/sore throat, headache,
+fever, runny nose, and cold.
+
+For more information, see:
+http://research.nii.ac.jp/ntcir/permission/ntcir-13/perm-en-MedWeb.html
+
+As this dataset also provides a parallel corpus of pseudo-tweets for english,
+japanese and chinese it can also be used to train translation models between
+these three languages.
+"""
+
+_HOMEPAGE = "http://research.nii.ac.jp/ntcir/permission/ntcir-13/perm-en-MedWeb.html"
+
+_LICENSE = 'Creative Commons Attribution 4.0 International'
+
+# NOTE: Data can only be obtained (locally) by first filling out form to provide
+# information about usage context under this link: http://www.nii.ac.jp/dsc/idr/en/ntcir/ntcir.html
+_URLS = {
+    _DATASETNAME: "ntcir13_MedWeb_taskdata.zip",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.TRANSLATION,
+    Tasks.TEXT_CLASSIFICATION,
+]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class NTCIR13MedWebDataset(datasets.GeneratorBasedBuilder):
+    """
+    NTCIR-13 MedWeb (Medical Natural Language Processing for Web Document) task requires
+    to perform a multi-label classification that labels for eight diseases/symptoms must
+    be assigned to each tweet. Given pseudo-tweets, the output are Positive:p or Negative:n
+    labels for eight diseases/symptoms. The achievements of this task can almost be
+    directly applied to a fundamental engine for actual applications.
+
+    This task provides pseudo-Twitter messages in a cross-language and multi-label corpus,
+    covering three languages (Japanese, English, and Chinese), and annotated with eight
+    labels such as influenza, diarrhea/stomachache, hay fever, cough/sore throat, headache,
+    fever, runny nose, and cold.
+
+    For more information, see:
+    http://research.nii.ac.jp/ntcir/permission/ntcir-13/perm-en-MedWeb.html
+
+    As this dataset also provides a parallel corpus of pseudo-tweets for english,
+    japanese and chinese it can also be used to train translation models between
+    these three languages.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        # Source configuration - all classification data for all languages
+        BigBioConfig(
+            name="ntcir_13_medweb_source",
+            version=SOURCE_VERSION,
+            description="NTCIR 13 MedWeb source schema",
+            schema="source",
+            subset_id="ntcir_13_medweb_source",
+        )
+    ]
+    for language_name, language_code in (
+        ("Japanese", "ja"),
+        ("English", "en"),
+        ("Chinese", "zh"),
+    ):
+        # NOTE: BigBio text classification configurations
+        # Text classification data for each language
+        BUILDER_CONFIGS.append(
+            BigBioConfig(
+                name=f"ntcir_13_medweb_classification_{language_code}_bigbio_text",
+                version=BIGBIO_VERSION,
+                description=f"NTCIR 13 MedWeb BigBio {language_name} Classification schema",
+                schema="bigbio_text",
+                subset_id=f"ntcir_13_medweb_classification_{language_code}_bigbio_text",
+            ),
+        )
+
+        for target_language_name, target_language_code in (
+            ("Japanese", "ja"),
+            ("English", "en"),
+            ("Chinese", "zh"),
+        ):
+            # NOTE: BigBio text to text (translation) configurations
+            # Parallel text corpora for all pairs of languages
+            if language_name != target_language_name:
+                BUILDER_CONFIGS.append(
+                    BigBioConfig(
+                        name=f"ntcir_13_medweb_translation_{language_code}_{target_language_code}_bigbio_t2t",
+                        version=BIGBIO_VERSION,
+                        description=(
+                            f"NTCIR 13 MedWeb BigBio {language_name} -> {target_language_name} translation schema",
+                        ),
+                        schema="bigbio_t2t",
+                        subset_id=f"ntcir_13_medweb_translation_{language_code}_{target_language_code}_bigbio_t2t",
+                    ),
+                )
+
+    DEFAULT_CONFIG_NAME = "ntcir_13_medweb_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        # Create the source schema; this schema will keep all keys/information/labels
+        # as close to the original dataset as possible.
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "ID": datasets.Value("string"),
+                    "Language": datasets.Value("string"),
+                    "Tweet": datasets.Value("string"),
+                    "Influenza": datasets.Value("string"),
+                    "Diarrhea": datasets.Value("string"),
+                    "Hayfever": datasets.Value("string"),
+                    "Cough": datasets.Value("string"),
+                    "Headache": datasets.Value("string"),
+                    "Fever": datasets.Value("string"),
+                    "Runnynose": datasets.Value("string"),
+                    "Cold": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == "bigbio_text":
+            features = text_features
+        elif self.config.schema == "bigbio_t2t":
+            features = text2text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
+        else:
+            data_dir = self.config.data_dir
+
+        raw_data_dir = dl_manager.download_and_extract(
+            str(Path(data_dir) / _URLS[_DATASETNAME])
+        )
+
+        data_dir = Path(raw_data_dir) / "MedWeb_TestCollection"
+
+        if self.config.schema == "source":
+            filepaths = {
+                datasets.Split.TRAIN: sorted(Path(data_dir).glob("*_training.xlsx")),
+                datasets.Split.TEST: sorted(Path(data_dir).glob("*_test.xlsx")),
+            }
+        elif self.config.schema == "bigbio_text":
+            # NOTE: Identify the language for the chosen subset using regex
+            pattern = r"ntcir_13_medweb_classification_(?P<language_code>ja|en|zh)_bigbio_text"
+            match = re.search(pattern=pattern, string=self.config.subset_id)
+
+            if not match:
+                raise ValueError(
+                    "Unable to parse language code for text classification from dataset subset id: "
+                    f"'{self.config.subset_id}'. Attempted to parse using this regex pattern: "
+                    f"'{pattern}' but failed to get a match."
+                )
+
+            language_code = match.group("language_code")
+
+            filepaths = {
+                datasets.Split.TRAIN: (
+                    Path(data_dir) / f"NTCIR-13_MedWeb_{language_code}_training.xlsx",
+                ),
+                datasets.Split.TEST: (
+                    Path(data_dir) / f"NTCIR-13_MedWeb_{language_code}_test.xlsx",
+                ),
+            }
+        elif self.config.schema == "bigbio_t2t":
+            pattern = r"ntcir_13_medweb_translation_(?P<source_language_code>ja|en|zh)_(?P<target_language_code>ja|en|zh)_bigbio_t2t"
+            match = re.search(pattern=pattern, string=self.config.subset_id)
+
+            if not match:
+                raise ValueError(
+                    "Unable to parse source and target language codes for translation "
+                    f"from dataset subset id: '{self.config.subset_id}'. Attempted to parse "
+                    f"using this regex pattern: '{pattern}' but failed to get a match."
+                )
+
+            source_language_code = match.group("source_language_code")
+            target_language_code = match.group("target_language_code")
+
+            filepaths = {
+                datasets.Split.TRAIN: (
+                    Path(data_dir)
+                    / f"NTCIR-13_MedWeb_{source_language_code}_training.xlsx",
+                    Path(data_dir)
+                    / f"NTCIR-13_MedWeb_{target_language_code}_training.xlsx",
+                ),
+                datasets.Split.TEST: (
+                    Path(data_dir)
+                    / f"NTCIR-13_MedWeb_{source_language_code}_test.xlsx",
+                    Path(data_dir)
+                    / f"NTCIR-13_MedWeb_{target_language_code}_test.xlsx",
+                ),
+            }
+
+        return [
+            datasets.SplitGenerator(
+                name=split_name,
+                gen_kwargs={
+                    "filepaths": filepaths[split_name],
+                    "split": split_name,
+                },
+            )
+            for split_name in (datasets.Split.TRAIN, datasets.Split.TEST)
+        ]
+
+    def _language_from_filepath(self, filepath: Path):
+        pattern = r"NTCIR-13_MedWeb_(?P<language_code>ja|en|zh)_(training|test).xlsx"
+        match = re.search(pattern=pattern, string=filepath.name)
+
+        if not match:
+            raise ValueError(
+                "Unable to parse language code from filename. "
+                f"Filename was: '{filepath.name}' and tried to parse using this "
+                f"regex pattern: '{pattern}' but failed to get a match."
+            )
+
+        return match.group("language_code")
+
+    def _generate_examples(
+        self, filepaths: Tuple[Path], split: str
+    ) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        if self.config.schema == "source":
+            dataframes = []
+
+            for filepath in filepaths:
+                language_code = self._language_from_filepath(filepath)
+                df = pd.read_excel(filepath, sheet_name=f"{language_code}_{split}")
+                df["Language"] = language_code
+                dataframes.append(df)
+
+            df = pd.concat(dataframes)
+
+            for row_index, row in enumerate(df.itertuples(index=False)):
+                yield row_index, row._asdict()
+
+        elif self.config.schema == "bigbio_text":
+            (filepath,) = filepaths
+            language_code = self._language_from_filepath(filepath)
+
+            df = pd.read_excel(
+                filepath,
+                sheet_name=f"{language_code}_{split}",
+            )
+
+            label_column_names = [
+                column_name
+                for column_name in df.columns
+                if column_name not in ("ID", "Tweet")
+            ]
+            labels = (
+                df[label_column_names]
+                .apply(lambda row: row[row == "p"].index.tolist(), axis=1)
+                .values
+            )
+
+            ids = df["ID"]
+            tweets = df["Tweet"]
+
+            for row_index, (record_labels, record_id, tweet) in enumerate(
+                zip(labels, ids, tweets)
+            ):
+                yield row_index, {
+                    "id": record_id,
+                    "text": tweets,
+                    "document_id": filepath.stem,
+                    "labels": record_labels,
+                }
+        elif self.config.schema == "bigbio_t2t":
+            source_filepath, target_filepath = filepaths
+
+            source_language_code = self._language_from_filepath(source_filepath)
+            target_language_code = self._language_from_filepath(target_filepath)
+
+            source_df = pd.read_excel(
+                source_filepath,
+                sheet_name=f"{source_language_code}_{split}",
+            )[["ID", "Tweet"]]
+            source_df["id_int"] = source_df["ID"].str.extract(r"(\d+)").astype(int)
+
+            target_df = pd.read_excel(
+                target_filepath,
+                sheet_name=f"{target_language_code}_{split}",
+            )[["ID", "Tweet"]]
+            target_df["id_int"] = target_df["ID"].str.extract(r"(\d+)").astype(int)
+
+            df_combined = source_df.merge(
+                target_df, on="id_int", suffixes=("_source", "_target")
+            )[["id_int", "Tweet_source", "Tweet_target"]]
+
+            for row_index, record in enumerate(df_combined.itertuples(index=False)):
+                row = record._asdict()
+                yield row_index, {
+                    "id": f"{row['id_int']}_{source_language_code}_{target_language_code}",
+                    "document_id": f"t2t_{source_language_code}_{target_language_code}",
+                    "text_1": row["Tweet_source"],
+                    "text_2": row["Tweet_target"],
+                    "text_1_name": source_language_code,
+                    "text_2_name": target_language_code,
+                }

--- a/hub/hubscripts/osiris_hub.py
+++ b/hub/hubscripts/osiris_hub.py
@@ -1,0 +1,328 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import itertools
+import os
+import uuid
+import xml.etree.ElementTree as ET
+from typing import List
+
+import datasets
+from numpy import int32
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@ARTICLE{Furlong2008,
+  author = {Laura I Furlong and Holger Dach and Martin Hofmann-Apitius and Ferran Sanz},
+  title = {OSIRISv1.2: a named entity recognition system for sequence variants
+  of genes in biomedical literature.},
+  journal = {BMC Bioinformatics},
+  year = {2008},
+  volume = {9},
+  pages = {84},
+  doi = {10.1186/1471-2105-9-84},
+  pii = {1471-2105-9-84},
+  pmid = {18251998},
+  timestamp = {2013.01.15},
+  url = {http://dx.doi.org/10.1186/1471-2105-9-84}
+}
+"""
+
+_DATASETNAME = "osiris"
+_DISPLAYNAME = "OSIRIS"
+
+_DESCRIPTION = """\
+The OSIRIS corpus is a set of MEDLINE abstracts manually annotated
+with human variation mentions. The corpus is distributed under the terms
+of the Creative Commons Attribution License
+Creative Commons Attribution 3.0 Unported License,
+which permits unrestricted use, distribution, and reproduction in any medium,
+provided the original work is properly cited (Furlong et al, BMC Bioinformatics 2008, 9:84).
+"""
+
+_HOMEPAGE = "https://sites.google.com/site/laurafurlongweb/databases-and-tools/corpora/"
+
+
+_LICENSE = 'Creative Commons Attribution 3.0 Unported'
+
+_URLS = {
+    _DATASETNAME: [
+        "https://github.com/rockt/SETH/blob/master/resources/OSIRIS/corpus.xml?raw=true "
+    ]
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION]
+
+
+_SOURCE_VERSION = "1.2.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class Osiris(datasets.GeneratorBasedBuilder):
+    """
+    The OSIRIS corpus is a set of MEDLINE abstracts manually annotated
+    with human variation mentions.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    # You will be able to load the "source" or "bigbio" configurations with
+    # ds_source = datasets.load_dataset('my_dataset', name='source')
+    # ds_bigbio = datasets.load_dataset('my_dataset', name='bigbio')
+
+    # For local datasets you can make use of the `data_dir` and `data_files` kwargs
+    # https://huggingface.co/docs/datasets/add_dataset.html#downloading-data-files-and-organizing-splits
+    # ds_source = datasets.load_dataset('my_dataset', name='source', data_dir="/path/to/data/files")
+    # ds_bigbio = datasets.load_dataset('my_dataset', name='bigbio', data_dir="/path/to/data/files")
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="osiris_source",
+            version=SOURCE_VERSION,
+            description="osiris source schema",
+            schema="source",
+            subset_id="osiris",
+        ),
+        BigBioConfig(
+            name="osiris_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="osiris BigBio schema",
+            schema="bigbio_kb",
+            subset_id="osiris",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "osiris_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+
+            features = datasets.Features(
+                {
+                    "Pmid": datasets.Value("string"),
+                    "Title": datasets.Value("string"),
+                    "Abstract": datasets.Value("string"),
+                    "genes": [
+                        {
+                            "g_id": datasets.Value("string"),
+                            "g_lex": datasets.Value("string"),
+                            "offsets": [[datasets.Value("int32")]],
+                        }
+                    ],
+                    "variants": [
+                        {
+                            "v_id": datasets.Value("string"),
+                            "v_lex": datasets.Value("string"),
+                            "v_norm": datasets.Value("string"),
+                            "offsets": [[datasets.Value("int32")]],
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir[0]),
+                    "split": "data",
+                },
+            )
+        ]
+
+    def _get_offsets(self, parent: ET.Element, child: ET.Element) -> List[int32]:
+        """
+        Retrieves character offsets for child from parent.
+        """
+        parent_text = " ".join(
+            [
+                " ".join([t for t in c.itertext()])
+                for c in list(parent)
+                if c.tag != "Pmid"
+            ]
+        )
+        child_text = " ".join([t for t in child.itertext()])
+        start = parent_text.index(child_text)
+        end = start + len(child_text)
+        return [start, end]
+
+    def _get_dict(self, elem: ET.Element) -> dict:
+        """
+        Retrieves dict from XML element.
+        """
+        elem_d = dict()
+        for child in elem:
+            elem_d[child.tag] = {}
+            elem_d[child.tag]["text"] = " ".join([t for t in child.itertext()])
+
+            if child.tag != "Pmid":
+                elem_d[child.tag]["offsets"] = self._get_offsets(elem, child)
+
+            for c in child:
+                elem_d[c.tag] = []
+
+            for c in child:
+                c_dict = c.attrib
+                c_dict["offsets"] = self._get_offsets(elem, c)
+                elem_d[c.tag].append(c.attrib)
+
+        return elem_d
+
+    def _handle_missing_variants(self, row: dict) -> dict:
+        """
+        If variant is not present in the row this function adds one variant
+        with no data (to make looping though items possible) and returns the new row.
+        These mocked variants will be romoved after parsing.
+        Otherwise returns unchanged row.
+        """
+
+        if row.get("variant", 0) == 0:
+            row["variant"] = [
+                {"v_id": "", "v_lex": "", "v_norm": "", "offsets": [0, 0]}
+            ]
+        return row
+
+    def _get_entities(self, row: dict) -> List[dict]:
+        """
+        Retrieves two lists of dicts for genes and variants.
+        After that, chains both together.
+        """
+        genes = [
+            {
+                "id": str(uuid.uuid4()),
+                "offsets": [gene["offsets"]],
+                "text": [gene["g_lex"]],
+                "type": "gene",
+                "normalized": [{"db_name": "NCBI Gene", "db_id": gene["g_id"]}],
+            }
+            for gene in row["gene"]
+        ]
+
+        variants = [
+            {
+                "id": str(uuid.uuid4()),
+                "offsets": [variant["offsets"]],
+                "text": [variant["v_lex"]],
+                "type": "variant",
+                "normalized": [
+                    {
+                        "db_name": "HGVS-like" if variant["v_id"] == "No" else "dbSNP",
+                        "db_id": variant["v_norm"]
+                        if variant["v_id"] == "No"
+                        else variant["v_id"],
+                    }
+                ],
+            }
+            for variant in row["variant"]
+            if variant["v_id"] != ""
+        ]
+        return list(itertools.chain(genes, variants))
+
+    def _generate_examples(self, filepath, split):
+
+        root = ET.parse(filepath).getroot()
+        uid = 0
+        if self.config.schema == "source":
+            for elem in list(root):
+                row = self._get_dict(elem)
+
+                # handling missing variants data
+                row = self._handle_missing_variants(row)
+                uid += 1
+                yield uid, {
+                    "Pmid": row["Pmid"]["text"],
+                    "Title": {
+                        "offsets": [row["Title"]["offsets"]],
+                        "text": row["Title"]["text"],
+                    },
+                    "Abstract": {
+                        "offsets": [row["Abstract"]["offsets"]],
+                        "text": row["Abstract"]["text"],
+                    },
+                    "genes": [
+                        {
+                            "g_id": gene["g_id"],
+                            "g_lex": gene["g_lex"],
+                            "offsets": [gene["offsets"]],
+                        }
+                        for gene in row["gene"]
+                    ],
+                    "variants": [
+                        {
+                            "v_id": variant["v_id"],
+                            "v_lex": variant["v_lex"],
+                            "v_norm": variant["v_norm"],
+                            "offsets": [variant["offsets"]],
+                        }
+                        for variant in row["variant"]
+                    ],
+                }
+
+        elif self.config.schema == "bigbio_kb":
+
+            for elem in list(root):
+                row = self._get_dict(elem)
+
+                # handling missing variants data
+                row = self._handle_missing_variants(row)
+                uid += 1
+                yield uid, {
+                    "id": str(uid),
+                    "document_id": row["Pmid"]["text"],
+                    "passages": [
+                        {
+                            "id": str(uuid.uuid4()),
+                            "type": "title",
+                            "text": [row["Title"]["text"]],
+                            "offsets": [row["Title"]["offsets"]],
+                        },
+                        {
+                            "id": str(uuid.uuid4()),
+                            "type": "abstract",
+                            "text": [row["Abstract"]["text"]],
+                            "offsets": [row["Abstract"]["offsets"]],
+                        },
+                    ],
+                    "entities": self._get_entities(row),
+                    "relations": [],
+                    "events": [],
+                    "coreferences": [],
+                }

--- a/hub/hubscripts/paramed_hub.py
+++ b/hub/hubscripts/paramed_hub.py
@@ -1,0 +1,197 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+NEJM is a Chinese-English parallel corpus crawled from the New England Journal of Medicine website.
+English articles are distributed through https://www.nejm.org/ and Chinese articles are distributed through
+http://nejmqianyan.cn/. The corpus contains all article pairs (around 2000 pairs) since 2011.
+The script loads dataset in bigbio schema (using schemas/text-to-text) AND/OR source (default) schema
+"""
+import os  # useful for paths
+from typing import Dict, Iterable, List
+
+import datasets
+
+from .bigbiohub import text2text_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+logger = datasets.logging.get_logger(__name__)
+
+
+_LANGUAGES = ['English', 'Chinese']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@article{liu2021paramed,
+  author    = {Liu, Boxiang and Huang, Liang},
+  title     = {ParaMed: a parallel corpus for English–Chinese translation in the biomedical domain},
+  journal   = {BMC Medical Informatics and Decision Making},
+  volume    = {21},
+  year      = {2021},
+  url       = {https://bmcmedinformdecismak.biomedcentral.com/articles/10.1186/s12911-021-01621-8},
+  doi       = {10.1186/s12911-021-01621-8}
+}
+"""
+_DATASETNAME = "paramed"
+_DISPLAYNAME = "ParaMed"
+
+_DESCRIPTION = """\
+NEJM is a Chinese-English parallel corpus crawled from the New England Journal of Medicine website. 
+English articles are distributed through https://www.nejm.org/ and Chinese articles are distributed through 
+http://nejmqianyan.cn/. The corpus contains all article pairs (around 2000 pairs) since 2011.
+"""
+
+_HOMEPAGE = "https://github.com/boxiangliu/ParaMed"
+
+_LICENSE = 'Creative Commons Attribution 4.0 International'
+
+_URLs = {
+    "source": "https://github.com/boxiangliu/ParaMed/blob/master/data/nejm-open-access.tar.gz?raw=true",
+    "bigbio_t2t": "https://github.com/boxiangliu/ParaMed/blob/master/data/nejm-open-access.tar.gz?raw=true",
+}
+_SUPPORTED_TASKS = [Tasks.TRANSLATION]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+_DATA_DIR = "./processed_data/open_access/open_access"
+
+
+class ParamedDataset(datasets.GeneratorBasedBuilder):
+    """Write a short docstring documenting what this dataset is"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="paramed_source",
+            version=SOURCE_VERSION,
+            description="Paramed source schema",
+            schema="source",
+            subset_id="paramed",
+        ),
+        BigBioConfig(
+            name="paramed_bigbio_t2t",
+            version=BIGBIO_VERSION,
+            description="Paramed BigBio schema",
+            schema="bigbio_t2t",
+            subset_id="paramed",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "paramed_source"
+
+    def _info(self):
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "text_1": datasets.Value("string"),
+                    "text_2": datasets.Value("string"),
+                    "text_1_name": datasets.Value("string"),
+                    "text_2_name": datasets.Value("string"),
+                }
+            )
+
+        elif self.config.schema == "bigbio_t2t":
+            features = text2text_features
+
+        return datasets.DatasetInfo(
+            # This is the description that will appear on the datasets page.
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+
+        my_urls = _URLs[self.config.schema]
+        data_dir = os.path.join(dl_manager.download_and_extract(my_urls), _DATA_DIR)
+        print(data_dir)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_dir,
+                    "zh_file": os.path.join(data_dir, "nejm.train.zh"),
+                    "en_file": os.path.join(data_dir, "nejm.train.en"),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": data_dir,
+                    "zh_file": os.path.join(data_dir, "nejm.dev.zh"),
+                    "en_file": os.path.join(data_dir, "nejm.dev.en"),
+                    "split": "dev",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": data_dir,
+                    "zh_file": os.path.join(data_dir, "nejm.test.zh"),
+                    "en_file": os.path.join(data_dir, "nejm.test.en"),
+                    "split": "test",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, zh_file, en_file, split):
+
+        logger.info("generating examples from = %s", filepath)
+        zh_file = open(zh_file, "r")
+        en_file = open(en_file, "r")
+        zh_file.seek(0)
+        en_file.seek(0)
+        zh_lines = zh_file.readlines()
+        en_lines = en_file.readlines()
+
+        assert len(en_lines) == len(zh_lines), "Line mismatch"
+
+        if self.config.schema == "source":
+            for key, (zh_line, en_line) in enumerate(zip(zh_lines, en_lines)):
+                yield key, {
+                    "document_id": str(key),
+                    "text_1": zh_line,
+                    "text_2": en_line,
+                    "text_1_name": "zh",
+                    "text_2_name": "en",
+                }
+            zh_file.close()
+            en_file.close()
+
+        elif self.config.schema == "bigbio_t2t":
+            uid = 0
+            for key, (zh_line, en_line) in enumerate(zip(zh_lines, en_lines)):
+                uid += 1
+                yield key, {
+                    "id": str(uid),
+                    "document_id": str(key),
+                    "text_1": zh_line,
+                    "text_2": en_line,
+                    "text_1_name": "zh",
+                    "text_2_name": "en",
+                }
+            zh_file.close()
+            en_file.close()

--- a/hub/hubscripts/pcr_hub.py
+++ b/hub/hubscripts/pcr_hub.py
@@ -1,0 +1,229 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+A corpus for plant and chemical entities and for the relationships between them.
+The corpus contains 2218 plant and chemical entities and 600 plant-chemical
+relationships which are drawn from 1109 sentences in 245 PubMed abstracts.
+"""
+from pathlib import Path
+from typing import Dict, Iterator, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{choi2016corpus,
+  title        = {A corpus for plant-chemical relationships in the biomedical domain},
+  author       = {
+    Choi, Wonjun and Kim, Baeksoo and Cho, Hyejin and Lee, Doheon and Lee,
+    Hyunju
+  },
+  year         = 2016,
+  journal      = {BMC bioinformatics},
+  publisher    = {Springer},
+  volume       = 17,
+  number       = 1,
+  pages        = {1--15}
+}
+"""
+
+_DATASETNAME = "pcr"
+_DISPLAYNAME = "PCR"
+
+_DESCRIPTION = """
+A corpus for plant / herb and chemical entities and for the relationships \
+between them. The corpus contains 2218 plant and chemical entities and 600 \
+plant-chemical relationships which are drawn from 1109 sentences in 245 PubMed \
+abstracts.
+"""
+
+_HOMEPAGE = "http://210.107.182.73/plantchemcorpus.htm"
+_LICENSE = 'License information unavailable'
+
+_URLS = {_DATASETNAME: "http://210.107.182.73/1109_corpus_units_STformat.tar"}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.EVENT_EXTRACTION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class PCRDataset(datasets.GeneratorBasedBuilder):
+    """
+    The corpus of plant-chemical relation consists of plants / herbs and
+    chemicals and relations between them.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="pcr_source",
+            version=SOURCE_VERSION,
+            description="PCR source schema",
+            schema="source",
+            subset_id="pcr",
+        ),
+        BigBioConfig(
+            name="pcr_fixed_source",
+            version=SOURCE_VERSION,
+            description="PCR (with fixed offsets) source schema",
+            schema="source",
+            subset_id="pcr_fixed",
+        ),
+        BigBioConfig(
+            name="pcr_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="PCR BigBio schema",
+            schema="bigbio_kb",
+            subset_id="pcr",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "pcr_source"
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "entities": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "normalized": [
+                                {
+                                    "db_name": datasets.Value("string"),
+                                    "db_id": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                    "events": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            # refers to the text_bound_annotation of the trigger
+                            "trigger": {
+                                "text": datasets.Sequence(datasets.Value("string")),
+                                "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            },
+                            "arguments": [
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                },
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        urls = _URLS[_DATASETNAME]
+        data_dir = Path(dl_manager.download_and_extract(urls))
+        data_dir = data_dir / "1109 corpus units"
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"data_dir": data_dir},
+            )
+        ]
+
+    def _generate_examples(self, data_dir: Path) -> Iterator[Tuple[str, Dict]]:
+        if self.config.schema == "source":
+            for file in data_dir.iterdir():
+                if not str(file).endswith(".txt"):
+                    continue
+
+                example = parsing.parse_brat_file(file)
+                example = parsing.brat_parse_to_bigbio_kb(example)
+                example = self._to_source_example(example)
+
+                # Three documents have incorrect offsets - fix them for fixed_source scheme
+                if self.config.subset_id == "pcr_fixed" and example["document_id"] in [
+                    "463",
+                    "509",
+                    "566",
+                ]:
+                    example = self._fix_example(example)
+
+                yield example["document_id"], example
+
+        elif self.config.schema == "bigbio_kb":
+            for file in data_dir.iterdir():
+                if not str(file).endswith(".txt"):
+                    continue
+
+                example = parsing.parse_brat_file(file)
+                example = parsing.brat_parse_to_bigbio_kb(example)
+
+                document_id = example["document_id"]
+                example["id"] = document_id
+
+                # Three documents have incorrect offsets - fix them for BigBio scheme
+                if document_id in ["463", "509", "566"]:
+                    example = self._fix_example(example)
+
+                yield example["id"], example
+
+    def _to_source_example(self, bigbio_example: Dict) -> Dict:
+        """
+        Converts an example in BigBio-KB scheme to an example according to the source scheme
+        """
+        source_example = bigbio_example.copy()
+        source_example["text"] = bigbio_example["passages"][0]["text"][0]
+
+        source_example.pop("passages", None)
+        source_example.pop("relations", None)
+        source_example.pop("coreferences", None)
+
+        return source_example
+
+    def _fix_example(self, example: Dict) -> Dict:
+        """
+        Fixes by the example by adapting the offsets of the trigger word of the first
+        event. In the official annotation data the end offset is incorrect (for 3 examples).
+        """
+        first_event = example["events"][0]
+        trigger_text = first_event["trigger"]["text"][0]
+        offsets = first_event["trigger"]["offsets"][0]
+
+        real_offsets = [offsets[0], offsets[0] + len(trigger_text)]
+        example["events"][0]["trigger"]["offsets"] = [real_offsets]
+
+        return example

--- a/hub/hubscripts/pdr_hub.py
+++ b/hub/hubscripts/pdr_hub.py
@@ -1,0 +1,462 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+The corpus of plant-disease relation consists of plants and diseases and their relation to PubMed abstract.
+The corpus consists of about 2400 plant and disease entities and 300 annotated relations from 179 abstracts.
+
+The big-bio and source version of this script are made by merging the 2 provided annotations on locations they intersected.
+Both annotations (1, 2) are provided as separate source schemas.
+"""
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Iterator, Optional, Tuple
+
+import datasets
+
+from .bigbiohub import 
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{kim2019corpus,
+  title={A corpus of plant--disease relations in the biomedical domain},
+  author={Kim, Baeksoo and Choi, Wonjun and Lee, Hyunju},
+  journal={PLoS One},
+  volume={14},
+  number={8},
+  pages={e0221582},
+  year={2019},
+  publisher={Public Library of Science San Francisco, CA USA}
+}
+"""
+
+_DATASETNAME = "pdr"
+_DISPLAYNAME = "PDR"
+
+_DESCRIPTION = """
+The corpus of plant-disease relation consists of plants and diseases and their relation to PubMed abstract.
+The corpus consists of about 2400 plant and disease entities and 300 annotated relations from 179 abstracts.
+"""
+
+_HOMEPAGE = "http://gcancer.org/pdr/"
+_LICENSE = 'License information unavailable'
+_URLS = {_DATASETNAME: "http://gcancer.org/pdr/Plant-Disease_Corpus.tar.gz"}
+
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    # Tasks.RELATION_EXTRACTION,
+    Tasks.EVENT_EXTRACTION,
+    Tasks.COREFERENCE_RESOLUTION,
+]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class PDRDataset(datasets.GeneratorBasedBuilder):
+    """The corpus of plant-disease relation consists of plants and diseases and their relation to PubMed abstract"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="pdr_annotator1_source",
+            version=SOURCE_VERSION,
+            description="PDR annotator 1 source schema",
+            schema="source",
+            subset_id="pdr_annotator1",
+        ),
+        BigBioConfig(
+            name="pdr_annotator2_source",
+            version=SOURCE_VERSION,
+            description="PDR annotator 2 source schema",
+            schema="source",
+            subset_id="pdr_annotator2",
+        ),
+        BigBioConfig(
+            name="pdr_source",
+            version=SOURCE_VERSION,
+            description="PDR source schema",
+            schema="source",
+            subset_id="pdr",
+        ),
+        BigBioConfig(
+            name="pdr_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="PDR BigBio schema",
+            schema="bigbio_kb",
+            subset_id="pdr",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "pdr_source"
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "entities": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "normalized": [
+                                {
+                                    "db_name": datasets.Value("string"),
+                                    "db_id": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                    "relations": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arg1_id": datasets.Value("string"),
+                            "arg2_id": datasets.Value("string"),
+                            "normalized": [
+                                {
+                                    "db_name": datasets.Value("string"),
+                                    "db_id": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                    "events": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            # refers to the text_bound_annotation of the trigger
+                            "trigger": {
+                                "text": datasets.Sequence(datasets.Value("string")),
+                                "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            },
+                            "arguments": [
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                    "coreferences": [
+                        {
+                            "id": datasets.Value("string"),
+                            "entity_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                },
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        urls = _URLS[_DATASETNAME]
+        data_dir = Path(dl_manager.download_and_extract(urls))
+        data_dir = data_dir / "Plant-Disease_Corpus"
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"data_dir": data_dir},
+            )
+        ]
+
+    def _generate_examples(self, data_dir: Path) -> Iterator[Tuple[str, Dict]]:
+        if self.config.schema == "source":
+            for file in data_dir.iterdir():
+                if not str(file).endswith(".txt"):
+                    continue
+
+                if self.config.subset_id == "pdr_annotator1":
+                    # Provide annotations of annotator 1
+                    example = parsing.parse_brat_file(file, [".ann"])
+                    example = parsing.brat_parse_to_bigbio_kb(example)
+
+                elif self.config.subset_id == "pdr_annotator2":
+                    # Provide annotations of annotator 2
+                    example = parsing.parse_brat_file(file, [".ann2"])
+                    example = parsing.brat_parse_to_bigbio_kb(example)
+
+                elif self.config.subset_id == "pdr":
+                    # Provide merged version of annotator 1 and 2
+                    annotator1 = parsing.parse_brat_file(file, [".ann"])
+                    annotator1 = parsing.brat_parse_to_bigbio_kb(annotator1)
+
+                    annotator2 = parsing.parse_brat_file(file, [".ann2"])
+                    annotator2 = parsing.brat_parse_to_bigbio_kb(annotator2)
+
+                    example = self._merge_annotations_by_intersection(
+                        file, annotator1, annotator2
+                    )
+
+                example["text"] = example["passages"][0]["text"][0]
+                example.pop("id", None)
+                example.pop("passages", None)
+
+                yield example["document_id"], example
+
+        elif self.config.schema == "bigbio_kb":
+            for file in data_dir.iterdir():
+                if not str(file).endswith(".txt"):
+                    continue
+
+                annotator1 = parsing.parse_brat_file(file, [".ann"])
+                annotator1 = parsing.brat_parse_to_bigbio_kb(annotator1)
+
+                annotator2 = parsing.parse_brat_file(file, [".ann2"])
+                annotator2 = parsing.brat_parse_to_bigbio_kb(annotator2)
+
+                merged_annotation = self._merge_annotations_by_intersection(
+                    file, annotator1, annotator2
+                )
+                merged_annotation["id"] = merged_annotation["document_id"]
+
+                yield merged_annotation["id"], merged_annotation
+
+    def _merge_annotations_by_intersection(
+        self, file: Path, example_ann1: Dict, example_ann2: Dict
+    ) -> Dict:
+        """
+        Merges the two given examples by only keeping annotations on which both annotators agree.
+        """
+        id_prefix = str(file.stem) + "_"
+
+        # Mapping entity identifiers from annotator 1 / 2 to merged entity ids
+        a1_entity_to_merged_entity = {}
+        a2_entity_to_merged_entity = {}
+        merged_entities = []
+
+        # 1. Find all common entities, i.e. both annotators agree on same type and their offsets overlap
+        entity_id = 1
+        for entity1 in example_ann1["entities"]:
+            for entity2 in example_ann2["entities"]:
+                if (
+                    self._overlaps(entity1, entity2)
+                    and entity1["type"] == entity2["type"]
+                ):
+                    text_entity1 = "".join(entity1["text"])
+                    text_entity2 = "".join(entity2["text"])
+
+                    longer_entity = (
+                        entity1 if len(text_entity1) > len(text_entity2) else entity2
+                    )
+                    merged_entity_id = id_prefix + f"E{entity_id}"
+                    entity_id += 1
+
+                    merged_entity = longer_entity.copy()
+                    merged_entity["id"] = merged_entity_id
+                    merged_entity["normalized"] = []
+                    merged_entities.append(merged_entity)
+
+                    a1_entity_to_merged_entity[entity1["id"]] = merged_entity_id
+                    a2_entity_to_merged_entity[entity2["id"]] = merged_entity_id
+                    break
+
+        # Find all relations the two annotators agree on
+        relations_ann1 = self._map_relations(example_ann1, a1_entity_to_merged_entity)
+        relations_ann2 = self._map_relations(example_ann2, a2_entity_to_merged_entity)
+        relations = []
+        relation_id = 1
+
+        for rel_type, relations_1 in relations_ann1.items():
+            relations_2 = relations_ann2[rel_type]
+
+            for relation_pair_1 in relations_1:
+                for relation_pair_2 in relations_2:
+                    if relation_pair_1 == relation_pair_2:
+                        relations.append(
+                            {
+                                "id": id_prefix + f"R{relation_id}",
+                                "type": rel_type,
+                                "arg1_id": relation_pair_1[0],
+                                "arg2_id": relation_pair_1[1],
+                                "normalized": [],
+                            }
+                        )
+                        relation_id += 1
+                        break
+
+        # Find all events the two annotators agree on
+        events_ann1 = self._map_events(example_ann1, a1_entity_to_merged_entity)
+        events_ann2 = self._map_events(example_ann2, a2_entity_to_merged_entity)
+        events = []
+        event_id = 1
+
+        for event_type, events_1 in events_ann1.items():
+            events_2 = events_ann2[event_type]
+
+            for (trigger1, theme1, cause1) in events_1:
+                for (trigger2, theme2, cause2) in events_2:
+                    if (
+                        theme1 == theme2
+                        and cause1 == cause2
+                        and self._overlaps(trigger1, trigger2)
+                    ):
+                        trigger1_text = "".join(trigger1["text"])
+                        trigger2_text = "".join(trigger2["text"])
+
+                        longer_trigger = (
+                            trigger1
+                            if len(trigger1_text) >= len(trigger2_text)
+                            else trigger2
+                        )
+                        events.append(
+                            {
+                                "id": id_prefix + f"T{event_id}",
+                                "type": event_type,
+                                "trigger": longer_trigger,
+                                "arguments": [
+                                    {"role": "Theme", "ref_id": theme1},
+                                    {"role": "Cause", "ref_id": cause1},
+                                ],
+                            }
+                        )
+                        event_id += 1
+                        break
+
+        # Find all coreferences the annotators agree on
+        coferences_ann1 = self._map_coreferences(
+            example_ann1, a1_entity_to_merged_entity
+        )
+        coferences_ann2 = self._map_coreferences(
+            example_ann2, a2_entity_to_merged_entity
+        )
+        coreferences = []
+        coreference_id = 1
+
+        for _, entity_ids1 in coferences_ann1.items():
+            for _, entity_ids2 in coferences_ann2.items():
+                if entity_ids1.intersection(entity_ids2) == entity_ids1.union(
+                    entity_ids2
+                ):
+                    coreferences.append(
+                        {
+                            "id": id_prefix + f"CO{coreference_id}",
+                            "entity_ids": list(entity_ids1),
+                        }
+                    )
+                    coreference_id += 1
+
+        merged_example = example_ann1.copy()
+        merged_example["entities"] = merged_entities
+        merged_example["relations"] = relations
+        merged_example["events"] = events
+        merged_example["coreferences"] = coreferences
+
+        return merged_example
+
+    def _map_relations(self, example: Dict, entity_id_mapping: Dict) -> Dict:
+        """
+        Maps the all relations of the given example to their merged entity identifiers
+        (if existent)
+        """
+        relation_map = defaultdict(list)
+
+        for relation in example["relations"]:
+            arg1_id = relation["arg1_id"]
+            arg2_id = relation["arg2_id"]
+
+            # Are both entities also in the merged version?
+            if arg1_id not in entity_id_mapping or arg2_id not in entity_id_mapping:
+                continue
+
+            com_arg1_id = entity_id_mapping[arg1_id]
+            com_arg2_id = entity_id_mapping[arg2_id]
+
+            relation_map[relation["type"]].append((com_arg1_id, com_arg2_id))
+
+        return relation_map
+
+    def _map_events(self, example: Dict, entity_id_mapping: Dict) -> Dict:
+        """
+        Maps the all events of the given example to their merged entity identifiers
+        (if existent)
+        """
+        event_map = defaultdict(list)
+
+        for event in example["events"]:
+            theme_id = self._get_event_argument(event, "Theme")
+            cause_id = self._get_event_argument(event, "Cause")
+
+            if theme_id not in entity_id_mapping or cause_id not in entity_id_mapping:
+                continue
+
+            common_theme_id = entity_id_mapping[theme_id]
+            common_cause_id = entity_id_mapping[cause_id]
+
+            event_map[event["type"]].append(
+                (event["trigger"], common_theme_id, common_cause_id)
+            )
+
+        return event_map
+
+    def _map_coreferences(self, annotation: Dict, entity_mapping: Dict) -> Dict:
+        """
+        Maps the all coreferences of the given example to their merged entity identifiers
+        (if existent)
+        """
+        id_to_corefs = defaultdict(set)
+        for coreference in annotation["coreferences"]:
+            entity_ids = set(
+                [
+                    entity_mapping[id]
+                    for id in coreference["entity_ids"]
+                    if id in entity_mapping
+                ]
+            )
+
+            # Are both id's also in the merged version?
+            if len(entity_ids) > 1:
+                id_to_corefs[coreference["id"]] = entity_ids
+
+        return id_to_corefs
+
+    def _overlaps(self, annotation1: Dict, annotation2: Dict) -> bool:
+        """
+        Checks whether the offsets of the two given annotations overlap.
+        """
+        for (start1, end1) in annotation1["offsets"]:
+            for (start2, end2) in annotation2["offsets"]:
+                if (start2 <= start1 <= end2) or (start2 <= end1 <= end2):
+                    return True
+
+        return False
+
+    def _get_event_argument(self, event: Dict, role: str) -> Optional[str]:
+        """
+        Returns the argument with the given role from the given event annotation.
+        """
+        for argument in event["arguments"]:
+            if argument["role"] == role:
+                return argument["ref_id"]
+
+        return None

--- a/hub/hubscripts/pharmaconer_hub.py
+++ b/hub/hubscripts/pharmaconer_hub.py
@@ -1,0 +1,355 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A dataset loading script for the PharmaCoNER corpus.
+
+The PharmaCoNER datset is a manually annotated collection of clinical case
+studies derived from the Spanish Clinical Case Corpus (SPACCC). It was designed
+for the Pharmacological Substances, Compounds and Proteins NER track, the first
+shared task on detecting drug and chemical entities in Spanish medical documents.
+"""
+
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['Spanish']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@inproceedings{gonzalez2019pharmaconer,
+    title = "PharmaCoNER: Pharmacological Substances, Compounds and proteins Named Entity Recognition track",
+    author = "Gonzalez-Agirre, Aitor  and
+      Marimon, Montserrat  and
+      Intxaurrondo, Ander  and
+      Rabal, Obdulia  and
+      Villegas, Marta  and
+      Krallinger, Martin",
+    booktitle = "Proceedings of The 5th Workshop on BioNLP Open Shared Tasks",
+    month = nov,
+    year = "2019",
+    address = "Hong Kong, China",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/D19-5701",
+    doi = "10.18653/v1/D19-5701",
+    pages = "1--10",
+}
+"""
+
+_DATASETNAME = "pharmaconer"
+_DISPLAYNAME = "PharmaCoNER"
+
+_GENERAL_DESCRIPTION = """\
+PharmaCoNER: Pharmacological Substances, Compounds and Proteins Named Entity Recognition track
+
+This dataset is designed for the PharmaCoNER task, sponsored by Plan de Impulso de las Tecnologías del Lenguaje.
+
+It is a manually classified collection of clinical case studies derived from the Spanish Clinical \
+Case Corpus (SPACCC), an open access electronic library that gathers Spanish medical publications \
+from SciELO (Scientific Electronic Library Online).
+
+The annotation of the entire set of entity mentions was carried out by medicinal chemistry experts \
+and it includes the following 4 entity types: NORMALIZABLES, NO_NORMALIZABLES, PROTEINAS and UNCLEAR.
+
+The PharmaCoNER corpus contains a total of 396,988 words and 1,000 clinical cases that have been \
+randomly sampled into 3 subsets. The training set contains 500 clinical cases, while the development \
+and test sets contain 250 clinical cases each.
+
+For further information, please visit https://temu.bsc.es/pharmaconer/ or send an email to encargo-pln-life@bsc.es
+"""
+
+_DESCRIPTION_SUBTRACK_1 = """\
+\n\nSUBTRACK 1: NER offset and entity type classification\n
+The first subtrack consists in the classical entity-based or instanced-based evaluation that requires \
+that system outputs match exactly the beginning and end locations of each entity tag, as well as match \
+the entity annotation type of the gold standard annotations.
+"""
+
+_DESCRIPTION_SUBTRACK_2 = """\
+\n\nSUBTRACK 2: CONCEPT INDEXING\n
+In the second subtask, a list of unique SNOMED concept identifiers have to be generated for each document. \
+The predictions are compared to the manually annotated concept ids corresponding to chemical compounds and \
+pharmacological substances.
+"""
+
+_DESCRIPTION = {
+    "subtrack_1": _GENERAL_DESCRIPTION + _DESCRIPTION_SUBTRACK_1,
+    "subtrack_2": _GENERAL_DESCRIPTION + _DESCRIPTION_SUBTRACK_2,
+    "full_task": _GENERAL_DESCRIPTION
+    + _DESCRIPTION_SUBTRACK_1
+    + _DESCRIPTION_SUBTRACK_2,
+}
+
+_HOMEPAGE = "https://temu.bsc.es/pharmaconer/index.php/datasets/"
+
+_LICENSE = 'Creative Commons Attribution 4.0 International'
+
+_URLS = {
+    "pharmaconer": "https://zenodo.org/record/4270158/files/pharmaconer.zip?download=1",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.TEXT_CLASSIFICATION]
+
+_SOURCE_VERSION = "1.1.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class PharmaconerDataset(datasets.GeneratorBasedBuilder):
+    """Manually annotated collection of clinical case studies from Spanish medical publications."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="pharmaconer_source",
+            version=SOURCE_VERSION,
+            description="PharmaCoNER source schema",
+            schema="source",
+            subset_id="full_task",
+        ),
+        BigBioConfig(
+            name="pharmaconer_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="PharmaCoNER BigBio schema",
+            schema="bigbio_kb",
+            subset_id="subtrack_1",
+        ),
+        BigBioConfig(
+            name="pharmaconer_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="PharmaCoNER BigBio schema",
+            schema="bigbio_text",
+            subset_id="subtrack_2",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "pharmaconer_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "labels": [datasets.Value("string")],  # subtrack 2 codes
+                    "text_bound_annotations": [  # T line in brat
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "trigger": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arguments": datasets.Sequence(
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "attributes": [  # M or A lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value("string"),
+                            "cuid": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                        }
+                    ],
+                },
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        elif self.config.schema == "bigbio_text":
+            features = text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION[self.config.subset_id],
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """
+        Downloads/extracts the data to generate the train, validation and test splits.
+
+        Each split is created by instantiating a `datasets.SplitGenerator`, which will
+        call `this._generate_examples` with the keyword arguments in `gen_kwargs`.
+        """
+
+        data_dir = dl_manager.download_and_extract(_URLS["pharmaconer"])
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepaths": [
+                        Path(
+                            os.path.join(
+                                data_dir, "pharmaconer/train-set_1.1/train/subtrack1"
+                            )
+                        ),
+                        Path(
+                            os.path.join(
+                                data_dir, "pharmaconer/train-set_1.1/train/subtrack2"
+                            )
+                        ),
+                    ],
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepaths": [
+                        Path(
+                            os.path.join(
+                                data_dir, "pharmaconer/test-set_1.1/test/subtrack1"
+                            )
+                        ),
+                        Path(
+                            os.path.join(
+                                data_dir, "pharmaconer/test-set_1.1/test/subtrack2"
+                            )
+                        ),
+                    ],
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepaths": [
+                        Path(
+                            os.path.join(
+                                data_dir, "pharmaconer/dev-set_1.1/dev/subtrack1"
+                            )
+                        ),
+                        Path(
+                            os.path.join(
+                                data_dir, "pharmaconer/dev-set_1.1/dev/subtrack2"
+                            )
+                        ),
+                    ],
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepaths, split: str) -> Tuple[int, Dict]:
+        """
+        This method handles input defined in _split_generators to yield (key, example) tuples from the dataset.
+        Method parameters are unpacked from `gen_kwargs` as given in `_split_generators`.
+        """
+
+        txt_files = sorted(list(filepaths[0].glob("*txt")))
+        tsv_files = sorted(list(filepaths[1].glob("*tsv")))
+
+        if self.config.schema == "source":
+            for guid, (txt_file, tsv_file) in enumerate(zip(txt_files, tsv_files)):
+                example = parsing.parse_brat_file(txt_file)
+                try:
+                    subtrack2_df = pd.read_csv(tsv_file, sep="\t", header=None)
+                    subtrack2_df[1] = subtrack2_df[1].apply(str)
+                    codes_set = set(subtrack2_df[1].unique().flatten())
+                    codes_set.discard("<null>")
+                    example["labels"] = list(codes_set)
+                except Exception:  # subtrack 2 has no codes for this document
+                    example["labels"] = []
+                example["id"] = str(guid)
+                yield guid, example
+
+        elif self.config.schema == "bigbio_kb":
+            for guid, (txt_file, tsv_file) in enumerate(zip(txt_files, tsv_files)):
+                example = parsing.brat_parse_to_bigbio_kb(
+                    parsing.parse_brat_file(txt_file)
+                )
+                example["id"] = str(guid)
+                yield guid, example
+
+        elif self.config.schema == "bigbio_text":
+            for guid, (txt_file, tsv_file) in enumerate(zip(txt_files, tsv_files)):
+                brat = parsing.brat_parse_to_bigbio_kb(
+                    parsing.parse_brat_file(txt_file)
+                )
+                try:
+                    subtrack2_df = pd.read_csv(tsv_file, sep="\t", header=None)
+                    subtrack2_df[1] = subtrack2_df[1].apply(str)
+                    codes_set = set(subtrack2_df[1].unique().flatten())
+                    codes_set.discard("<null>")
+                    labels = list(codes_set)
+                except Exception:  # subtrack 2 has no codes for this document
+                    labels = []
+                example = {
+                    "id": str(guid),
+                    "document_id": brat["document_id"],
+                    "text": brat["passages"][0]["text"][0],
+                    "labels": labels,
+                }
+                yield guid, example
+
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/hub/hubscripts/pico_extraction_hub.py
+++ b/hub/hubscripts/pico_extraction_hub.py
@@ -1,0 +1,291 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This dataset contains annotations for Participants, Interventions, and Outcomes (referred to as PICO task).
+For 423 sentences, annotations collected by 3 medical experts are available.
+To get the final annotations, we perform the majority voting.
+The script loads dataset in bigbio schema (using knowledgebase schema: schemas/kb) AND/OR source (default) schema
+"""
+import json
+from typing import Dict, List, Tuple, Union
+
+import datasets
+import numpy as np
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{zlabinger-etal-2020-effective,
+    title = "Effective Crowd-Annotation of Participants, Interventions, and Outcomes in the Text of Clinical Trial Reports",
+    author = {Zlabinger, Markus  and
+      Sabou, Marta  and
+      Hofst{\"a}tter, Sebastian  and
+      Hanbury, Allan},
+    booktitle = "Findings of the Association for Computational Linguistics: EMNLP 2020",
+    month = nov,
+    year = "2020",
+    address = "Online",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2020.findings-emnlp.274",
+    doi = "10.18653/v1/2020.findings-emnlp.274",
+    pages = "3064--3074",
+}
+"""
+
+_DATASETNAME = "pico_extraction"
+_DISPLAYNAME = "PICO Annotation"
+
+
+_DESCRIPTION = """\
+This dataset contains annotations for Participants, Interventions, and Outcomes (referred to as PICO task).
+For 423 sentences, annotations collected by 3 medical experts are available.
+To get the final annotations, we perform the majority voting.
+"""
+
+_HOMEPAGE = "https://github.com/Markus-Zlabinger/pico-annotation"
+
+_LICENSE = 'License information unavailable'
+
+_DATA_PATH = (
+    "https://raw.githubusercontent.com/Markus-Zlabinger/pico-annotation/master/data"
+)
+_URLS = {
+    _DATASETNAME: {
+        "sentence_file": f"{_DATA_PATH}/sentences.json",
+        "annotation_files": {
+            "intervention": f"{_DATA_PATH}/annotations/interventions_expert.json",
+            "outcome": f"{_DATA_PATH}/annotations/outcomes_expert.json",
+            "participant": f"{_DATA_PATH}/annotations/participants_expert.json",
+        },
+    }
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+def _pico_extraction_data_loader(
+    sentence_file: str, annotation_files: Dict[str, str]
+) -> Tuple[Dict[str, str], Dict[str, Dict[str, Dict[str, List[int]]]]]:
+    """Loads four files with PICO extraction dataset:
+    - one json file with sentences
+    - three json files with annotations for PIO
+    """
+    # load sentences
+    with open(sentence_file) as fp:
+        sentences = json.load(fp)
+
+    # load annotations
+    annotation_dict = {}
+    for annotation_type, _file in annotation_files.items():
+        with open(_file) as fp:
+            annotations = json.load(fp)
+            annotation_dict[annotation_type] = annotations
+
+    return sentences, annotation_dict
+
+
+def _get_entities_pico(
+    annotation_dict: Dict[str, Dict[str, Dict[str, List[int]]]],
+    sentence: str,
+    sentence_id: str,
+) -> List[Dict[str, Union[int, str]]]:
+    """extract entities from sentences using annotation_dict"""
+
+    def _partition(alist, indices):
+        return [alist[i:j] for i, j in zip([0] + indices, indices + [None])]
+
+    ents = []
+    for annotation_type, annotations in annotation_dict.items():
+        # get indices from three annotators by majority voting
+        indices = np.where(
+            np.round(np.mean(annotations[sentence_id]["annotations"], axis=0)) == 1
+        )[0]
+
+        if len(indices) > 0:  # if annotations exist for this sentence
+            split_indices = []
+            # if there are two annotations of one type in one sentence
+            for item_index, item in enumerate(indices):
+                if item_index + 1 == len(indices):
+                    break
+                if indices[item_index] + 1 != indices[item_index + 1]:
+                    split_indices.append(item_index + 1)
+            multiple_indices = _partition(indices, split_indices)
+
+            for _indices in multiple_indices:
+
+                annotation_text = " ".join([sentence.split()[ind] for ind in _indices])
+
+                char_start = sentence.find(annotation_text)
+                char_end = char_start + len(annotation_text)
+
+                ent = {
+                    "annotation_text": annotation_text,
+                    "annotation_type": annotation_type,
+                    "char_start": char_start,
+                    "char_end": char_end,
+                }
+
+                ents.append(ent)
+    return ents
+
+
+class PicoExtractionDataset(datasets.GeneratorBasedBuilder):
+    """PICO Extraction dataset with annotations for
+    Participants, Interventions, and Outcomes."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="pico_extraction_source",
+            version=SOURCE_VERSION,
+            description="pico_extraction source schema",
+            schema="source",
+            subset_id="pico_extraction",
+        ),
+        BigBioConfig(
+            name="pico_extraction_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="pico_extraction BigBio schema",
+            schema="bigbio_kb",
+            subset_id="pico_extraction",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "pico_extraction_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "doc_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "entities": [
+                        {
+                            "text": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "start": datasets.Value("int64"),
+                            "end": datasets.Value("int64"),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "split": "train",
+                    "sentence_file": data_dir["sentence_file"],
+                    "annotation_files": data_dir["annotation_files"],
+                },
+            ),
+        ]
+
+    def _generate_examples(self, split, sentence_file, annotation_files):
+        """Yields examples as (key, example) tuples."""
+
+        sentences, annotation_dict = _pico_extraction_data_loader(
+            sentence_file=sentence_file, annotation_files=annotation_files
+        )
+
+        if self.config.schema == "source":
+            for uid, sentence_tuple in enumerate(sentences.items()):
+                sentence_id, sentence = sentence_tuple
+                ents = _get_entities_pico(annotation_dict, sentence, sentence_id)
+
+                data = {
+                    "doc_id": sentence_id,
+                    "text": sentence,
+                    "entities": [
+                        {
+                            "text": ent["annotation_text"],
+                            "type": ent["annotation_type"],
+                            "start": ent["char_start"],
+                            "end": ent["char_end"],
+                        }
+                        for ent in ents
+                    ],
+                }
+                yield uid, data
+
+        elif self.config.schema == "bigbio_kb":
+            uid = 0
+            for id_, sentence_tuple in enumerate(sentences.items()):
+                if id_ < 2:
+                    continue
+                sentence_id, sentence = sentence_tuple
+                ents = _get_entities_pico(annotation_dict, sentence, sentence_id)
+
+                data = {
+                    "id": str(uid),
+                    "document_id": sentence_id,
+                    "passages": [],
+                    "entities": [],
+                    "relations": [],
+                    "events": [],
+                    "coreferences": [],
+                }
+                uid += 1
+
+                data["passages"] = [
+                    {
+                        "id": str(uid),
+                        "type": "sentence",
+                        "text": [sentence],
+                        "offsets": [[0, len(sentence)]],
+                    }
+                ]
+                uid += 1
+
+                for ent in ents:
+                    entity = {
+                        "id": uid,
+                        "type": ent["annotation_type"],
+                        "text": [ent["annotation_text"]],
+                        "offsets": [[ent["char_start"], ent["char_end"]]],
+                        "normalized": [],
+                    }
+                    data["entities"].append(entity)
+                    uid += 1
+
+                yield uid, data

--- a/hub/hubscripts/pmc_patients_hub.py
+++ b/hub/hubscripts/pmc_patients_hub.py
@@ -1,0 +1,207 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+PPS dataset is a list of triplets. Each entry is in format (patient_uid_1, patient_uid_2, similarity)
+where similarity has three values:0, 1, 2, indicating corresponding similarity.
+"""
+
+import json
+import os
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import pairs_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@misc{zhao2022pmcpatients,
+      title={PMC-Patients: A Large-scale Dataset of Patient Notes and Relations Extracted from Case
+          Reports in PubMed Central},
+      author={Zhengyun Zhao and Qiao Jin and Sheng Yu},
+      year={2022},
+      eprint={2202.13876},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}"""
+
+_DATASETNAME = "pmc_patients"
+_DISPLAYNAME = "PMC-Patients"
+
+_DESCRIPTION = """\
+This dataset is used for calculating the similarity between two patient descriptions.
+"""
+
+_HOMEPAGE = "https://github.com/zhao-zy15/PMC-Patients"
+
+_LICENSE = 'Creative Commons Attribution Non Commercial Share Alike 4.0 International'
+
+_URLS = {
+    _DATASETNAME: "https://drive.google.com/u/0/uc?id=1vFCLy_CF8fxPDZvDtHPR6Dl6x9l0TyvW&export=download",
+}
+
+_SUPPORTED_TASKS = [Tasks.SEMANTIC_SIMILARITY]
+
+_SOURCE_VERSION = "1.2.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class PMCPatientsDataset(datasets.GeneratorBasedBuilder):
+    """PPS dataset is a list of triplets.
+    Each entry is in format (patient_uid_1, patient_uid_2, similarity) and their
+    respective texts.
+    where similarity has three values:0, 1, 2, indicating corresponding similarity.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="pmc_patients_source",
+            version=SOURCE_VERSION,
+            description="pmc_patients source schema",
+            schema="source",
+            subset_id="pmc_patients",
+        ),
+        BigBioConfig(
+            name="pmc_patients_bigbio_pairs",
+            version=BIGBIO_VERSION,
+            description="pmc_patients BigBio schema",
+            schema="bigbio_pairs",
+            subset_id="pmc_patients",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "pmc_patients_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "id_text1": datasets.Value("string"),
+                    "id_text2": datasets.Value("string"),
+                    "label": datasets.Value("int8"),
+                }
+            )
+
+        elif self.config.schema == "bigbio_pairs":
+            features = pairs_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir,
+                        "datasets/task_2_patient2patient_similarity/PPS_train.json",
+                    ),
+                    "split": "train",
+                    "data_dir": data_dir,
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir,
+                        "datasets/task_2_patient2patient_similarity/PPS_test.json",
+                    ),
+                    "split": "test",
+                    "data_dir": data_dir,
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir,
+                        "datasets/task_2_patient2patient_similarity/PPS_dev.json",
+                    ),
+                    "split": "dev",
+                    "data_dir": data_dir,
+                },
+            ),
+        ]
+
+    def _generate_examples(
+        self, filepath, split: str, data_dir: str
+    ) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        uid = 0
+
+        def lookup_text(patient_uid: str, df: pd.DataFrame) -> str:
+            try:
+                return df.loc[patient_uid]["patient"]
+            except KeyError:
+                return ""
+
+        with open(filepath, "r") as j:
+            ret_file = json.load(j)
+
+        if self.config.schema == "source":
+
+            for key, (id1, id2, label) in enumerate(ret_file):
+                feature_dict = {
+                    "id": uid,
+                    "id_text1": id1,
+                    "id_text2": id2,
+                    "label": label,
+                }
+                uid += 1
+                yield key, feature_dict
+
+        elif self.config.schema == "bigbio_pairs":
+            source_files = os.path.join(data_dir, f"datasets/PMC-Patients_{split}.json")
+            src_frame = pd.read_json(source_files, encoding="utf8").set_index(
+                "patient_uid"
+            )
+            for key, (id1, id2, label) in enumerate(ret_file):
+                text_1 = lookup_text(id1, src_frame)
+                text_2 = lookup_text(id2, src_frame)
+                # test/dev splits are faulty and may not contain the patient_uid
+                # if any of the lookup texts are empty skip the sample
+                if text_1 == "" or text_2 == "":
+                    continue
+                feature_dict = {
+                    "id": uid,
+                    "document_id": "NULL",
+                    "text_1": text_1,
+                    "text_2": text_2,
+                    "label": label,
+                }
+                uid += 1
+                yield key, feature_dict

--- a/hub/hubscripts/progene_hub.py
+++ b/hub/hubscripts/progene_hub.py
@@ -1,0 +1,354 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+import os
+import pathlib
+from typing import Dict, Iterable, Iterator, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{faessler-etal-2020-progene,
+    title = "{P}ro{G}ene - A Large-scale, High-Quality Protein-Gene Annotated Benchmark Corpus",
+    author = "Faessler, Erik  and
+      Modersohn, Luise  and
+      Lohr, Christina  and
+      Hahn, Udo",
+    booktitle = "Proceedings of the 12th Language Resources and Evaluation Conference",
+    month = may,
+    year = "2020",
+    address = "Marseille, France",
+    publisher = "European Language Resources Association",
+    url = "https://aclanthology.org/2020.lrec-1.564",
+    pages = "4585--4596",
+    abstract = "Genes and proteins constitute the fundamental entities of molecular genetics. We here introduce ProGene (formerly called FSU-PRGE), a corpus that reflects our efforts to cope with this important class of named entities within the framework of a long-lasting large-scale annotation campaign at the Jena University Language {\&} Information Engineering (JULIE) Lab. We assembled the entire corpus from 11 subcorpora covering various biological domains to achieve an overall subdomain-independent corpus. It consists of 3,308 MEDLINE abstracts with over 36k sentences and more than 960k tokens annotated with nearly 60k named entity mentions. Two annotators strove for carefully assigning entity mentions to classes of genes/proteins as well as families/groups, complexes, variants and enumerations of those where genes and proteins are represented by a single class. The main purpose of the corpus is to provide a large body of consistent and reliable annotations for supervised training and evaluation of machine learning algorithms in this relevant domain. Furthermore, we provide an evaluation of two state-of-the-art baseline systems {---} BioBert and flair {---} on the ProGene corpus. We make the evaluation datasets and the trained models available to encourage comparable evaluations of new methods in the future.",
+    language = "English",
+    ISBN = "979-10-95546-34-4",
+}
+"""
+
+_DATASETNAME = "progene"
+_DISPLAYNAME = "ProGene"
+
+_DESCRIPTION = """\
+The Protein/Gene corpus was developed at the JULIE Lab Jena under supervision of Prof. Udo Hahn.
+The executing scientist was Dr. Joachim Wermter.
+The main annotator was Dr. Rico Pusch who is an expert in biology.
+The corpus was developed in the context of the StemNet project (http://www.stemnet.de/).
+"""
+
+_HOMEPAGE = "https://zenodo.org/record/3698568#.YlVHqdNBxeg"
+
+_LICENSE = 'Creative Commons Attribution 4.0 International'
+
+# using custom url: original distribution includes trained models (>25GB) and original dataset license allow for redistribution
+_URLS = "https://huggingface.co/datasets/bigscience-biomedical/progene/resolve/main/crossvalidation_data.zip"
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.1.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class ProgeneDataset(datasets.GeneratorBasedBuilder):
+    """ProgeneDataset"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="progene_source",
+            version=SOURCE_VERSION,
+            description="PROGENE source schema",
+            schema="source",
+            subset_id="progene",
+        ),
+        BigBioConfig(
+            name="progene_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="PROGENE BigBio schema",
+            schema="bigbio_kb",
+            subset_id="progene",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "progene_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            # This follows something similar to CONLL dataset that is in the IOB Format as well
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "tokens": datasets.Sequence(datasets.Value("string")),
+                    "tags": datasets.Sequence(datasets.Value("string")),
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+        else:
+            raise ValueError(
+                "config schema is one of source or bigbio_kb for Progene Dataset"
+            )
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS
+        dl_dir = dl_manager.download_and_extract(urls)
+        dataset_dir = os.path.join(dl_dir, "crossvalidation_data")
+        dataset_dir = pathlib.Path(dataset_dir)
+        splits = []
+        for split_num in range(0, 10):
+            for file in dataset_dir.joinpath(f"flairSplit{split_num}").iterdir():
+                if file.name == "train.txt":
+                    split_id = f"split_{split_num}_{datasets.Split.TRAIN}"
+                elif file.name == "dev.txt":
+                    split_id = f"split_{split_num}_{datasets.Split.VALIDATION}"
+                else:
+                    split_id = f"split_{split_num}_{datasets.Split.TEST}"
+
+                splits.append(
+                    datasets.SplitGenerator(
+                        name=split_id,
+                        gen_kwargs={"filepath": file, "split_id": split_id},
+                    )
+                )
+
+        return splits
+
+    def _generate_examples(self, filepath, split_id: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        with open(filepath, "r") as fp:
+            guid = 0
+            tokens = []
+            ner_tags = []
+            entity_ids = 0
+            for line in fp:
+                if line == "" or line == "\n":
+                    if tokens:
+                        entities = self.iob_tags_to_entities(tokens, ner_tags)
+                        entity_dicts = []
+
+                        for entity in entities:
+                            entity_text = [str(entity[0])]
+                            entity_offset = [entity[1]]
+                            entity_dict = {
+                                "id": f"{split_id}_{entity_ids}_entity",
+                                "type": "progene_text",
+                                "text": entity_text,
+                                "offsets": entity_offset,
+                                "normalized": [],
+                            }
+                            entity_ids += 1
+                            entity_dicts.append(entity_dict)
+
+                        if self.config.schema == "source":
+                            yield f"{split_id}_{guid}", {
+                                "id": f"{split_id}_{guid}",
+                                "tokens": tokens,
+                                "tags": ner_tags,
+                            }
+                        elif self.config.schema == "bigbio_kb":
+                            yield f"{split_id}_{guid}", {
+                                "id": f"{split_id}_{guid}",
+                                "document_id": f"{split_id}_{guid}",
+                                "passages": [
+                                    {
+                                        "id": f"{split_id}_{guid}_passage",
+                                        "type": "progene_text",
+                                        "text": [" ".join(tokens)],
+                                        "offsets": [[0, len(" ".join(tokens))]],
+                                    }
+                                ],
+                                "entities": entity_dicts,
+                                "events": [],
+                                "coreferences": [],
+                                "relations": [],
+                            }
+                        guid += 1
+                        tokens = []
+                        ner_tags = []
+                else:
+                    text_tags = line.split("\t")
+                    token = text_tags[0].strip()
+                    ner_tag = text_tags[1].strip()
+                    tokens.append(token)
+                    ner_tags.append(ner_tag)
+
+            # residual tokens and tags at the end of the file
+            entities = self.iob_tags_to_entities(tokens, ner_tags)
+            entity_dicts = []
+            for entity in entities:
+                entity_text = [str(entity[0])]
+                entity_offset = [entity[1]]
+                entity_dict = {
+                    "id": f"{split_id}_{entity_ids}_entity",
+                    "type": "progene_text",
+                    "text": entity_text,
+                    "offsets": entity_offset,
+                    "normalized": [],
+                }
+                entity_ids += 1
+                entity_dicts.append(entity_dict)
+
+            if self.config.schema == "source":
+                yield f"{split_id}_{guid}", {
+                    "id": f"{split_id}_{guid}",
+                    "tokens": tokens,
+                    "tags": ner_tags,
+                }
+            elif self.config.schema == "bigbio_kb":
+                yield f"{split_id}_{guid}", {
+                    "id": f"{split_id}_{guid}",
+                    "document_id": f"{split_id}_{guid}",
+                    "passages": [
+                        {
+                            "id": f"{split_id}_{guid}_passage",
+                            "type": "progene_text",
+                            "text": [" ".join(tokens)],
+                            "offsets": [[0, len(" ".join(tokens))]],
+                        }
+                    ],
+                    "entities": entity_dicts,
+                    "events": [],
+                    "coreferences": [],
+                    "relations": [],
+                }
+
+    def iob_to_biluo(self, tags: Iterable[str]) -> List[str]:
+        """Converts IOB tags to BILUO tags. This is taken from spacy.training.iob_utils"""
+        out: List[str] = []
+        tags = list(tags)
+        while tags:
+            out.extend(self._consume_os(tags))
+            out.extend(self._consume_ent(tags))
+        return out
+
+    def _consume_os(self, tags: List[str]) -> Iterator[str]:
+        while tags and tags[0] == "O":
+            yield tags.pop(0)
+
+    def _consume_ent(self, tags: List[str]) -> List[str]:
+        if not tags:
+            return []
+        tag = tags.pop(0)
+        target_in = "I" + tag[1:]
+        target_last = "L" + tag[1:]
+        length = 1
+        while tags and tags[0] in {target_in, target_last}:
+            length += 1
+            tags.pop(0)
+        label = tag[2:]
+        if length == 1:
+            if len(label) == 0:
+                raise ValueError("Error parsing iob")
+            return ["U-" + label]
+        else:
+            start = "B-" + label
+            end = "L-" + label
+            middle = [f"I-{label}" for _ in range(1, length - 1)]
+            return [start] + middle + [end]
+
+    def tags_to_entities(self, tags: Iterable[str]) -> List[Tuple[str, int, int]]:
+        """This has been taken from spacy.training.iob_utils
+        Note that the end index returned by this function is inclusive.
+        To use it for Span creation, increment the end by 1."""
+        entities = []
+        start = None
+        for i, tag in enumerate(tags):
+            if tag is None or tag.startswith("-"):
+                # TODO: We shouldn't be getting these malformed inputs. Fix this.
+                if start is not None:
+                    start = None
+                else:
+                    entities.append(("", i, i))
+            elif tag.startswith("O"):
+                pass
+            elif tag.startswith("I"):
+                if start is None:
+                    raise ValueError("Error converting tags to entities")
+            elif tag.startswith("U"):
+                entities.append((tag[2:], i, i))
+            elif tag.startswith("B"):
+                start = i
+            elif tag.startswith("L"):
+                if start is None:
+                    raise ValueError("Error converting tags to entities")
+                entities.append((tag[2:], start, i))
+                start = None
+            else:
+                raise ValueError("Error converting tags to entities")
+        return entities
+
+    def iob_tags_to_entities(self, text: List[str], tags: List[str]):
+        """Converts IOB Tags to a set of entities
+        text: List[str] - A list of tokens
+        tags: List[str] - A list of corresponding tags
+        """
+
+        assert len(text) == len(tags)
+
+        biluo_tags = self.iob_to_biluo(tags)
+        entity_offsets = self.tags_to_entities(biluo_tags)
+        spans = self.get_span_offsets(" ".join(text))
+        entities = []
+        text_string = " ".join(text)
+        for entity, start_word, end_word in entity_offsets:
+            start_char = spans[start_word][0]
+            end_char = (
+                spans[end_word][1] - 1
+            )  # The offsets include the space in the text
+            entity_text = text_string[start_char:end_char]
+            entity_offsets = [start_char, end_char]
+            entities.append((entity_text, entity_offsets))
+
+        return entities
+
+    def get_span_offsets(self, text):
+        """Returns the character offsets for every word in the text.
+        We assume that every word ends in a space for this function
+        """
+        words = text.split()
+        len_words = list(map(lambda word: len(word) + 1, words))
+        offsets = [0] + len_words
+        offsets = itertools.accumulate(offsets)
+        offsets = list(offsets)
+        offsets = list(zip(offsets, offsets[1:]))
+        return offsets
+
+
+if __name__ == "__main__":
+    datasets.load_dataset(__file__, name="progene_bigbio_kb")

--- a/hub/hubscripts/psytar_hub.py
+++ b/hub/hubscripts/psytar_hub.py
@@ -1,0 +1,506 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The "Psychiatric Treatment Adverse Reactions" (PsyTAR) dataset contains 891 drugs
+reviews posted by patients on "askapatient.com", about the effectiveness and adverse
+drug events associated with Zoloft, Lexapro, Cymbalta, and Effexor XR.
+
+For each drug review, patient demographics, duration of treatment, and satisfaction
+with the drugs were reported.
+
+This dataset can be used for:
+
+1. (multi-label) sentence classification, across 5 labels:
+    Adverse Drug Reaction (ADR)
+    Withdrawal Symptoms (WDs)
+    Sign/Symptoms/Illness (SSIs)
+    Drug Indications (DIs)
+    Drug Effectiveness (EF)
+    Drug Infectiveness (INF)
+    and Others (not applicable)
+
+2. Recognition of 5 different types of entity:
+    ADRs (4813 mentions)
+    WDs (590 mentions)
+    SSIs (1219 mentions)
+    DIs (792 mentions)
+
+In the source schema, systematic annotation with UMLS and SNOMED-CT concepts are provided.
+"""
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = True
+_CITATION = """\
+@article{Zolnoori2019,
+  author    = {Maryam Zolnoori and
+               Kin Wah Fung and
+               Timothy B. Patrick and
+               Paul Fontelo and
+               Hadi Kharrazi and
+               Anthony Faiola and
+               Yi Shuan Shirley Wu and
+               Christina E. Eldredge and
+               Jake Luo and
+               Mike Conway and
+               Jiaxi Zhu and
+               Soo Kyung Park and
+               Kelly Xu and
+               Hamideh Moayyed and
+               Somaieh Goudarzvand},
+  title     = {A systematic approach for developing a corpus of patient \
+               reported adverse drug events: A case study for {SSRI} and {SNRI} medications},
+  journal   = {Journal of Biomedical Informatics},
+  volume    = {90},
+  year      = {2019},
+  url       = {https://doi.org/10.1016/j.jbi.2018.12.005},
+  doi       = {10.1016/j.jbi.2018.12.005},
+}
+"""
+
+_DATASETNAME = "psytar"
+_DISPLAYNAME = "PsyTAR"
+
+_DESCRIPTION = """\
+The "Psychiatric Treatment Adverse Reactions" (PsyTAR) dataset contains 891 drugs
+reviews posted by patients on "askapatient.com", about the effectiveness and adverse
+drug events associated with Zoloft, Lexapro, Cymbalta, and Effexor XR.
+
+This dataset can be used for (multi-label) sentence classification of Adverse Drug
+Reaction (ADR), Withdrawal Symptoms (WDs), Sign/Symptoms/Illness (SSIs), Drug
+Indications (DIs), Drug Effectiveness (EF), Drug Infectiveness (INF) and Others, as well
+as for recognition of 5 different types of named entity (in the categories ADRs, WDs,
+SSIs and DIs)
+"""
+
+_HOMEPAGE = "https://www.askapatient.com/research/pharmacovigilance/corpus-ades-psychiatric-medications.asp"
+
+_LICENSE = 'Creative Commons Attribution 4.0 International'
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.TEXT_CLASSIFICATION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+@dataclass
+class PsyTARBigBioConfig(BigBioConfig):
+    schema: str = "source"
+    name: str = "psytar_source"
+    version: datasets.Version = _SOURCE_VERSION
+    description: str = "PsyTAR source schema"
+    subset_id: str = "psytar"
+
+
+class PsyTARDataset(datasets.GeneratorBasedBuilder):
+    """The PsyTAR dataset contains patient's reviews on the effectiveness and adverse
+    drug events associated with Zoloft, Lexapro, Cymbalta, and Effexor XR."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        PsyTARBigBioConfig(
+            name="psytar_source",
+            version=SOURCE_VERSION,
+            description="PsyTAR source schema",
+            schema="source",
+            subset_id="psytar",
+        ),
+        PsyTARBigBioConfig(
+            name="psytar_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="PsyTAR BigBio KB schema",
+            schema="bigbio_kb",
+            subset_id="psytar",
+        ),
+        PsyTARBigBioConfig(
+            name="psytar_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="PsyTAR BigBio text classification schema",
+            schema="bigbio_text",
+            subset_id="psytar",
+        ),
+    ]
+
+    BUILDER_CONFIG_CLASS = PsyTARBigBioConfig
+
+    DEFAULT_CONFIG_NAME = "psytar_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "doc_id": datasets.Value("string"),
+                    "disorder": datasets.Value("string"),
+                    "side_effect": datasets.Value("string"),
+                    "comment": datasets.Value("string"),
+                    "gender": datasets.Value("string"),
+                    "age": datasets.Value("int32"),
+                    "dosage_duration": datasets.Value("string"),
+                    "date": datasets.Value("string"),
+                    "category": datasets.Value("string"),
+                    "sentences": [
+                        {
+                            "text": datasets.Value("string"),
+                            "label": datasets.Sequence([datasets.Value("string")]),
+                            "findings": datasets.Value("string"),
+                            "others": datasets.Value("string"),
+                            "rating": datasets.Value("string"),
+                            "category": datasets.Value("string"),
+                            "entities": [
+                                {
+                                    "text": datasets.Value("string"),
+                                    "type": datasets.Value("string"),
+                                    "mild": datasets.Value("string"),
+                                    "moderate": datasets.Value("string"),
+                                    "severe": datasets.Value("string"),
+                                    "persistent": datasets.Value("string"),
+                                    "non_persistent": datasets.Value("string"),
+                                    "body_site": datasets.Value("string"),
+                                    "rating": datasets.Value("string"),
+                                    "drug": datasets.Value("string"),
+                                    "class": datasets.Value("string"),
+                                    "entity_type": datasets.Value("string"),
+                                    "UMLS": datasets.Sequence(
+                                        [datasets.Value("string")]
+                                    ),
+                                    "SNOMED": datasets.Sequence(
+                                        [datasets.Value("string")]
+                                    ),
+                                }
+                            ],
+                        }
+                    ],
+                }
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+        elif self.config.schema == "bigbio_text":
+            features = text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        if self.config.data_dir is None:
+            raise ValueError(
+                "This is a local dataset. Please pass the data_dir kwarg to load_dataset."
+            )
+        else:
+            data_dir = self.config.data_dir
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": Path(data_dir),
+                },
+            ),
+        ]
+
+    def _extract_labels(self, row):
+        label = [
+            "ADR" * row.ADR,
+            "WD" * row.WD,
+            "EF" * row.EF,
+            "INF" * row.INF,
+            "SSI" * row.SSI,
+            "DI" * row.DI,
+            "Others" * row.others,
+        ]
+        label = [_l for _l in label if _l != ""]
+        return label
+
+    def _columns_to_list(self, row, sheet="ADR"):
+        annotations = []
+        for i in range(30 if sheet == "ADR" else 10):
+            annotations.append(row[f"{sheet}{i + 1}"])
+        annotations = [a for a in annotations if not pd.isna(a)]
+        return annotations
+
+    def _columns_to_bigbio_kb(self, row, sheet="ADR"):
+        annotations = []
+        for i in range(30 if sheet == "ADR" else 10):
+            annotation = row[f"{sheet}{i + 1}"]
+            if not pd.isna(annotation):
+                start_index = row.sentences.lower().find(annotation.lower())
+                if start_index != -1:
+                    end_index = start_index + len(annotation)
+                    entity = {
+                        "id": f"T{i+1}",
+                        "offsets": [[start_index, end_index]],
+                        "text": [annotation],
+                        "type": sheet,
+                    }
+
+                    annotations.append(entity)
+        return annotations
+
+    def _standards_columns_to_list(self, row, standard="UMLS"):
+        standards = {"UMLS": ["UMLS1", "UMLS2"], "SNOMED": ["SNOMED-CT", "SNOMED-CT.1"]}
+        _out_list = []
+        for s in standards[standard]:
+            _out_list.append(row[s])
+        _out_list = [a for a in _out_list if not pd.isna(a)]
+        return _out_list
+
+    def _read_sentence_xlsx(self, filepath: Path) -> pd.DataFrame:
+        sentence_df = pd.read_excel(
+            filepath,
+            sheet_name="Sentence_Labeling",
+            dtype={"drug_id": str, "sentences": str},
+        )
+
+        sentence_df = sentence_df.dropna(subset=["sentences"])
+        sentence_df = sentence_df.loc[
+            sentence_df.sentences.apply(lambda x: len(x.strip())) > 0
+        ]
+        sentence_df = sentence_df.fillna(0)
+
+        sentence_df[["ADR", "WD", "EF", "INF", "SSI", "DI"]] = (
+            sentence_df[["ADR", "WD", "EF", "INF", "SSI", "DI"]]
+            .replace(re.compile("[!* ]+"), 1)
+            .astype(int)
+        )
+
+        sentence_df["sentence_index"] = sentence_df["sentence_index"].astype("int32")
+        sentence_df["drug_id"] = sentence_df["drug_id"].astype("str")
+
+        return sentence_df
+
+    def _read_samples_xlsx(self, filepath: Path) -> pd.DataFrame:
+        samples_df = pd.read_excel(
+            filepath, sheet_name="Sample", dtype={"drug_id": str}
+        )
+        samples_df["age"] = samples_df["age"].fillna(0).astype(int)
+        samples_df["drug_id"] = samples_df["drug_id"].astype("str")
+
+        return samples_df
+
+    def _read_identified_xlsx_to_bigbio_kb(self, filepath: Path) -> Dict:
+        sheet_names = ["ADR", "WD", "SSI", "DI"]
+        identified_entities = {}
+
+        for sheet in sheet_names:
+            identified_entities[sheet] = pd.read_excel(
+                filepath, sheet_name=sheet + "_Identified"
+            )
+            identified_entities[sheet]["bigbio_kb"] = identified_entities[sheet].apply(
+                lambda x: self._columns_to_bigbio_kb(x, sheet), axis=1
+            )
+
+        return identified_entities
+
+    TYPE_TO_COLNAME = {"ADR": "ADRs", "DI": "DIs", "SSI": "SSI", "WD": "WDs"}
+
+    def _identified_mapped_xlsx_to_df(self, filepath: Path) -> pd.DataFrame:
+        sheet_names_mapped = [
+            ["ADR_Mapped", "ADR"],
+            ["WD-Mapped ", "WD"],
+            ["SSI_Mapped", "SSI"],
+            ["DI_Mapped", "DI"],
+        ]
+
+        _mappings = []
+
+        # Read the specific XLSX sheet with _Mapped annotations
+        for sheet, sheet_short in sheet_names_mapped:
+            _df_mapping = pd.read_excel(filepath, sheet_name=sheet)
+
+            # Correcting column names
+            if sheet_short in ["WD"]:
+                _df_mapping = _df_mapping.rename(
+                    columns={"sentence_id": "sentence_index"}
+                )
+
+            # Changing column names to allow concatenation
+            _df_mapping = _df_mapping.rename(
+                columns={self.TYPE_TO_COLNAME[sheet_short]: "entity"}
+            )
+
+            # Putting UMLS and SNOMED annotations in a single column
+            _df_mapping["UMLS"] = _df_mapping.apply(
+                lambda x: self._standards_columns_to_list(x), axis=1
+            )
+            _df_mapping["SNOMED"] = _df_mapping.apply(
+                lambda x: self._standards_columns_to_list(x, standard="SNOMED"), axis=1
+            )
+
+            _mappings.append(_df_mapping)
+
+        df_mappings = pd.concat(_mappings).fillna(0)
+        df_mappings["sentence_index"] = df_mappings["sentence_index"].astype("int32")
+        df_mappings["drug_id"] = df_mappings["drug_id"].astype("str")
+
+        return df_mappings
+
+    def _convert_xlsx_to_source(self, filepath: Path) -> Dict:
+        # Read XLSX files
+        df_sentences = self._read_sentence_xlsx(filepath)
+        df_sentences["label"] = df_sentences.apply(
+            lambda x: self._extract_labels(x), axis=1
+        )
+        df_mappings = self._identified_mapped_xlsx_to_df(filepath)
+        df_samples = self._read_samples_xlsx(filepath)
+
+        # Configure indices
+        df_samples = df_samples.set_index("drug_id").sort_index()
+        df_sentences = df_sentences.set_index(
+            ["drug_id", "sentence_index"]
+        ).sort_index()
+        df_mappings = df_mappings.set_index(["drug_id", "sentence_index"]).sort_index()
+
+        # Iterate over samples
+        for sample_row_id, sample in df_samples.iterrows():
+            sentences = []
+            try:
+                df_sentence_selection = df_sentences.loc[sample_row_id]
+
+                # Iterate over sentences
+                for sentence_row_id, sentence in df_sentence_selection.iterrows():
+                    entities = []
+                    try:
+                        df_mapped_selection = df_mappings.loc[
+                            sample_row_id, sentence_row_id
+                        ]
+
+                        # Iterate over entities per sentence
+                        for mapped_row_id, row in df_mapped_selection.iterrows():
+                            entities.append(
+                                {
+                                    "text": row["entity"],
+                                    "UMLS": row.UMLS,
+                                    "SNOMED": row.SNOMED,
+                                    "entity_type": row.entity_type,
+                                    "type": row.type,
+                                    "class": row["class"],
+                                    "drug": row.drug,
+                                    "rating": row.rating,
+                                    "body_site": row["body-site"],
+                                    "non_persistent": row["not-persistent"],
+                                    "persistent": row["persistent"],
+                                    "severe": row.severe,
+                                    "moderate": row.moderate,
+                                    "mild": row.mild,
+                                }
+                            )
+                    except KeyError:
+                        pass
+
+                    sentences.append(
+                        {
+                            "text": sentence.sentences,
+                            "entities": entities,
+                            "label": sentence.label,
+                            "findings": sentence.Findings,
+                            "others": sentence.others,
+                            "rating": sentence.rating,
+                            "category": sentence.category,
+                        }
+                    )
+            except KeyError:
+                pass
+
+            example = {
+                "id": sample_row_id,
+                "doc_id": sample_row_id,
+                "disorder": sample.disorder,
+                "side_effect": sample["side-effect"],
+                "comment": sample.comment,
+                "gender": sample.gender,
+                "age": sample.age,
+                "dosage_duration": sample.dosage_duration,
+                "date": str(sample.date),
+                "category": sample.category,
+                "sentences": sentences,
+            }
+            yield example
+
+    def _convert_xlsx_to_bigbio_kb(self, filepath: Path) -> Dict:
+        bigbio_kb = self._read_identified_xlsx_to_bigbio_kb(filepath)
+
+        i_doc = 0
+        for _, df in bigbio_kb.items():
+            for _, row in df.iterrows():
+                text = row.sentences
+                entities = row["bigbio_kb"]
+                doc_id = f"{row['drug_id']}_{row['sentence_index']}_{i_doc}"
+
+                if len(entities) != 0:
+                    example = parsing.brat_parse_to_bigbio_kb(
+                        {
+                            "document_id": doc_id,
+                            "text": text,
+                            "text_bound_annotations": entities,
+                            "normalizations": [],
+                            "events": [],
+                            "relations": [],
+                            "equivalences": [],
+                            "attributes": [],
+                        },
+                    )
+                    example["id"] = i_doc
+                    i_doc += 1
+                    yield example
+
+    def _convert_xlsx_to_bigbio_text(self, filepath: Path) -> Dict:
+        df = self._read_sentence_xlsx(filepath)
+        df["label"] = df.apply(lambda x: self._extract_labels(x), axis=1)
+
+        for idx, row in df.iterrows():
+            example = {
+                "id": idx,
+                "document_id": f"{row['drug_id']}_{row['sentence_index']}",
+                "text": row["label"],
+                "labels": row["category"],
+            }
+            yield example
+
+    def _generate_examples(self, filepath) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        if self.config.schema == "source":
+            examples = self._convert_xlsx_to_source(filepath)
+
+        elif self.config.schema == "bigbio_kb":
+            examples = self._convert_xlsx_to_bigbio_kb(filepath)
+
+        elif self.config.schema == "bigbio_text":
+            examples = self._convert_xlsx_to_bigbio_text(filepath)
+
+        for idx, example in enumerate(examples):
+            yield idx, example

--- a/hub/hubscripts/pubhealth_hub.py
+++ b/hub/hubscripts/pubhealth_hub.py
@@ -1,0 +1,209 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+A dataset of 11,832 claims for fact- checking, which are related a range of health topics
+including biomedical subjects (e.g., infectious diseases, stem cell research), government healthcare policy
+(e.g., abortion, mental health, women’s health), and other public health-related stories
+"""
+
+import csv
+import os
+from pathlib import Path
+
+import datasets
+
+from .bigbiohub import pairs_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+logger = datasets.utils.logging.get_logger(__name__)
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@article{kotonya2020explainable,
+  title={Explainable automated fact-checking for public health claims},
+  author={Kotonya, Neema and Toni, Francesca},
+  journal={arXiv preprint arXiv:2010.09926},
+  year={2020}
+}
+"""
+
+_DATASETNAME = "pubhealth"
+_DISPLAYNAME = "PUBHEALTH"
+
+_DESCRIPTION = """\
+A dataset of 11,832 claims for fact- checking, which are related a range of health topics
+including biomedical subjects (e.g., infectious diseases, stem cell research), government healthcare policy
+(e.g., abortion, mental health, women’s health), and other public health-related stories
+"""
+
+_HOMEPAGE = "https://github.com/neemakot/Health-Fact-Checking/tree/master/data"
+
+_LICENSE = 'MIT License'
+
+_URLs = {
+    _DATASETNAME: "https://drive.google.com/uc?export=download&id=1eTtRs5cUlBP5dXsx-FTAlmXuB6JQi2qj"
+}
+
+_SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+_CLASSES = ["true", "false", "unproven", "mixture"]
+
+
+class PUBHEALTHDataset(datasets.GeneratorBasedBuilder):
+    """Pubhealth text classification dataset"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="pubhealth_source",
+            version=SOURCE_VERSION,
+            description="PUBHEALTH source schema",
+            schema="source",
+            subset_id="pubhealth",
+        ),
+        BigBioConfig(
+            name="pubhealth_bigbio_pairs",
+            version=BIGBIO_VERSION,
+            description="PUBHEALTH BigBio schema",
+            schema="bigbio_pairs",
+            subset_id="pubhealth",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "pubhealth_source"
+
+    def _info(self):
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "claim_id": datasets.Value("string"),
+                    "claim": datasets.Value("string"),
+                    "date_published": datasets.Value("string"),
+                    "explanation": datasets.Value("string"),
+                    "fact_checkers": datasets.Value("string"),
+                    "main_text": datasets.Value("string"),
+                    "sources": datasets.Value("string"),
+                    "label": datasets.ClassLabel(names=_CLASSES),
+                    "subjects": datasets.Value("string"),
+                }
+            )
+
+        # Using in entailment schema
+        elif self.config.schema == "bigbio_pairs":
+            features = pairs_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+        urls = _URLs[_DATASETNAME]
+        data_dir = Path(dl_manager.download_and_extract(urls))
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "PUBHEALTH/train.tsv"),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "PUBHEALTH/test.tsv"),
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "PUBHEALTH/dev.tsv"),
+                    "split": "validation",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split):
+        """Yields examples as (key, example) tuples."""
+
+        with open(filepath, encoding="utf-8") as csv_file:
+            csv_reader = csv.reader(
+                csv_file,
+                quotechar='"',
+                delimiter="\t",
+                quoting=csv.QUOTE_NONE,
+                skipinitialspace=True,
+            )
+            next(csv_reader, None)  # remove column headers
+            for id_, row in enumerate(csv_reader):
+                # train.tsv/dev.tsv only has 9 columns
+                # test.tsv has an additional column at the beginning
+                #  Some entries are malformed, will log skipped lines
+                if len(row) < 9:
+                    logger.info("Line %s is malformed", id_)
+                    continue
+                (
+                    claim_id,
+                    claim,
+                    date_published,
+                    explanation,
+                    fact_checkers,
+                    main_text,
+                    sources,
+                    label,
+                    subjects,
+                ) = row[
+                    -9:
+                ]  # only take last 9 columns to fix test.tsv disparity
+
+                if label not in _CLASSES:
+                    logger.info("Line %s is missing label", id_)
+                    continue
+
+                if self.config.schema == "source":
+                    yield id_, {
+                        "claim_id": claim_id,
+                        "claim": claim,
+                        "date_published": date_published,
+                        "explanation": explanation,
+                        "fact_checkers": fact_checkers,
+                        "main_text": main_text,
+                        "sources": sources,
+                        "label": label,
+                        "subjects": subjects,
+                    }
+
+                elif self.config.schema == "bigbio_pairs":
+                    yield id_, {
+                        "id": id_,  # uid is an unique identifier for every record that starts from 0
+                        "document_id": claim_id,
+                        "text_1": claim,
+                        "text_2": explanation,
+                        "label": label,
+                    }

--- a/hub/hubscripts/pubmed_qa_hub.py
+++ b/hub/hubscripts/pubmed_qa_hub.py
@@ -1,0 +1,259 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO: see if we can add long answer for QA task and text classification for MESH tags
+
+import glob
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterator, Tuple
+
+import datasets
+
+from .bigbiohub import qa_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{jin2019pubmedqa,
+  title={PubMedQA: A Dataset for Biomedical Research Question Answering},
+  author={Jin, Qiao and Dhingra, Bhuwan and Liu, Zhengping and Cohen, William and Lu, Xinghua},
+  booktitle={Proceedings of the 2019 Conference on Empirical Methods in Natural Language Processing and the 9th International Joint Conference on Natural Language Processing (EMNLP-IJCNLP)},
+  pages={2567--2577},
+  year={2019}
+}
+"""
+
+_DATASETNAME = "pubmed_qa"
+_DISPLAYNAME = "PubMedQA"
+
+_DESCRIPTION = """\
+PubMedQA is a novel biomedical question answering (QA) dataset collected from PubMed abstracts.
+The task of PubMedQA is to answer research biomedical questions with yes/no/maybe using the corresponding abstracts.
+PubMedQA has 1k expert-annotated (PQA-L), 61.2k unlabeled (PQA-U) and 211.3k artificially generated QA instances (PQA-A).
+
+Each PubMedQA instance is composed of:
+  (1) a question which is either an existing research article title or derived from one,
+  (2) a context which is the corresponding PubMed abstract without its conclusion,
+  (3) a long answer, which is the conclusion of the abstract and, presumably, answers the research question, and
+  (4) a yes/no/maybe answer which summarizes the conclusion.
+
+PubMedQA is the first QA dataset where reasoning over biomedical research texts,
+especially their quantitative contents, is required to answer the questions.
+
+PubMedQA datasets comprise of 3 different subsets:
+  (1) PubMedQA Labeled (PQA-L): A labeled PubMedQA subset comprises of 1k manually annotated yes/no/maybe QA data collected from PubMed articles.
+  (2) PubMedQA Artificial (PQA-A): An artificially labelled PubMedQA subset comprises of 211.3k PubMed articles with automatically generated questions from the statement titles and yes/no answer labels generated using a simple heuristic.
+  (3) PubMedQA Unlabeled (PQA-U): An unlabeled PubMedQA subset comprises of 61.2k context-question pairs data collected from PubMed articles.
+"""
+
+_HOMEPAGE = "https://github.com/pubmedqa/pubmedqa"
+_LICENSE = 'MIT License'
+_URLS = {
+    "pubmed_qa_artificial": "https://drive.google.com/uc?export=download&id=1kaU0ECRbVkrfjBAKtVsPCRF6qXSouoq9",
+    "pubmed_qa_labeled": "https://drive.google.com/uc?export=download&id=1kQnjowPHOcxETvYko7DRG9wE7217BQrD",
+    "pubmed_qa_unlabeled": "https://drive.google.com/uc?export=download&id=1q4T_nhhj8UvJ9JbZedhkTZHN6ZeEZ2H9",
+}
+
+_SUPPORTED_TASKS = [Tasks.QUESTION_ANSWERING]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+_CLASS_NAMES = ["yes", "no", "maybe"]
+
+
+class PubmedQADataset(datasets.GeneratorBasedBuilder):
+    """PubmedQA Dataset"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = (
+        [
+            # PQA-A Source
+            BigBioConfig(
+                name="pubmed_qa_artificial_source",
+                version=SOURCE_VERSION,
+                description="PubmedQA artificial source schema",
+                schema="source",
+                subset_id="pubmed_qa_artificial",
+            ),
+            # PQA-U Source
+            BigBioConfig(
+                name="pubmed_qa_unlabeled_source",
+                version=SOURCE_VERSION,
+                description="PubmedQA unlabeled source schema",
+                schema="source",
+                subset_id="pubmed_qa_unlabeled",
+            ),
+            # PQA-A BigBio Schema
+            BigBioConfig(
+                name="pubmed_qa_artificial_bigbio_qa",
+                version=BIGBIO_VERSION,
+                description="PubmedQA artificial BigBio schema",
+                schema="bigbio_qa",
+                subset_id="pubmed_qa_artificial",
+            ),
+            # PQA-U BigBio Schema
+            BigBioConfig(
+                name="pubmed_qa_unlabeled_bigbio_qa",
+                version=BIGBIO_VERSION,
+                description="PubmedQA unlabeled BigBio schema",
+                schema="bigbio_qa",
+                subset_id="pubmed_qa_unlabeled",
+            ),
+        ]
+        + [
+            # PQA-L Source Schema
+            BigBioConfig(
+                name=f"pubmed_qa_labeled_fold{i}_source",
+                version=datasets.Version(_SOURCE_VERSION),
+                description="PubmedQA labeled source schema",
+                schema="source",
+                subset_id=f"pubmed_qa_labeled_fold{i}",
+            )
+            for i in range(10)
+        ]
+        + [
+            # PQA-L BigBio Schema
+            BigBioConfig(
+                name=f"pubmed_qa_labeled_fold{i}_bigbio_qa",
+                version=datasets.Version(_BIGBIO_VERSION),
+                description="PubmedQA labeled BigBio schema",
+                schema="bigbio_qa",
+                subset_id=f"pubmed_qa_labeled_fold{i}",
+            )
+            for i in range(10)
+        ]
+    )
+
+    DEFAULT_CONFIG_NAME = "pubmed_qa_artificial_source"
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "QUESTION": datasets.Value("string"),
+                    "CONTEXTS": datasets.Sequence(datasets.Value("string")),
+                    "LABELS": datasets.Sequence(datasets.Value("string")),
+                    "MESHES": datasets.Sequence(datasets.Value("string")),
+                    "YEAR": datasets.Value("string"),
+                    "reasoning_required_pred": datasets.Value("string"),
+                    "reasoning_free_pred": datasets.Value("string"),
+                    "final_decision": datasets.Value("string"),
+                    "LONG_ANSWER": datasets.Value("string"),
+                },
+            )
+        elif self.config.schema == "bigbio_qa":
+            features = qa_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        url_id = self.config.subset_id
+        if "pubmed_qa_labeled" in url_id:
+            # Enforce naming since there is fold number in the PQA-L subset
+            url_id = "pubmed_qa_labeled"
+
+        urls = _URLS[url_id]
+        data_dir = Path(dl_manager.download_and_extract(urls))
+
+        if "pubmed_qa_labeled" in self.config.subset_id:
+            return [
+                datasets.SplitGenerator(
+                    name=datasets.Split.TRAIN,
+                    gen_kwargs={
+                        "filepath": data_dir
+                        / self.config.subset_id.replace("pubmed_qa_labeled", "pqal")
+                        / "train_set.json"
+                    },
+                ),
+                datasets.SplitGenerator(
+                    name=datasets.Split.VALIDATION,
+                    gen_kwargs={
+                        "filepath": data_dir
+                        / self.config.subset_id.replace("pubmed_qa_labeled", "pqal")
+                        / "dev_set.json"
+                    },
+                ),
+                datasets.SplitGenerator(
+                    name=datasets.Split.TEST,
+                    gen_kwargs={"filepath": data_dir / "pqal_test_set.json"},
+                ),
+            ]
+        elif self.config.subset_id == "pubmed_qa_artificial":
+            return [
+                datasets.SplitGenerator(
+                    name=datasets.Split.TRAIN,
+                    gen_kwargs={"filepath": data_dir / "pqaa_train_set.json"},
+                ),
+                datasets.SplitGenerator(
+                    name=datasets.Split.VALIDATION,
+                    gen_kwargs={"filepath": data_dir / "pqaa_dev_set.json"},
+                ),
+            ]
+        else:  # if self.config.subset_id == 'pubmed_qa_unlabeled'
+            return [
+                datasets.SplitGenerator(
+                    name=datasets.Split.TRAIN,
+                    gen_kwargs={"filepath": data_dir / "ori_pqau.json"},
+                )
+            ]
+
+    def _generate_examples(self, filepath: Path) -> Iterator[Tuple[str, Dict]]:
+        data = json.load(open(filepath, "r"))
+
+        if self.config.schema == "source":
+            for id, row in data.items():
+                if self.config.subset_id == "pubmed_qa_unlabeled":
+                    row["reasoning_required_pred"] = None
+                    row["reasoning_free_pred"] = None
+                    row["final_decision"] = None
+                elif self.config.subset_id == "pubmed_qa_artificial":
+                    row["YEAR"] = None
+                    row["reasoning_required_pred"] = None
+                    row["reasoning_free_pred"] = None
+
+                yield id, row
+        elif self.config.schema == "bigbio_qa":
+            for id, row in data.items():
+                if self.config.subset_id == "pubmed_qa_unlabeled":
+                    answers = [BigBioValues.NULL]
+                else:
+                    answers = [row["final_decision"]]
+
+                qa_row = {
+                    "id": id,
+                    "question_id": id,
+                    "document_id": id,
+                    "question": row["QUESTION"],
+                    "type": "yesno",
+                    "choices": ["yes", "no", "maybe"],
+                    "context": " ".join(row["CONTEXTS"]),
+                    "answer": answers,
+                }
+
+                yield id, qa_row

--- a/hub/hubscripts/pubtator_central_hub.py
+++ b/hub/hubscripts/pubtator_central_hub.py
@@ -1,0 +1,305 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+PubTator Central (PTC, https://www.ncbi.nlm.nih.gov/research/pubtator/) [1] is a web service for
+exploring and retrieving bioconcept annotations in full text biomedical articles. PTC provides
+automated annotations from state-of-the-art text mining systems for genes/proteins, genetic
+variants, diseases, chemicals, species and cell lines, all available for immediate download. PTC
+annotates PubMed (30 million abstracts), the PMC Open Access Subset and the Author Manuscript
+Collection (3 million full text articles). Updated entity identification methods and a
+disambiguation module [2] based on cutting-edge deep learning techniques provide increased accuracy.
+This FTP repository aggregated all the bio-entity annotations in PTC in tab-separated text format.
+The files are expected to be updated monthly.
+
+REFERENCE:
+---------------------------------------------------------------------------
+[1] Wei C-H, Allot A, Leaman R and Lu Z (2019) "PubTator Central: Automated Concept Annotation for
+    Biomedical Full Text Articles", Nucleic Acids Res.
+[2] wei C-H, et al., (2019) "Biomedical Mention Disambiguation Using a Deep Learning Approach",
+    ACM-BCB 2019, September 7-10, 2019, Niagara Falls, NY, USA.
+[3] Wei C-H, Kao H-Y, Lu Z (2015) "GNormPlus: An Integrative Approach for Tagging Gene, Gene Family
+    and Protein Domain", 2015, Article ID 918710
+[4] Leaman R and Lu Z (2013) "TaggerOne: joint named entity recognition and normalization with
+    semi-Markov Models", Bioinformatics, 32(18): 839-2846
+[5] Wei C-H, Kao H-Y, Lu Z (2012) "SR4GN: a species recognition software tool for gene normalization",
+    PLoS ONE,7(6):e38460
+[6] Wei C-H, et al., (2017) "Integrating genomic variant information from literature with dbSNP and
+    ClinVar for precision medicine", Bioinformatics,34(1): 80-87
+"""
+
+
+from typing import Dict, Iterator, List, Tuple
+
+import datasets
+from bioc import pubtator
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{10.1093/nar/gkz389,
+  title        = {{PubTator central: automated concept annotation for biomedical full text articles}},
+  author       = {Wei, Chih-Hsuan and Allot, Alexis and Leaman, Robert and Lu, Zhiyong},
+  year         = 2019,
+  month        = {05},
+  journal      = {Nucleic Acids Research},
+  volume       = 47,
+  number       = {W1},
+  pages        = {W587-W593},
+  doi          = {10.1093/nar/gkz389},
+  issn         = {0305-1048},
+  url          = {https://doi.org/10.1093/nar/gkz389},
+  eprint       = {https://academic.oup.com/nar/article-pdf/47/W1/W587/28880193/gkz389.pdf}
+}
+"""
+
+_DATASETNAME = "pubtator_central"
+_DISPLAYNAME = "PubTator Central"
+
+_DESCRIPTION = """\
+PubTator Central (PTC, https://www.ncbi.nlm.nih.gov/research/pubtator/) is a web service for
+exploring and retrieving bioconcept annotations in full text biomedical articles. PTC provides
+automated annotations from state-of-the-art text mining systems for genes/proteins, genetic
+variants, diseases, chemicals, species and cell lines, all available for immediate download. PTC
+annotates PubMed (30 million abstracts), the PMC Open Access Subset and the Author Manuscript
+Collection (3 million full text articles). Updated entity identification methods and a
+disambiguation module based on cutting-edge deep learning techniques provide increased accuracy.
+"""
+
+_HOMEPAGE = "https://www.ncbi.nlm.nih.gov/research/pubtator/"
+
+_LICENSE = 'National Center fr Biotechnology Information PUBLIC DOMAIN NOTICE'
+
+_URLS = {
+    "sample": "https://ftp.ncbi.nlm.nih.gov/pub/lu/PubTatorCentral/bioconcepts2pubtatorcentral.offset.sample",
+    "full": "https://ftp.ncbi.nlm.nih.gov/pub/lu/PubTatorCentral/bioconcepts2pubtatorcentral.offset.gz",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION]
+
+_SOURCE_VERSION = "2022.01.08"
+_BIGBIO_VERSION = "1.0.0"
+
+# Maps the entity types in PubTator to the name of the database they are grounded to
+_TYPE_TO_DB_NAME = {
+    "Gene": "ncbi_gene",
+    "Disease": "mesh",
+    "Species": "ncbi_taxon",
+    "Chemical": "mesh",
+    "CellLine": "cellosaurus",
+}
+
+_DB_NAME_TO_URL = {
+    "ncbi_gene": "https://www.ncbi.nlm.nih.gov/gene/",
+    "mesh": "https://www.nlm.nih.gov/mesh/meshhome.html",
+    "ncbi_taxon": "https://www.ncbi.nlm.nih.gov/taxonomy/",
+    "cellosaurus": "https://web.expasy.org/cellosaurus/",
+    "ncbi_dbsnp": "https://www.ncbi.nlm.nih.gov/snp/",
+    "tmvar": "https://www.ncbi.nlm.nih.gov/research/bionlp/Tools/tmvar/",
+}
+
+
+class PubtatorCentralDataset(datasets.GeneratorBasedBuilder):
+    """PubTator Central"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        # sample source
+        BigBioConfig(
+            name="pubtator_central_sample_source",
+            version=SOURCE_VERSION,
+            description="PubTator Central sample source schema",
+            schema="source",
+            subset_id="pubtator_central_sample",
+        ),
+        # sample big bio
+        BigBioConfig(
+            name="pubtator_central_sample_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="PubTator Central sample BigBio schema",
+            schema="bigbio_kb",
+            subset_id="pubtator_central_sample",
+        ),
+        # full dataset source
+        BigBioConfig(
+            name="pubtator_central_source",
+            version=SOURCE_VERSION,
+            description="PubTator Central source schema",
+            schema="source",
+            subset_id="pubtator_central",
+        ),
+        # full dataset bigbio
+        BigBioConfig(
+            name="pubtator_central_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="PubTator Central BigBio schema",
+            schema="bigbio_kb",
+            subset_id="pubtator_central",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "pubtator_central_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "pmid": datasets.Value("string"),
+                    "title": datasets.Value("string"),
+                    "abstract": datasets.Value("string"),
+                    "mentions": [
+                        {
+                            "concept_id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                            "offsets": datasets.Sequence(datasets.Value("int32")),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = (
+            _URLS["sample"]
+            if self.config.subset_id.endswith("sample")
+            else _URLS["full"]
+        )
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_dir,
+                    "split": "train",
+                },
+            ),
+        ]
+
+    def _generate_examples(
+        self, filepath: str, split: str
+    ) -> Iterator[Tuple[str, Dict]]:
+        if self.config.schema == "source":
+            for source_example in self._pubtator_to_source(filepath):
+                yield source_example["pmid"], source_example
+
+        elif self.config.schema == "bigbio_kb":
+            for kb_example in self._pubtator_to_bigbio_kb(filepath):
+                yield kb_example["id"], kb_example
+
+    @staticmethod
+    def _pubtator_to_source(filepath: Dict) -> Iterator[Dict]:
+        with open(filepath, "r") as f:
+            for doc in pubtator.iterparse(f):
+                source_example = {
+                    "pmid": doc.pmid,
+                    "title": doc.title,
+                    "abstract": doc.abstract,
+                    "mentions": [
+                        {
+                            "concept_id": mention.id,
+                            "type": mention.type,
+                            "text": mention.text,
+                            "offsets": [mention.start, mention.end],
+                        }
+                        for mention in doc.annotations
+                    ],
+                }
+                yield source_example
+
+    def _pubtator_to_bigbio_kb(self, filepath: Dict) -> Iterator[Dict]:
+        with open(filepath, "r") as f:
+            unified_example = {}
+            for doc in pubtator.iterparse(f):
+                unified_example["id"] = doc.pmid
+                unified_example["document_id"] = doc.pmid
+
+                unified_example["passages"] = [
+                    {
+                        "id": doc.pmid + "_title",
+                        "type": "title",
+                        "text": [doc.title],
+                        "offsets": [[0, len(doc.title)]],
+                    },
+                    {
+                        "id": doc.pmid + "_abstract",
+                        "type": "abstract",
+                        "text": [doc.abstract],
+                        "offsets": [
+                            [
+                                # +1 assumes the title and abstract will be joined by a space.
+                                len(doc.title) + 1,
+                                len(doc.title) + 1 + len(doc.abstract),
+                            ]
+                        ],
+                    },
+                ]
+
+                unified_entities = []
+                for i, entity in enumerate(doc.annotations):
+                    # We need a unique identifier for this entity, so build it from the document id and entity id
+                    unified_entity_id = "_".join([doc.pmid, entity.id, str(i)])
+                    # Determining db_name is tricky so use a helper to determine this from the entity annotation
+                    db_name = self._get_db_name(entity)
+                    unified_entities.append(
+                        {
+                            "id": unified_entity_id,
+                            "type": entity.type,
+                            "text": [entity.text],
+                            "offsets": [[entity.start, entity.end]],
+                            "normalized": [{"db_name": db_name, "db_id": entity.id}],
+                        }
+                    )
+
+                unified_example["entities"] = unified_entities
+                unified_example["relations"] = []
+                unified_example["events"] = []
+                unified_example["coreferences"] = []
+
+                yield unified_example
+
+    @staticmethod
+    def _get_db_name(entity: pubtator.PubTatorAnn) -> str:
+        if entity.type in _TYPE_TO_DB_NAME:
+            db_name = _TYPE_TO_DB_NAME[entity.type]
+        elif entity.type in ["Mutation", "ProteinMutation", "DNAMutation"]:
+            # Mutation anntotations are grounded to either tmVar or dbSNP
+            if entity.id.startswith("tmVar"):
+                db_name = "tmVar"
+            else:
+                db_name = "ncbi_dbsnp"
+        else:
+            db_name = "unknown"
+        return db_name

--- a/hub/hubscripts/quaero_hub.py
+++ b/hub/hubscripts/quaero_hub.py
@@ -1,0 +1,218 @@
+import re
+from pathlib import Path
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['French']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@InProceedings{neveol14quaero, 
+  author = {Névéol, Aurélie and Grouin, Cyril and Leixa, Jeremy 
+            and Rosset, Sophie and Zweigenbaum, Pierre},
+  title = {The {QUAERO} {French} Medical Corpus: A Ressource for
+           Medical Entity Recognition and Normalization}, 
+  OPTbooktitle = {Proceedings of the Fourth Workshop on Building 
+                 and Evaluating Ressources for Health and Biomedical 
+                 Text Processing}, 
+  booktitle = {Proc of BioTextMining Work}, 
+  OPTseries = {BioTxtM 2014}, 
+  year = {2014}, 
+  pages = {24--30}, 
+}
+"""
+
+_DESCRIPTION = """\
+The QUAERO French Medical Corpus has been initially developed as a resource for named entity recognition and normalization [1]. It was then improved with the purpose of creating a gold standard set of normalized entities for French biomedical text, that was used in the CLEF eHealth evaluation lab [2][3].
+
+A selection of MEDLINE titles and EMEA documents were manually annotated. The annotation process was guided by concepts in the Unified Medical Language System (UMLS):
+
+1. Ten types of clinical entities, as defined by the following UMLS Semantic Groups (Bodenreider and McCray 2003) were annotated: Anatomy, Chemical and Drugs, Devices, Disorders, Geographic Areas, Living Beings, Objects, Phenomena, Physiology, Procedures.
+
+2. The annotations were made in a comprehensive fashion, so that nested entities were marked, and entities could be mapped to more than one UMLS concept. In particular: (a) If a mention can refer to more than one Semantic Group, all the relevant Semantic Groups should be annotated. For instance, the mention “récidive” (recurrence) in the phrase “prévention des récidives” (recurrence prevention) should be annotated with the category “DISORDER” (CUI C2825055) and the category “PHENOMENON” (CUI C0034897); (b) If a mention can refer to more than one UMLS concept within the same Semantic Group, all the relevant concepts should be annotated. For instance, the mention “maniaques” (obsessive) in the phrase “patients maniaques” (obsessive patients) should be annotated with CUIs C0564408 and C0338831 (category “DISORDER”); (c) Entities which span overlaps with that of another entity should still be annotated. For instance, in the phrase “infarctus du myocarde” (myocardial infarction), the mention “myocarde” (myocardium) should be annotated with category “ANATOMY” (CUI C0027061) and the mention “infarctus du myocarde” should be annotated with category “DISORDER” (CUI C0027051)
+
+The QUAERO French Medical Corpus BioC release comprises a subset of the QUAERO French Medical corpus, as follows:
+
+Training data (BRAT version used in CLEF eHealth 2015 task 1b as training data): 
+- MEDLINE_train_bioc file: 833 MEDLINE titles, annotated with normalized entities in the BioC format 
+- EMEA_train_bioc file: 3 EMEA documents, segmented into 11 sub-documents, annotated with normalized entities in the BioC format 
+
+Development data  (BRAT version used in CLEF eHealth 2015 task 1b as test data and in CLEF eHealth 2016 task 2 as development data): 
+- MEDLINE_dev_bioc file: 832 MEDLINE titles, annotated with normalized entities in the BioC format
+- EMEA_dev_bioc file: 3 EMEA documents, segmented into 12 sub-documents, annotated with normalized entities in the BioC format 
+
+Test data (BRAT version used in CLEF eHealth 2016 task 2 as test data): 
+- MEDLINE_test_bioc folder: 833 MEDLINE titles, annotated with normalized entities in the BioC format 
+- EMEA folder_test_bioc: 4 EMEA documents, segmented into 15 sub-documents, annotated with normalized entities in the BioC format 
+
+
+
+This release of the QUAERO French medical corpus, BioC version, comes in the BioC format, through automatic conversion from the original BRAT format obtained with the Brat2BioC tool https://bitbucket.org/nicta_biomed/brat2bioc developped by Jimeno Yepes et al.
+
+Antonio Jimeno Yepes, Mariana Neves, Karin Verspoor 
+Brat2BioC: conversion tool between brat and BioC
+BioCreative IV track 1 - BioC: The BioCreative Interoperability Initiative, 2013
+
+
+Please note that the original version of the QUAERO corpus distributed in the CLEF eHealth challenge 2015 and 2016 came in the BRAT stand alone format. It was distributed with the CLEF eHealth evaluation tool. This original distribution of the QUAERO French Medical corpus is available separately from https://quaerofrenchmed.limsi.fr  
+
+All questions regarding the task or data should be addressed to aurelie.neveol@limsi.fr
+"""
+
+_HOMEPAGE = "https://quaerofrenchmed.limsi.fr/"
+
+_LICENSE = 'GNU Free Documentation License v1.3'
+
+_URL = "https://quaerofrenchmed.limsi.fr/QUAERO_FrenchMed_brat.zip"
+
+_DATASET_NAME = "quaero"
+_DISPLAYNAME = "QUAERO"
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class QUAERO(datasets.GeneratorBasedBuilder):
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="quaero_emea_source",
+            version=SOURCE_VERSION,
+            description="QUAERO source schema on the EMEA subset",
+            schema="source",
+            subset_id="quaero_emea",
+        ),
+        BigBioConfig(
+            name="quaero_medline_source",
+            version=SOURCE_VERSION,
+            description="QUAERO source schema on the MEDLINE subset",
+            schema="source",
+            subset_id="quaero_medline",
+        ),
+        BigBioConfig(
+            name="quaero_emea_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="QUAERO simplified BigBio schema on the EMEA subset",
+            schema="bigbio_kb",
+            subset_id="quaero_emea",
+        ),
+        BigBioConfig(
+            name="quaero_medline_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="QUAERO simplified BigBio schema on the MEDLINE subset",
+            schema="bigbio_kb",
+            subset_id="quaero_medline",
+        ),
+    ]
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "notes": [  # # lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            supervised_keys=None,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        urls = _URL
+        data_dir = dl_manager.download_and_extract(urls)
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # These kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": data_dir,
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                # These kwargs will be passed to _generate_examples
+                gen_kwargs={"filepath": data_dir, "split": "test"},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                # These kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": data_dir,
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    # method parameters are unpacked from `gen_kwargs` as given in `_split_generators`
+    def _generate_examples(self, filepath, split):
+        if self.config.subset_id == "quaero_emea":
+            subset = "EMEA"
+        elif self.config.subset_id == "quaero_medline":
+            subset = "MEDLINE"
+
+        folder = Path(filepath) / "QUAERO_FrenchMed" / "corpus" / split / subset
+
+        if self.config.schema == "source":
+            for guid, txt_file in enumerate(sorted(folder.glob("*.txt"))):
+                example = parse_brat_file(txt_file, parse_notes=True)
+                example["id"] = guid
+                # Remove unused items from BRAT
+                del example["events"]
+                del example["relations"]
+                del example["equivalences"]
+                del example["attributes"]
+                del example["normalizations"]
+                yield guid, example
+        elif self.config.schema == "bigbio_kb":
+            for guid, txt_file in enumerate(sorted(folder.glob("*.txt"))):
+                example = parse_brat_file(txt_file, parse_notes=True)
+                annotator_notes = example["notes"]
+                document_id = example["document_id"]
+
+                example = brat_parse_to_bigbio_kb(example)
+                example["id"] = guid
+
+                for note in annotator_notes:
+                    entity_id = f'{document_id}_{note["ref_id"]}'
+                    for e in example["entities"]:
+                        if e["id"] == entity_id:
+                            for cui in re.split("[\s\+,]", note["text"].strip()):
+                                if cui:
+                                    e["normalized"].append({"db_id": cui, "db_name": "UMLS"})
+                yield guid, example
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/hub/hubscripts/scai_chemical_hub.py
+++ b/hub/hubscripts/scai_chemical_hub.py
@@ -1,0 +1,257 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A dataset loader for the SCAI Chemical dataset.
+
+SCAI Chemical is a corpus of MEDLINE abstracts that has been annotated
+to give an overview of the different chemical name classes
+found in MEDLINE text.
+"""
+
+import gzip
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{kolarik:lrec-ws08,
+  author    = {Kol{\'a}{\vr}ik, Corinna and Klinger, Roman and Friedrich, Christoph M and Hofmann-Apitius, Martin and Fluck, Juliane},
+  title     = {Chemical Names: {T}erminological Resources and Corpora Annotation},
+  booktitle = {LREC Workshop on Building and Evaluating Resources for Biomedical Text Mining},
+  year      = {2008},
+}
+"""
+
+_DATASETNAME = "scai_chemical"
+_DISPLAYNAME = "SCAI Chemical"
+
+_DESCRIPTION = """\
+SCAI Chemical is a corpus of MEDLINE abstracts that has been annotated
+to give an overview of the different chemical name classes
+found in MEDLINE text.
+"""
+
+_HOMEPAGE = "https://www.scai.fraunhofer.de/en/business-research-areas/bioinformatics/downloads/corpora-for-chemical-entity-recognition.html"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: "https://www.scai.fraunhofer.de/content/dam/scai/de/downloads/bioinformatik/Corpora-for-Chemical-Entity-Recognition/chemicals-test-corpus-27-04-2009-v3_iob.gz",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "3.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class ScaiChemicalDataset(datasets.GeneratorBasedBuilder):
+    """SCAI Chemical is a dataset annotated in 2008 with mentions of chemicals."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="scai_chemical_source",
+            version=SOURCE_VERSION,
+            description="SCAI Chemical source schema",
+            schema="source",
+            subset_id="scai_chemical",
+        ),
+        BigBioConfig(
+            name="scai_chemical_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="SCAI Chemical BigBio schema",
+            schema="bigbio_kb",
+            subset_id="scai_chemical",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "scai_chemical_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "tokens": [
+                        {
+                            "offsets": [datasets.Value("int64")],
+                            "text": datasets.Value("string"),
+                            "tag": datasets.Value("string"),
+                        }
+                    ],
+                    "entities": [
+                        {
+                            "offsets": [datasets.Value("int64")],
+                            "text": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+        else:
+            raise ValueError("Unrecognized schema: %s" % self.config.schema)
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        url = _URLS[_DATASETNAME]
+        filepath = dl_manager.download(url)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": filepath,
+                    "split": "train",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        # Iterates through lines in file, collecting all lines belonging
+        # to an example and converting into a single dict
+        examples = []
+        tokens = None
+        with gzip.open(filepath, "rt", encoding="mac_roman") as data_file:
+            print(filepath)
+            for line in data_file:
+                line = line.strip()
+                if line.startswith("###"):
+                    tokens = [line]
+                elif line == "":
+                    examples.append(self._make_example(tokens))
+                else:
+                    tokens.append(line)
+
+        # Returns the examples using the desired schema
+        if self.config.schema == "source":
+            for i, example in enumerate(examples):
+                yield i, example
+
+        elif self.config.schema == "bigbio_kb":
+            for i, example in enumerate(examples):
+                bigbio_example = {
+                    "id": "example-" + str(i),
+                    "document_id": example["document_id"],
+                    "passages": [
+                        {
+                            "id": "passage-" + str(i),
+                            "type": "abstract",
+                            "text": [example["text"]],
+                            "offsets": [[0, len(example["text"])]],
+                        }
+                    ],
+                    "entities": [],
+                    "events": [],
+                    "coreferences": [],
+                    "relations": [],
+                }
+
+                # Converts entities to BigBio format
+                for j, entity in enumerate(example["entities"]):
+                    bigbio_example["entities"].append(
+                        {
+                            "id": "entity-" + str(i) + "-" + str(j),
+                            "offsets": [entity["offsets"]],
+                            "text": [entity["text"]],
+                            "type": entity["type"],
+                            "normalized": [],
+                        }
+                    )
+
+                yield i, bigbio_example
+
+    @staticmethod
+    def _make_example(tokens):
+        """
+        Converts a list of lines representing tokens into an example dictionary
+        formatted according to the source schema
+
+        :param tokens: list of strings
+        :return: dictionary in the source schema
+        """
+        document_id = tokens[0][4:]
+
+        text = ""
+        processed_tokens = []
+        entities = []
+        last_offset = 0
+
+        for token in tokens[1:]:
+            token_pieces = token.split("\t")
+            if len(token_pieces) != 5:
+                raise ValueError("Failed to parse line: %s" % token)
+
+            token_text = str(token_pieces[0])
+            token_start = int(token_pieces[1])
+            token_end = int(token_pieces[2])
+            entity_text = str(token_pieces[3])
+            token_tag = str(token_pieces[4])[1:]
+
+            if token_start > last_offset:
+                for _ in range(token_start - last_offset):
+                    text += " "
+            elif token_start < last_offset:
+                raise ValueError("Invalid start index: %s" % token)
+            last_offset = token_end
+
+            text += token_text
+            processed_tokens.append(
+                {
+                    "offsets": [token_start, token_end],
+                    "text": token_text,
+                    "tag": token_tag,
+                }
+            )
+            if entity_text != "":
+                entities.append(
+                    {
+                        "offsets": [token_start, token_start + len(entity_text)],
+                        "text": entity_text,
+                        "type": token_tag[2:],
+                    }
+                )
+
+        return {
+            "document_id": document_id,
+            "text": text,
+            "entities": entities,
+            "tokens": processed_tokens,
+        }

--- a/hub/hubscripts/scai_disease_hub.py
+++ b/hub/hubscripts/scai_disease_hub.py
@@ -1,0 +1,261 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A dataset loader for the SCAI Disease dataset.
+
+SCAI Disease is a dataset annotated in 2010 with mentions of diseases and
+adverse effects. It is a corpus containing 400 randomly selected MEDLINE
+abstracts generated using ‘Disease OR Adverse effect’ as a PubMed query. This
+evaluation corpus was annotated by two individuals who hold a Master’s degree
+in life sciences.
+"""
+
+import os
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@inproceedings{gurulingappa:lrec-ws10,
+  author    = {Harsha Gurulingappa and Roman Klinger and Martin Hofmann-Apitius and Juliane Fluck},
+  title     = {An Empirical Evaluation of Resources for the Identification of Diseases and Adverse Effects in Biomedical Literature},
+  booktitle = {LREC Workshop on Building and Evaluating Resources for Biomedical Text Mining},
+  year      = {2010},
+}
+"""
+
+_DATASETNAME = "scai_disease"
+_DISPLAYNAME = "SCAI Disease"
+
+_DESCRIPTION = """\
+SCAI Disease is a dataset annotated in 2010 with mentions of diseases and
+adverse effects. It is a corpus containing 400 randomly selected MEDLINE
+abstracts generated using ‘Disease OR Adverse effect’ as a PubMed query. This
+evaluation corpus was annotated by two individuals who hold a Master’s degree
+in life sciences.
+"""
+
+_HOMEPAGE = "https://www.scai.fraunhofer.de/en/business-research-areas/bioinformatics/downloads/corpus-for-disease-names-and-adverse-effects.html"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: "https://www.scai.fraunhofer.de/content/dam/scai/de/downloads/bioinformatik/Disease-ae-corpus.iob",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class ScaiDiseaseDataset(datasets.GeneratorBasedBuilder):
+    """SCAI Disease is a dataset annotated in 2010 with mentions of diseases and
+    adverse effects."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="scai_disease_source",
+            version=SOURCE_VERSION,
+            description="SCAI Disease source schema",
+            schema="source",
+            subset_id="scai_disease",
+        ),
+        BigBioConfig(
+            name="scai_disease_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="SCAI Disease BigBio schema",
+            schema="bigbio_kb",
+            subset_id="scai_disease",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "scai_disease_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "tokens": [
+                        {
+                            "offsets": [datasets.Value("int64")],
+                            "text": datasets.Value("string"),
+                            "tag": datasets.Value("string"),
+                        }
+                    ],
+                    "entities": [
+                        {
+                            "offsets": [datasets.Value("int64")],
+                            "text": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+        else:
+            raise ValueError("Unrecognized schema: %s" % self.config.schema)
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        url = _URLS[_DATASETNAME]
+        filepath = dl_manager.download(url)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": filepath,
+                    "split": "train",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        # Iterates through lines in file, collecting all lines belonging
+        # to an example and converting into a single dict
+        examples = []
+        tokens = None
+        with open(filepath, "r") as data_file:
+            for line in data_file:
+                line = line.strip()
+                if line.startswith("###"):
+                    tokens = [line]
+                elif line == "":
+                    examples.append(self._make_example(tokens))
+                else:
+                    tokens.append(line)
+
+        # Returns the examples using the desired schema
+        if self.config.schema == "source":
+            for i, example in enumerate(examples):
+                yield i, example
+
+        elif self.config.schema == "bigbio_kb":
+            for i, example in enumerate(examples):
+                bigbio_example = {
+                    "id": "example-" + str(i),
+                    "document_id": example["document_id"],
+                    "passages": [
+                        {
+                            "id": "passage-" + str(i),
+                            "type": "abstract",
+                            "text": [example["text"]],
+                            "offsets": [[0, len(example["text"])]],
+                        }
+                    ],
+                    "entities": [],
+                    "events": [],
+                    "coreferences": [],
+                    "relations": [],
+                }
+
+                # Converts entities to BigBio format
+                for j, entity in enumerate(example["entities"]):
+                    bigbio_example["entities"].append(
+                        {
+                            "id": "entity-" + str(i) + "-" + str(j),
+                            "offsets": [entity["offsets"]],
+                            "text": [entity["text"]],
+                            "type": entity["type"],
+                            "normalized": [],
+                        }
+                    )
+
+                yield i, bigbio_example
+
+    @staticmethod
+    def _make_example(tokens):
+        """
+        Converts a list of lines representing tokens into an example dictionary
+        formatted according to the source schema
+
+        :param tokens: list of strings
+        :return: dictionary in the source schema
+        """
+        document_id = tokens[0][4:]
+
+        text = ""
+        processed_tokens = []
+        entities = []
+        last_offset = 0
+
+        for token in tokens[1:]:
+            token_pieces = token.split("\t")
+            if len(token_pieces) != 5:
+                raise ValueError("Failed to parse line: %s" % token)
+
+            token_text = str(token_pieces[0])
+            token_start = int(token_pieces[1])
+            token_end = int(token_pieces[2])
+            entity_text = str(token_pieces[3])
+            token_tag = str(token_pieces[4])[1:]
+
+            if token_start > last_offset:
+                for _ in range(token_start - last_offset):
+                    text += " "
+            elif token_start < last_offset:
+                raise ValueError("Invalid start index: %s" % token)
+            last_offset = token_end
+
+            text += token_text
+            processed_tokens.append(
+                {
+                    "offsets": [token_start, token_end],
+                    "text": token_text,
+                    "tag": token_tag,
+                }
+            )
+            if entity_text != "":
+                entities.append(
+                    {
+                        "offsets": [token_start, token_start + len(entity_text)],
+                        "text": entity_text,
+                        "type": token_tag[2:],
+                    }
+                )
+
+        return {
+            "document_id": document_id,
+            "text": text,
+            "entities": entities,
+            "tokens": processed_tokens,
+        }

--- a/hub/hubscripts/scicite_hub.py
+++ b/hub/hubscripts/scicite_hub.py
@@ -1,0 +1,235 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A dataset loader for the SciCite dataset.
+
+SciCite is a dataset of 11K manually annotated citation intents based on
+citation context in the computer science and biomedical domains.
+
+Some of the code in this module is based on the corresponding module in the
+datasets library.
+https://github.com/huggingface/datasets/blob/master/datasets/scicite/scicite.py
+
+In the source schema, we follow the datasets implementation and replace
+missing values.
+TODO: Use standard BigBio missing values.
+"""
+
+import json
+import os
+from typing import Dict, List, Tuple
+
+import datasets
+import numpy as np
+
+from .bigbiohub import text.features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@inproceedings{cohan:naacl19,
+  author    = {Arman Cohan and Waleed Ammar and Madeleine van Zuylen and Field Cady},
+  title     = {Structural Scaffolds for Citation Intent Classification in Scientific Publications},
+  booktitle = {Conference of the North American Chapter of the Association for Computational Linguistics},
+  year      = {2019},
+  url       = {https://aclanthology.org/N19-1361/},
+  doi       = {10.18653/v1/N19-1361},
+}
+"""
+
+_DATASETNAME = "scicite"
+_DISPLAYNAME = "SciCite"
+
+_DESCRIPTION = """\
+SciCite is a dataset of 11K manually annotated citation intents based on
+citation context in the computer science and biomedical domains.
+"""
+
+_HOMEPAGE = "https://allenai.org/data/scicite"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: "https://s3-us-west-2.amazonaws.com/ai2-s2-research/scicite/scicite.tar.gz",
+}
+
+_SUPPORTED_TASKS = [Tasks.TEXT_CLASSIFICATION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class SciciteDataset(datasets.GeneratorBasedBuilder):
+    """SciCite is a dataset of 11K manually annotated citation intents based on
+    citation context in the computer science and biomedical domains."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    # You will be able to load the "source" or "bigbio" configurations with
+    # ds_source = datasets.load_dataset('scicite', name='source')
+    # ds_bigbio = datasets.load_dataset('scicite', name='bigbio')
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="scicite_source",
+            version=SOURCE_VERSION,
+            description="SciCite source schema",
+            schema="source",
+            subset_id="scicite",
+        ),
+        BigBioConfig(
+            name="scicite_bigbio_text",
+            version=BIGBIO_VERSION,
+            description="SciCite BigBio schema",
+            schema="bigbio_text",
+            subset_id="scicite",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "scicite_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "source": datasets.Value("string"),
+                    "citeStart": datasets.Value("int64"),
+                    "sectionName": datasets.Value("string"),
+                    "string": datasets.Value("string"),
+                    "citeEnd": datasets.Value("int64"),
+                    "label": datasets.features.ClassLabel(
+                        names=["method", "background", "result"]
+                    ),
+                    "label_confidence": datasets.Value("float"),
+                    "label2": datasets.features.ClassLabel(
+                        names=["supportive", "not_supportive", "cant_determine", "none"]
+                    ),
+                    "label2_confidence": datasets.Value("float"),
+                    "citingPaperId": datasets.Value("string"),
+                    "citedPaperId": datasets.Value("string"),
+                    "isKeyCitation": datasets.Value("bool"),
+                    "id": datasets.Value("string"),
+                    "unique_id": datasets.Value("string"),
+                    "excerpt_index": datasets.Value("int64"),
+                }
+            )
+        elif self.config.schema == "bigbio_text":
+            features = text.features
+        else:
+            raise ValueError("Unrecognized schema: %s" % self.config.schema)
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "scicite", "train.jsonl"),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "scicite", "test.jsonl"),
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "scicite", "dev.jsonl"),
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        with open(filepath, "r") as data_file:
+            examples = [json.loads(line) for line in data_file]
+
+            # Preprocesses examples
+            keys = set()
+            for example in examples:
+                # Fixes duplicate keys
+                if example["unique_id"] in keys:
+                    example["unique_id"] = example["unique_id"] + "_duplicate"
+                else:
+                    keys.add(example["unique_id"])
+
+            if self.config.schema == "source":
+                for example in examples:
+                    yield str(example["unique_id"]), {
+                        "string": example["string"],
+                        "label": str(example["label"]),
+                        "sectionName": str(example["sectionName"]),
+                        "citingPaperId": str(example["citingPaperId"]),
+                        "citedPaperId": str(example["citedPaperId"]),
+                        "excerpt_index": int(example["excerpt_index"]),
+                        "isKeyCitation": bool(example["isKeyCitation"]),
+                        "label2": str(example.get("label2", "none")),
+                        "citeEnd": _safe_int(example["citeEnd"]),
+                        "citeStart": _safe_int(example["citeStart"]),
+                        "source": str(example["source"]),
+                        "label_confidence": float(
+                            example.get("label_confidence", np.nan)
+                        ),
+                        "label2_confidence": float(
+                            example.get("label2_confidence", np.nan)
+                        ),
+                        "id": str(example["id"]),
+                        "unique_id": str(example["unique_id"]),
+                    }
+
+            elif self.config.schema == "bigbio_text":
+                for example in examples:
+                    if "label2" in example:
+                        labels = [example["label"], example["label2"]]
+                    else:
+                        labels = [example["label"]]
+
+                    yield str(example["unique_id"]), {
+                        "id": example["unique_id"],
+                        "document_id": example["citingPaperId"],
+                        "text": example["string"],
+                        "labels": labels,
+                    }
+
+
+def _safe_int(a):
+    try:
+        # skip NaNs
+        return int(a)
+    except ValueError:
+        return -1

--- a/hub/hubscripts/scielo_hub.py
+++ b/hub/hubscripts/scielo_hub.py
@@ -1,0 +1,222 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Parallel corpus of full-text articles in Portuguese, English and Spanish from SciELO.
+"""
+from typing import IO, Any, Generator, List, Optional, Tuple
+
+import datasets
+
+from .bigbiohub import text2text_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English', 'Spanish', 'Portuguese']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@inproceedings{soares2018large,
+  title        = {A Large Parallel Corpus of Full-Text Scientific Articles},
+  author       = {Soares, Felipe and Moreira, Viviane and Becker, Karin},
+  year         = 2018,
+  booktitle    = {
+    Proceedings of the Eleventh International Conference on Language Resources
+    and Evaluation (LREC-2018)
+  }
+}
+"""
+
+_DATASETNAME = "scielo"
+_DISPLAYNAME = "SciELO"
+
+_DESCRIPTION = """\
+A parallel corpus of full-text scientific articles collected from Scielo \
+database in the following languages: English, Portuguese and Spanish. The corpus \
+is sentence aligned for all language pairs, as well as trilingual aligned for a \
+small subset of sentences. Alignment was carried out using the Hunalign \
+algorithm.
+"""
+
+_HOMEPAGE = "https://sites.google.com/view/felipe-soares/datasets#h.p_92uSCyAjWSRB"
+
+_LICENSE = 'Creative Commons Attribution 4.0 International'
+
+_URLS = {
+    "en_es": "https://ndownloader.figstatic.com/files/14019287",
+    "en_pt": "https://ndownloader.figstatic.com/files/14019308",
+    "en_pt_es": "https://ndownloader.figstatic.com/files/14019293",
+}
+
+_SUPPORTED_TASKS = [Tasks.TRANSLATION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class ScieloDataset(datasets.GeneratorBasedBuilder):
+    """Parallel corpus of full-text articles in Portuguese, English and Spanish from SciELO."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    # NOTE: bigbio_t2t schema doesn't allow only for more than two texts in text-to-text schema.
+    #  en-pt-es translation is not implemented using the bigbio schema
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="scielo_en_es_source",
+            version=SOURCE_VERSION,
+            description="English-Spanish",
+            schema="source",
+            subset_id="scielo_en_es",
+        ),
+        BigBioConfig(
+            name="scielo_en_pt_source",
+            version=SOURCE_VERSION,
+            description="English-Portuguese",
+            schema="source",
+            subset_id="scielo_en_pt",
+        ),
+        BigBioConfig(
+            name="scielo_en_pt_es_source",
+            version=SOURCE_VERSION,
+            description="English-Portuguese-Spanish",
+            schema="source",
+            subset_id="scielo_en_pt_es",
+        ),
+        BigBioConfig(
+            name="scielo_en_es_bigbio_t2t",
+            version=BIGBIO_VERSION,
+            description="scielo BigBio schema English-Spanish",
+            schema="bigbio_t2t",
+            subset_id="scielo_en_es",
+        ),
+        BigBioConfig(
+            name="scielo_en_pt_bigbio_t2t",
+            version=BIGBIO_VERSION,
+            description="scielo BigBio schema English-Portuguese",
+            schema="bigbio_t2t",
+            subset_id="scielo_en_pt",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "scielo_source_en_es"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            lang_list: List[str] = self.config.subset_id.split("_")[1:]
+            features = datasets.Features(
+                {"translation": datasets.features.Translation(languages=lang_list)}
+            )
+
+        elif self.config.schema == "bigbio_t2t":
+            features = text2text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        lang_list: List[str] = self.config.subset_id.split("_")[1:]
+        languages = "_".join(lang_list)
+        archive = dl_manager.download(_URLS[languages])
+
+        fname = languages
+
+        if languages == "en_pt_es":
+            return [
+                datasets.SplitGenerator(
+                    name=datasets.Split.TRAIN,
+                    gen_kwargs={
+                        "source_file": f"{fname}.en",
+                        "target_file": f"{fname}.pt",
+                        "target_file_2": f"{fname}.es",
+                        "files": dl_manager.iter_archive(archive),
+                        "languages": languages,
+                        "split": "train",
+                    },
+                ),
+            ]
+        else:
+            return [
+                datasets.SplitGenerator(
+                    name=datasets.Split.TRAIN,
+                    gen_kwargs={
+                        "source_file": f"{fname}.{lang_list[0]}",
+                        "target_file": f"{fname}.{lang_list[1]}",
+                        "files": dl_manager.iter_archive(archive),
+                        "languages": languages,
+                        "split": "train",
+                    },
+                ),
+            ]
+
+    def _generate_examples(
+        self,
+        languages: str,
+        split: str,
+        source_file: str,
+        target_file: str,
+        files: Generator[Tuple[str, IO[bytes]], Any, None],
+        target_file_2: Optional[str] = None,
+    ) -> Tuple[int, dict]:
+
+        if self.config.schema == "source":
+            for path, f in files:
+                if path == source_file:
+                    source_sentences = f.read().decode("utf-8").split("\n")
+                elif path == target_file:
+                    target_sentences = f.read().decode("utf-8").split("\n")
+                elif languages == "en_pt_es" and path == target_file_2:
+                    target_sentences_2 = f.read().decode("utf-8").split("\n")
+
+            if languages == "en_pt_es":
+                source, target, target_2 = tuple(languages.split("_"))
+                for idx, (l1, l2, l3) in enumerate(
+                    zip(source_sentences, target_sentences, target_sentences_2)
+                ):
+                    result = {"translation": {source: l1, target: l2, target_2: l3}}
+                    yield idx, result
+            else:
+                source, target = tuple(languages.split("_"))
+                for idx, (l1, l2) in enumerate(zip(source_sentences, target_sentences)):
+                    result = {"translation": {source: l1, target: l2}}
+                    yield idx, result
+
+        elif self.config.schema == "bigbio_t2t":
+            for path, f in files:
+                if path == source_file:
+                    source_sentences = f.read().decode("utf-8").split("\n")
+                elif path == target_file:
+                    target_sentences = f.read().decode("utf-8").split("\n")
+
+            uid = 0
+            source, target = tuple(languages.split("_"))
+            for idx, (l1, l2) in enumerate(zip(source_sentences, target_sentences)):
+                uid += 1
+                yield idx, {
+                    "id": str(uid),
+                    "document_id": str(idx),
+                    "text_1": l1,
+                    "text_2": l2,
+                    "text_1_name": source,
+                    "text_2_name": target,
+                }

--- a/hub/hubscripts/scifact_hub.py
+++ b/hub/hubscripts/scifact_hub.py
@@ -1,0 +1,421 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+from itertools import chain
+from typing import Dict, List, Tuple
+
+import datasets
+from datasets import Value
+import pandas as pd
+
+from .bigbiohub import pairs.features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@article{wadden2020fact,
+  author    = {David Wadden and Shanchuan Lin and Kyle Lo and Lucy Lu Wang and Madeleine van Zuylen and Arman Cohan and Hannaneh Hajishirzi},
+  title     = {Fact or Fiction: Verifying Scientific Claims},
+  year      = {2020},
+  address   = {Online},
+  publisher = {Association for Computational Linguistics},
+  url       = {https://aclanthology.org/2020.emnlp-main.609},
+  doi       = {10.18653/v1/2020.emnlp-main.609},
+  pages     = {7534--7550},
+  biburl    = {},
+  bibsource = {}
+}
+"""
+
+_DATASETNAME = "scifact"
+_DISPLAYNAME = "SciFact"
+
+
+_DESCRIPTION_BASE = """\
+    SciFact is a dataset of 1.4K expert-written scientific claims paired with evidence-containing abstracts, and annotated with labels and rationales.
+    """
+
+_SOURCE_CORPUS_DESCRIPTION = f"""\
+    {_DESCRIPTION_BASE} This config has abstracts and document ids.
+    """
+
+_SOURCE_CLAIMS_DESCRIPTION = """\
+    {_DESCRIPTION_BASE} This config connects the claims to the evidence and doc ids.
+    """
+
+_BIGBIO_PAIRS_RATIONALE_DESCRIPTION = """\
+    {_DESCRIPTION_BASE} This task is the following: given a claim and a text span composed of one or more sentences from an abstract, predict a label from ("rationale", "not_rationale") indicating if the span is evidence (can be supporting or refuting) for the claim. This roughly corresponds to the second task outlined in Section 5 of the paper."
+    """
+
+_BIGBIO_PAIRS_LABELPREDICTION_DESCRIPTION = """\
+    {_DESCRIPTION_BASE} This task is the following: given a claim and a text span composed of one or more sentences from an abstract, predict a label from ("SUPPORT", "NOINFO", "CONTRADICT") indicating if the span supports, provides no info, or contradicts the claim. This roughly corresponds to the thrid task outlined in Section 5 of the paper.
+    """
+
+_DESCRIPTION = {
+    "scifact_corpus_source": _SOURCE_CORPUS_DESCRIPTION,
+    "scifact_claims_source": _SOURCE_CLAIMS_DESCRIPTION,
+    "scifact_rationale_bigbio_pairs": _BIGBIO_PAIRS_RATIONALE_DESCRIPTION,
+    "scifact_labelprediction_bigbio_pairs": _BIGBIO_PAIRS_LABELPREDICTION_DESCRIPTION,
+}
+
+_HOMEPAGE = "https://scifact.apps.allenai.org/"
+
+
+_LICENSE = 'Creative Commons Attribution Non Commercial 2.0 Generic'
+
+_URLS = {
+    _DATASETNAME: "https://scifact.s3-us-west-2.amazonaws.com/release/latest/data.tar.gz",
+}
+
+_SUPPORTED_TASKS = [Tasks.TEXT_PAIRS_CLASSIFICATION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class SciFact(datasets.GeneratorBasedBuilder):
+    """
+    SciFact is a dataset of 1.4K expert-written scientific claims paired with evidence-containing abstracts, and annotated with labels and rationales.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="scifact_corpus_source",
+            version=SOURCE_VERSION,
+            description="scifact source schema for the corpus config",
+            schema="source",
+            subset_id="scifact_corpus_source",
+        ),
+        BigBioConfig(
+            name="scifact_claims_source",
+            version=SOURCE_VERSION,
+            description="scifact source schema for the claims config",
+            schema="source",
+            subset_id="scifact_claims_source",
+        ),
+        BigBioConfig(
+            name="scifact_rationale_bigbio_pairs",
+            version=BIGBIO_VERSION,
+            description="scifact BigBio text pairs classification schema for rationale task",
+            schema="bigbio_pairs",
+            subset_id="scifact_rationale_pairs",
+        ),
+        BigBioConfig(
+            name="scifact_labelprediction_bigbio_pairs",
+            version=BIGBIO_VERSION,
+            description="scifact BigBio text pairs classification schema for label prediction task",
+            schema="bigbio_pairs",
+            subset_id="scifact_labelprediction_pairs",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "scifact_claims_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            # modified from
+            # https://huggingface.co/datasets/scifact/blob/main/scifact.py#L50
+
+            if self.config.name == "scifact_corpus_source":
+                features = datasets.Features(
+                    {
+                        "doc_id": Value("int32"),      # The document's S2ORC ID.
+                        "title": Value("string"),      # The title.
+                        "abstract": [Value("string")], # The abstract, written as a list of sentences.
+                        "structured": Value("bool"),   # Indicator for whether this is a structured abstract.
+                    }
+                )
+
+            elif self.config.name == "scifact_claims_source":
+                features = datasets.Features(
+                    {
+                        "id": Value("int32"),  # An integer claim ID.
+                        "claim": Value("string"),  # The text of the claim.
+                        "evidences": [
+                            {
+                                "doc_id": Value("int32"),         # source doc_id for evidence
+                                "sentence_ids": [Value("int32")], # sentence ids from doc_id
+                                "label": Value("string"),         # SUPPORT or CONTRADICT
+                            },
+                        ],
+                        "cited_doc_ids": [Value("int32")],   # The claim's "cited documents".
+                    }
+                )
+
+            else:
+                raise NotImplementedError(
+                    f"{self.config.name} config not implemented"
+                )
+
+        elif self.config.schema == "bigbio_pairs":
+            features = pairs.features
+
+        else:
+            raise NotImplementedError(f"{self.config.schema} schema not implemented")
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION[self.config.name],
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        urls = _URLS[_DATASETNAME]
+        self.config.data_dir = dl_manager.download_and_extract(urls)
+
+        if self.config.name == "scifact_corpus_source":
+            return [
+                datasets.SplitGenerator(
+                    name=datasets.Split.TRAIN,
+                    gen_kwargs={
+                        "filepath": os.path.join(
+                            self.config.data_dir, "data", "corpus.jsonl"
+                        ),
+                        "split": "train",
+                    },
+                ),
+            ]
+
+        # the test split is only returned in source schema
+        # this is b/c it only has claims with no cited docs or evidence
+        # the bigbio implementation of this dataset requires
+        # cited docs or evidence to construct samples
+        elif self.config.name == "scifact_claims_source":
+            return [
+                datasets.SplitGenerator(
+                    name=datasets.Split.TRAIN,
+                    gen_kwargs={
+                        "filepath": os.path.join(
+                            self.config.data_dir, "data", "claims_train.jsonl"
+                        ),
+                        "split": "train",
+                    },
+                ),
+                datasets.SplitGenerator(
+                    name=datasets.Split.VALIDATION,
+                    gen_kwargs={
+                        "filepath": os.path.join(
+                            self.config.data_dir, "data", "claims_dev.jsonl"
+                        ),
+                        "split": "dev",
+                    },
+                ),
+                datasets.SplitGenerator(
+                    name=datasets.Split.TEST,
+                    gen_kwargs={
+                        "filepath": os.path.join(
+                            self.config.data_dir, "data", "claims_test.jsonl"
+                        ),
+                        "split": "test",
+                    },
+                ),
+            ]
+
+        elif self.config.name in [
+            "scifact_rationale_bigbio_pairs",
+            "scifact_labelprediction_bigbio_pairs",
+        ]:
+            return [
+                datasets.SplitGenerator(
+                    name=datasets.Split.TRAIN,
+                    gen_kwargs={
+                        "filepath": os.path.join(
+                            self.config.data_dir, "data", "claims_train.jsonl"
+                        ),
+                        "split": "train",
+                    },
+                ),
+                datasets.SplitGenerator(
+                    name=datasets.Split.VALIDATION,
+                    gen_kwargs={
+                        "filepath": os.path.join(
+                            self.config.data_dir, "data", "claims_dev.jsonl"
+                        ),
+                        "split": "dev",
+                    },
+                ),
+            ]
+
+
+    def _source_generate_examples(self, filepath, split) -> Tuple[str, Dict[str, str]]:
+
+        # here we just read corpus.jsonl and return the abstracts
+        if self.config.name == "scifact_corpus_source":
+            with open(filepath) as fp:
+                for id_, row in enumerate(fp.readlines()):
+                    data = json.loads(row)
+                    yield id_, {
+                        "doc_id": int(data["doc_id"]),
+                        "title": data["title"],
+                        "abstract": data["abstract"],
+                        "structured": data["structured"],
+                    }
+
+        # here we are reading one of claims_(train|dev|test).jsonl
+        elif self.config.name == "scifact_claims_source":
+
+            # claims_test.jsonl only has "id" and "claim" keys
+            # claims_train.jsonl and claims_dev.jsonl sometimes have evidence
+            with open(filepath) as fp:
+                for id_, row in enumerate(fp.readlines()):
+                    data = json.loads(row)
+                    evidences_dict = data.get("evidence", {})
+                    evidences_list = []
+                    for doc_id, sent_lbl_list in evidences_dict.items():
+                        for sent_lbl_dict in sent_lbl_list:
+                            evidence = {
+                                "doc_id": doc_id,
+                                "sentence_ids": sent_lbl_dict["sentences"],
+                                "label": sent_lbl_dict["label"],
+                            }
+                            evidences_list.append(evidence)
+
+                    yield id_, {
+                        "id": data["id"],
+                        "claim": data["claim"],
+                        "evidences": evidences_list,
+                        "cited_doc_ids": data.get("cited_doc_ids", []),
+                    }
+
+
+    def _bigbio_generate_examples(self, filepath, split) -> Tuple[str, Dict[str, str]]:
+        """
+        Here we always create one sample per sentence group.
+        Any sentence group in an evidence attribute will have
+        a label in {"rationale"} for the rationale task or
+        in {"SUPPORT", "CONTRADICT"} for the labelprediction task.
+        All other sentences will have either a "not_rationale"
+        label or a "NOINFO" label depending on the task.
+        """
+
+        # read corpus (one row per abstract)
+        corpus_file_path = os.path.join(self.config.data_dir, "data", "corpus.jsonl")
+        df_corpus = pd.read_json(corpus_file_path, lines=True)
+
+        # create one row per sentence and create sentence index
+        df_sents = df_corpus.explode('abstract')
+        df_sents = df_sents.rename(columns={"abstract": "sentence"})
+        df_sents['sent_num'] = df_sents.groupby('doc_id').transform('cumcount')
+        df_sents['doc_sent_id'] = df_sents.apply(lambda x: f"{x['doc_id']}-{x['sent_num']}", axis=1)
+
+        # read claims
+        df_claims = pd.read_json(filepath, lines=True)
+
+
+        # join claims to corpus
+        for _, claim_row in df_claims.iterrows():
+
+            evidence = claim_row['evidence']
+            cited_doc_ids = set(claim_row['cited_doc_ids'])
+            evidence_doc_ids = set([int(doc_id) for doc_id in evidence.keys()])
+
+            # assert all evidence doc IDs are in cited_doc_ids
+            assert len(evidence_doc_ids - cited_doc_ids) == 0
+
+            # this will have all abstract sentences from cited docs
+            df_claim_sents = df_sents[df_sents['doc_id'].isin(cited_doc_ids)]
+
+            # create all sentence samples as NOINFO then fix
+            noinfo_samples = {}
+            for _, row in df_claim_sents.iterrows():
+                sample = {
+                    "claim": claim_row["claim"],
+                    "claim_id": claim_row["id"],
+                    "doc_id": row['doc_id'],
+                    "sentence_ids": (row['sent_num'],),
+                    "doc_sent_ids": (row['doc_sent_id'],),
+                    "span": row['sentence'].strip(),
+                    "label": "NOINFO",
+                }
+                noinfo_samples[sample["doc_sent_ids"]] = sample
+
+            # create evidence samples and remove from noinfo samples as we go
+            evidence_samples = []
+            for doc_id_str, sent_lbl_list in evidence.items():
+                doc_id = int(doc_id_str)
+
+                for sent_lbl_dict in sent_lbl_list:
+                    sent_ids = sent_lbl_dict['sentences']
+                    doc_sent_ids = [f"{doc_id}-{sent_id}" for sent_id in sent_ids]
+                    df_evi = df_claim_sents[df_claim_sents['doc_sent_id'].isin(doc_sent_ids)]
+
+                    sample = {
+                        "claim": claim_row["claim"],
+                        "claim_id": claim_row["id"],
+                        "doc_id": doc_id,
+                        "sentence_ids": tuple(sent_ids),
+                        "doc_sent_ids": tuple(doc_sent_ids),
+                        "span": " ".join([el.strip() for el in df_evi["sentence"].values]),
+                        "label": sent_lbl_dict["label"],
+                    }
+                    evidence_samples.append(sample)
+                    for doc_sent_id in doc_sent_ids:
+                        del noinfo_samples[(doc_sent_id,)]
+
+            # combine all sample and put back in sentence order
+            all_samples = evidence_samples + list(noinfo_samples.values())
+            all_samples = sorted(all_samples, key=lambda x: (x['doc_id'], x['sentence_ids'][0]))
+
+            # add a unique ID
+            for _id, sample in enumerate(all_samples):
+                sample["id"] = f"{_id}-{sample['claim_id']}-{sample['doc_id']}-{sample['sentence_ids'][0]}"
+
+            RATIONALE_LABEL_MAP = {
+                "SUPPORT": "rationale",
+                "CONTRADICT": "rationale",
+                "NOINFO": "not_rationale",
+            }
+
+            if self.config.name == "scifact_rationale_bigbio_pairs":
+                for sample in all_samples:
+                    yield sample['id'], {
+                        "id": sample["id"],
+                        "document_id": sample["doc_id"],
+                        "text_1": sample["claim"],
+                        "text_2": sample["span"],
+                        "label": RATIONALE_LABEL_MAP[sample['label']],
+                    }
+
+            elif self.config.name == "scifact_labelprediction_bigbio_pairs":
+                for sample in all_samples:
+                    yield sample['id'], {
+                        "id": sample["id"],
+                        "document_id": sample["doc_id"],
+                        "text_1": sample["claim"],
+                        "text_2": sample["span"],
+                        "label": sample['label'],
+                    }
+
+    def _generate_examples(self, filepath, split) -> Tuple[int, dict]:
+
+        if "source" in self.config.name:
+            for sample in self._source_generate_examples(filepath, split):
+                yield sample
+
+        elif "bigbio" in self.config.name:
+            for sample in self._bigbio_generate_examples(filepath, split):
+                yield sample

--- a/hub/hubscripts/sciq_hub.py
+++ b/hub/hubscripts/sciq_hub.py
@@ -1,0 +1,167 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+
+import datasets
+
+from .bigbiohub import qa_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "sciq"
+_DISPLAYNAME = "SciQ"
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """
+@inproceedings{welbl-etal-2017-crowdsourcing,
+    title = "Crowdsourcing Multiple Choice Science Questions",
+    author = "Welbl, Johannes  and
+      Liu, Nelson F.  and
+      Gardner, Matt",
+    booktitle = "Proceedings of the 3rd Workshop on Noisy User-generated Text",
+    month = sep,
+    year = "2017",
+    address = "Copenhagen, Denmark",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/W17-4413",
+    doi = "10.18653/v1/W17-4413",
+    pages = "94--106",
+}
+"""
+
+_DESCRIPTION = """\
+The SciQ dataset contains 13,679 crowdsourced science exam questions about \
+Physics, Chemistry and Biology, among others. The questions are in \
+multiple-choice format with 4 answer options each. For most questions, an \
+additional paragraph with supporting evidence for the correct answer is \
+provided.
+"""
+
+_HOMEPAGE = "https://allenai.org/data/sciq"
+
+_LICENSE = 'Creative Commons Attribution Non Commercial 3.0 Unported'
+
+_URLs = "https://ai2-public-datasets.s3.amazonaws.com/sciq/SciQ.zip"
+
+_SUPPORTED_TASKS = [Tasks.QUESTION_ANSWERING]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class SciQ(datasets.GeneratorBasedBuilder):
+    """SciQ: a crowdsourced science exam QA dataset."""
+
+    DEFAULT_CONFIG_NAME = f"sciq_source"
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        # Source schema
+        BigBioConfig(
+            name="sciq_source",
+            version=SOURCE_VERSION,
+            description="SciQ source schema",
+            schema="source",
+            subset_id=f"sciq",
+        ),
+        # BigBio schema: question answering
+        BigBioConfig(
+            name=f"sciq_bigbio_qa",
+            version=BIGBIO_VERSION,
+            description="SciQ simplified BigBio schema",
+            schema="bigbio_qa",
+            subset_id="sciq",
+        ),
+    ]
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "question": datasets.Value("string"),
+                    "distractor1": datasets.Value("string"),
+                    "distractor2": datasets.Value("string"),
+                    "distractor3": datasets.Value("string"),
+                    "correct_answer": datasets.Value("string"),
+                    "support": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == "bigbio_qa":
+            features = qa_features
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            supervised_keys=None,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        dl_dir = dl_manager.download_and_extract(_URLs)
+        data_dir = os.path.join(dl_dir, "SciQ dataset-2 3")
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "train.json"),
+                    "split": datasets.Split.TRAIN,
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "valid.json"),
+                    "split": datasets.Split.VALIDATION,
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "test.json"),
+                    "split": datasets.Split.TEST,
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split):
+        with open(filepath, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if self.config.schema == "source":
+            for i, d in enumerate(data):
+                yield i, d
+        elif self.config.schema == "bigbio_qa":
+            question_type = "multiple_choice"
+            for i, d in enumerate(data):
+                id = f"{split}_{i}"
+                yield id, {
+                    "id": id,
+                    "question_id": id,
+                    "document_id": id,
+                    "question": d["question"],
+                    "type": question_type,
+                    "context": d["support"],
+                    "answer": [d["correct_answer"]],
+                    "choices": [
+                        d["distractor1"],
+                        d["distractor2"],
+                        d["distractor3"],
+                        d["correct_answer"],
+                    ],
+                }

--- a/hub/hubscripts/scitail_hub.py
+++ b/hub/hubscripts/scitail_hub.py
@@ -1,0 +1,174 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The SciTail dataset is an entailment dataset created from multiple-choice science exams and
+web sentences. Each question and the correct answer choice are converted into an assertive
+statement to form the hypothesis. We use information retrieval to obtain relevant text from
+a large text corpus of web sentences, and use these sentences as a premise P. We crowdsource
+the annotation of such premise-hypothesis pair as supports (entails) or not (neutral), in order
+to create the SciTail dataset. The dataset contains 27,026 examples with 10,101 examples with
+entails label and 16,925 examples with neutral label.
+"""
+
+import os
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import entailment_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@inproceedings{scitail,
+    author = {Tushar Khot and Ashish Sabharwal and Peter Clark},
+    booktitle = {AAAI}
+    title = {SciTail: A Textual Entailment Dataset from Science Question Answering},
+    year = {2018}
+}
+"""
+
+_DATASETNAME = "scitail"
+_DISPLAYNAME = "SciTail"
+
+_DESCRIPTION = """\
+The SciTail dataset is an entailment dataset created from multiple-choice science exams and
+web sentences. Each question and the correct answer choice are converted into an assertive
+statement to form the hypothesis. We use information retrieval to obtain relevant text from
+a large text corpus of web sentences, and use these sentences as a premise P. We crowdsource
+the annotation of such premise-hypothesis pair as supports (entails) or not (neutral), in order
+to create the SciTail dataset. The dataset contains 27,026 examples with 10,101 examples with
+entails label and 16,925 examples with neutral label.
+"""
+
+_HOMEPAGE = "https://allenai.org/data/scitail"
+
+_LICENSE = 'Apache License 2.0'
+
+_URLS = {
+    _DATASETNAME: "https://ai2-public-datasets.s3.amazonaws.com/scitail/SciTailV1.1.zip",
+}
+
+_SUPPORTED_TASKS = [Tasks.TEXTUAL_ENTAILMENT]
+
+_SOURCE_VERSION = "1.1.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+LABEL_MAP = {"entails": "entailment", "neutral": "neutral"}
+
+
+class SciTailDataset(datasets.GeneratorBasedBuilder):
+    """TODO: Short description of my dataset."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="scitail_source",
+            version=SOURCE_VERSION,
+            description="SciTail source schema",
+            schema="source",
+            subset_id="scitail",
+        ),
+        BigBioConfig(
+            name="scitail_bigbio_te",
+            version=BIGBIO_VERSION,
+            description="SciTail BigBio schema",
+            schema="bigbio_te",
+            subset_id="scitail",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "scitail_source"
+
+    def _info(self):
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "premise": datasets.Value("string"),
+                    "hypothesis": datasets.Value("string"),
+                    "label": datasets.Value("string"),
+                }
+            )
+
+        elif self.config.schema == "bigbio_te":
+            features = entailment_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "SciTailV1.1", "tsv_format", "scitail_1.0_train.tsv"
+                    ),
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "SciTailV1.1", "tsv_format", "scitail_1.0_test.tsv"
+                    ),
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "SciTailV1.1", "tsv_format", "scitail_1.0_dev.tsv"
+                    ),
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath):
+        # since examples can contain quotes mid text set quoting to QUOTE_NONE (3) when reading tsv
+        # e.g.: ... and apply specific "tools" to examples and ...
+        data = pd.read_csv(
+            filepath, sep="\t", names=["premise", "hypothesis", "label"], quoting=3
+        )
+        data["id"] = data.index
+
+        if self.config.schema == "source":
+            for _, row in data.iterrows():
+                yield row["id"], row.to_dict()
+
+        elif self.config.schema == "bigbio_te":
+            # normalize labels
+            data["label"] = data["label"].apply(lambda x: LABEL_MAP[x])
+            for _, row in data.iterrows():
+                yield row["id"], row.to_dict()

--- a/hub/hubscripts/seth_corpus_hub.py
+++ b/hub/hubscripts/seth_corpus_hub.py
@@ -1,0 +1,233 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Descriptions of genetic variations and their effect are widely spread across the biomedical literature. However,
+finding all mentions of a specific variation, or all mentions of variations in a specific gene, is difficult to
+achieve due to the many ways such variations are described. Here, we describe SETH, a tool for the recognition of
+variations from text and their subsequent normalization to dbSNP or UniProt. SETH achieves high precision and recall
+on several evaluation corpora of PubMed abstracts. It is freely available and encompasses stand-alone scripts for
+isolated application and evaluation as well as a thorough documentation for integration into other applications.
+The script loads dataset in bigbio schema (using knowledgebase schema: schemas/kb) AND/OR source (default) schema """
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@Article{SETH2016,
+    Title       = {SETH detects and normalizes genetic variants in text.},
+    Author      = {Thomas, Philippe and Rockt{"{a}}schel, Tim and Hakenberg, J{"{o}}rg and Lichtblau, Yvonne and Leser, Ulf},
+    Journal     = {Bioinformatics},
+    Year        = {2016},
+    Month       = {Jun},
+    Doi         = {10.1093/bioinformatics/btw234},
+    Language    = {eng},
+    Medline-pst = {aheadofprint},
+    Pmid        = {27256315},
+    Url         = {http://dx.doi.org/10.1093/bioinformatics/btw234
+}
+"""
+
+_DATASETNAME = "seth_corpus"
+_DISPLAYNAME = "SETH Corpus"
+
+_DESCRIPTION = (
+    """SNP named entity recognition corpus consisting of 630 PubMed citations."""
+)
+
+_HOMEPAGE = "https://github.com/rockt/SETH"
+
+_LICENSE = 'Apache License 2.0'
+_URLS = {
+    "source": "https://github.com/rockt/SETH/archive/refs/heads/master.zip",
+    "bigbio_kb": "https://github.com/rockt/SETH/archive/refs/heads/master.zip",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class SethCorpusDataset(datasets.GeneratorBasedBuilder):
+    """SNP named entity recognition corpus consisting of 630 PubMed citations."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="seth_corpus_source",
+            version=SOURCE_VERSION,
+            description="SETH corpus source schema",
+            schema="source",
+            subset_id="seth_corpus",
+        ),
+        BigBioConfig(
+            name="seth_corpus_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="SETH corpus BigBio schema",
+            schema="bigbio_kb",
+            subset_id="seth_corpus",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "seth_corpus_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "trigger": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arguments": datasets.Sequence(
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "attributes": [  # M or A lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value("string"),
+                            "cuid": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                        }
+                    ],
+                },
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[self.config.schema]
+        data_dir = Path(dl_manager.download_and_extract(urls))
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_dir / "SETH-master" / "resources" / "SETH-corpus",
+                    "corpus_file": "corpus.txt",
+                    "split": "train",
+                },
+            ),
+        ]
+
+    def _generate_examples(
+        self, filepath: Path, corpus_file: str, split: str
+    ) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        if self.config.schema == "source":
+            with open(filepath / corpus_file, encoding="utf-8") as f:
+                contents = f.readlines()
+            for guid, content in enumerate(contents):
+                file_name, text = content.split("\t")
+                example = parsing.parse_brat_file(
+                    filepath / "annotations" / f"{file_name}.ann"
+                )
+                example["id"] = str(guid)
+                example["text"] = text
+                yield guid, example
+
+        elif self.config.schema == "bigbio_kb":
+            with open(filepath / corpus_file, encoding="utf-8") as f:
+                contents = f.readlines()
+            for guid, content in enumerate(contents):
+                file_name, text = content.split("\t")
+                example = parsing.parse_brat_file(
+                    filepath / "annotations" / f"{file_name}.ann"
+                )
+
+                # this example contains event lines
+                # but events have not arguments
+                # this is most likely an error on the annotation side
+                if example["document_id"] == "11058905":
+                    example["events"] = []
+
+                example["text"] = text
+                example = parsing.brat_parse_to_bigbio_kb(example)
+                example["id"] = str(guid)
+                yield guid, example
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/hub/hubscripts/spl_adr_200db_hub.py
+++ b/hub/hubscripts/spl_adr_200db_hub.py
@@ -1,0 +1,405 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Dataset containing standardised information about known adverse reactions for 200
+FDA-approved drugs using information from the respective Structured Product Labels (SPLs).
+This data resulted from a partnership between the United States Food and Drug Administration
+(FDA) and the National Library of Medicine.
+
+Structured Product Labels (SPLs) are the documents FDA uses to exchange information
+about drugs and other products. For this dataset, SPLs were manually annotated for
+adverse reactions at the mention level to facilitate development and evaluation of
+text mining tools for extraction of ADRs from all SPLs. The ADRs were then normalised
+to the Unified Medical Language System (UMLS) and to the Medical Dictionary for
+Regulatory Activities (MedDRA).
+
+These data were used for the adverse event challenge at TAC 2017 (Text Analysis Conference)
+in four different tasks:
+* Task 1: Extract AdverseReactions and related mentions (Severity, Factor, DrugClass,
+Negation, Animal). This is similar to many NLP Named Entity Recognition (NER) evaluations.
+* Task 2: Identify the relations between AdverseReactions and related mentions (i.e.,
+Negated, Hypothetical, and Effect). This is similar to many NLP relation
+identification evaluations.
+* Task 3: Identify the positive AdverseReaction mention names in the labels.
+For the purposes of this task, positive will be defined as the caseless strings
+of all the AdverseReactions that have not been negated and are not related by
+a Hypothetical relation to a DrugClass or Animal. Note that this means Factors
+related via a Hypothetical relation are considered positive (e.g., "[unknown risk]
+Factor of [stroke]AdverseReaction") for the purposes of this task. The result of
+this task will be a list of unique strings corresponding to the positive ADRs
+as they were written in the label.
+* Task 4: Provide MedDRA PT(s) and LLT(s) for each positive AdverseReaction (occasionally,
+two or more PTs are necessary to fully describe the reaction). For participants
+approaching the tasks sequentially, this can be viewed as normalization of the terms
+extracted in Task 3 to MedDRA LLTs/PTs. Because MedDRA is not publicly available,
+and contains several versions, a standard version of MedDRA v18.1 will be provided
+to the participants. Other resources such as the UMLS Terminology Services may be
+used to aid with the normalization process.
+
+For more information regarding the challenge at TAC 2017, please visit:
+https://bionlp.nlm.nih.gov/tac2017adversereactions/
+
+"""
+
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@article{demner2018dataset,
+  author    = {Demner-Fushman, Dina and Shooshan, Sonya and Rodriguez, Laritza and Aronson,
+               Alan and Lang, Francois and Rogers, Willie and Roberts, Kirk and Tonning, Joseph},
+  title     = {A dataset of 200 structured product labels annotated for adverse drug reactions},
+  journal   = {Scientific Data},
+  volume    = {5},
+  year      = {2018},
+  month     = {01},
+  pages     = {180001},
+  url       = {
+    https://www.researchgate.net/publication/322810855_A_dataset_of_200_structured_product_labels_annotated_for_adverse_drug_reactions
+  },
+  doi       = {10.1038/sdata.2018.1}
+}
+"""
+
+_DATASETNAME = "spl_adr_200db"
+_DISPLAYNAME = "SPL ADR"
+
+_DESCRIPTION = """\
+The United States Food and Drug Administration (FDA) partnered with the National Library
+of Medicine to create a pilot dataset containing standardised information about known
+adverse reactions for 200 FDA-approved drugs. The Structured Product Labels (SPLs),
+the documents FDA uses to exchange information about drugs and other products, were
+manually annotated for adverse reactions at the mention level to facilitate development
+and evaluation of text mining tools for extraction of ADRs from all SPLs.  The ADRs were
+then normalised to the Unified Medical Language System (UMLS) and to the Medical
+Dictionary for Regulatory Activities (MedDRA).
+"""
+
+_HOMEPAGE = "https://bionlp.nlm.nih.gov/tac2017adversereactions/"
+
+# NOTE: Source: https://osf.io/6h9q4/
+_LICENSE = 'Creative Commons Zero v1.0 Universal'
+_URLS = {
+    _DATASETNAME: {
+        "train": "https://bionlp.nlm.nih.gov/tac2017adversereactions/train_xml.tar.gz",
+        "unannotated": "https://bionlp.nlm.nih.gov/tac2017adversereactions/unannotated_xml.tar.gz",
+    }
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.NAMED_ENTITY_DISAMBIGUATION,
+    Tasks.RELATION_EXTRACTION,
+]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class SplAdr200DBDataset(datasets.GeneratorBasedBuilder):
+    """
+    The United States Food and Drug Administration (FDA) partnered with the National Library
+    of Medicine to create a pilot dataset containing standardised information about known
+    adverse reactions for 200 FDA-approved drugs.
+
+    These data were used in the adverse event challenge at TAC 2017 (Text Analysis Conference).
+    For more information on the tasks, see: https://bionlp.nlm.nih.gov/tac2017adversereactions/
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = []
+
+    for subset_name in _URLS[_DATASETNAME]:
+        BUILDER_CONFIGS.extend(
+            [
+                BigBioConfig(
+                    name=f"spl_adr_200db_{subset_name}_source",
+                    version=SOURCE_VERSION,
+                    description=f"SPL ADR 200db source {subset_name} schema",
+                    schema="source",
+                    subset_id=f"spl_adr_200db_{subset_name}",
+                ),
+                BigBioConfig(
+                    name=f"spl_adr_200db_{subset_name}_bigbio_kb",
+                    version=BIGBIO_VERSION,
+                    description=f"SPL ADR 200db BigBio {subset_name} schema",
+                    schema="bigbio_kb",
+                    subset_id=f"spl_adr_200db_{subset_name}",
+                ),
+            ]
+        )
+
+    DEFAULT_CONFIG_NAME = "spl_adr_200db_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            unannotated_features = {
+                "drug_name": datasets.Value("string"),
+                "text": [datasets.Value("string")],
+                "sections": [
+                    {
+                        "id": datasets.Value("string"),
+                        "name": datasets.Value("string"),
+                        "text": datasets.Value("string"),
+                    }
+                ],
+            }
+            features = datasets.Features(
+                {
+                    **unannotated_features,
+                    "mentions": [
+                        {
+                            "id": datasets.Value("string"),
+                            "section": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "start": datasets.Value("string"),
+                            "len": datasets.Value("string"),
+                            "str": datasets.Value("string"),
+                        }
+                    ],
+                    "relations": [
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arg1": datasets.Value("string"),
+                            "arg2": datasets.Value("string"),
+                        }
+                    ],
+                    "reactions": [
+                        {
+                            "id": datasets.Value("string"),
+                            "str": datasets.Value("string"),
+                            "normalizations": [
+                                {
+                                    "id": datasets.Value("string"),
+                                    "meddra_pt": datasets.Value("string"),
+                                    "meddra_pt_id": datasets.Value("string"),
+                                    "meddra_llt": datasets.Value("string"),
+                                    "meddra_llt_id": datasets.Value("string"),
+                                    "flag": datasets.Value("string"),
+                                }
+                            ],
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        *_, subset_name = self.config.subset_id.split("_")
+
+        urls = _URLS[_DATASETNAME][subset_name]
+
+        data_dir = dl_manager.download_and_extract(urls)
+
+        data_files = (Path(data_dir) / f"{subset_name}_xml").glob("*.xml")
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepaths": tuple(data_files),
+                },
+            ),
+        ]
+
+    def _source_features_from_xml(self, element_tree):
+        root = element_tree.getroot()
+        drug_name = root.attrib["drug"]
+
+        sections = root.findall(".//Text/Section")
+        relations = root.findall(".//Relations/Relation")
+        reactions = [
+            {
+                "id": reaction.attrib["id"],
+                "str": reaction.attrib["str"],
+                "normalizations": [
+                    {
+                        # NOTE: Default features to `None` as not all of them
+                        # will be present in all reactions.
+                        "meddra_pt": None,
+                        "meddra_pt_id": None,
+                        "meddra_llt": None,
+                        "meddra_llt_id": None,
+                        "flag": None,
+                        **normalization.attrib,
+                    }
+                    for normalization in reaction.findall("Normalization")
+                ],
+            }
+            for reaction in root.findall(".//Reactions/Reaction")
+        ]
+
+        mentions = root.findall(".//Mentions/Mention")
+        return {
+            "drug_name": drug_name,
+            "text": [section.text for section in sections],
+            "mentions": [mention.attrib for mention in mentions],
+            "relations": [relation.attrib for relation in relations],
+            "reactions": reactions,
+            "sections": [
+                {**section.attrib, "text": section.text} for section in sections
+            ],
+        }
+
+    def _bigbio_kb_features_from_xml(self, element_tree):
+        source_features = self._source_features_from_xml(
+            element_tree=element_tree,
+        )
+        entity_normalizations = defaultdict(list)
+
+        for reaction in source_features["reactions"]:
+            entity_name = reaction["str"]
+            for normalization in reaction["normalizations"]:
+
+                # commenting this out for now
+                # if there is no db_name then its not a useful normalization
+                # if normalization["meddra_pt_id"]:
+                #    entity_normalizations[entity_name].append(
+                #        {"db_name": None, "db_id": f"pt_{normalization['meddra_pt_id']}"}
+                #    )
+
+                if normalization["meddra_llt_id"]:
+                    entity_normalizations[entity_name].append(
+                        {
+                            "db_name": "MedDRA v18.1",
+                            "db_id": f"llt_{normalization['meddra_llt_id']}",
+                        }
+                    )
+
+        section_lengths = list(
+            accumulate(len(section["text"]) for section in source_features["sections"])
+        )
+
+        section_offsets = [
+            (start + index, end + index)
+            for index, (start, end) in enumerate(
+                zip([0] + section_lengths[:-1], section_lengths)
+            )
+        ]
+
+        section_start_offset_map = {
+            f"S{section_index}": offsets[0]
+            for section_index, offsets in enumerate(section_offsets, 1)
+        }
+
+        entities = []
+
+        for mention in source_features["mentions"]:
+            start_points = [
+                int(start_point) + section_start_offset_map[mention["section"]]
+                for start_point in mention["start"].split(",")
+            ]
+
+            lens = [int(len_) for len_ in mention["len"].split(",")]
+
+            offsets = [
+                (start_point, start_point + len_)
+                for start_point, len_ in zip(start_points, lens)
+            ]
+
+            text = " ".join(section["text"] for section in source_features["sections"])
+
+            entity_strings = [
+                text[start_point : start_point + len_]
+                for start_point, len_ in zip(start_points, lens)
+            ]
+
+            entities.append(
+                {
+                    "id": f"{source_features['drug_name']}_entity_{mention['id']}",
+                    "type": mention["type"],
+                    "text": entity_strings,
+                    "offsets": offsets,
+                    "normalized": entity_normalizations[mention["str"]],
+                }
+            )
+
+        return {
+            "document_id": source_features["drug_name"],
+            "passages": [
+                {
+                    "id": f"{source_features['drug_name']}_section_{section['id']}",
+                    "type": section["name"],
+                    "text": [section["text"]],
+                    "offsets": [offsets],
+                }
+                for section, offsets in zip(
+                    source_features["sections"], section_offsets
+                )
+            ],
+            "entities": entities,
+            "relations": [
+                {
+                    "id": f"{source_features['drug_name']}_relation_{relation['id']}",
+                    "type": relation["type"],
+                    "arg1_id": relation["arg1"],
+                    "arg2_id": relation["arg2"],
+                    "normalized": [],
+                }
+                for relation in source_features["relations"]
+            ],
+            "events": [],
+            "coreferences": [],
+        }
+
+    def _generate_examples(self, filepaths: Tuple[Path]) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        for file_index, drug_filename in enumerate(filepaths):
+            element_tree = ET.parse(drug_filename)
+
+            if self.config.schema == "source":
+                features = self._source_features_from_xml(
+                    element_tree=element_tree,
+                )
+            elif self.config.schema == "bigbio_kb":
+                features = self._bigbio_kb_features_from_xml(
+                    element_tree=element_tree,
+                )
+                features["id"] = file_index
+            else:
+                raise ValueError(
+                    f"Unsupported schema '{self.config.schema}' requested for "
+                    f"dataset with name '{_DATASETNAME}'."
+                )
+
+            yield file_index, features

--- a/hub/hubscripts/swedish_medical_ner_hub.py
+++ b/hub/hubscripts/swedish_medical_ner_hub.py
@@ -1,0 +1,302 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+swedish_medical_ner is Named Entity Recognition dataset on medical text in Swedish. 
+
+It consists three subsets which are in turn derived from three different sources respectively: 
+
+* the Swedish Wikipedia (a.k.a. wiki): Wiki_annotated_60.txt
+* Läkartidningen (a.k.a. lt): LT_annotated_60.txt
+* 1177 Vårdguiden (a.k.a. 1177): 1177_annotated_sentences.txt
+
+Texts from both Swedish Wikipedia and Läkartidningen were automatically annotated using a 
+list of medical seed terms. Sentences from 1177 Vårdguiden were manuually annotated.
+
+It can be found in Hugging Face Datasets: https://huggingface.co/datasets/swedish_medical_ner.
+
+"""
+
+import os
+import re
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "swedish_medical_ner"
+_DISPLAYNAME = "Swedish Medical NER"
+
+_LANGUAGES = ['Swedish']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@inproceedings{almgren-etal-2016-named,
+    author = {
+        Almgren, Simon and
+        Pavlov, Sean and
+        Mogren, Olof
+    },
+    title     = {Named Entity Recognition in Swedish Medical Journals with Deep Bidirectional Character-Based LSTMs},
+    booktitle = {Proceedings of the Fifth Workshop on Building and Evaluating Resources for Biomedical Text Mining (BioTxtM 2016)},
+    publisher = {The COLING 2016 Organizing Committee},
+    pages     = {30-39},
+    year      = {2016},
+    month     = {12},
+    url       = {https://aclanthology.org/W16-5104},
+    eprint    = {https://aclanthology.org/W16-5104.pdf}
+}
+"""
+
+_DESCRIPTION = """\
+swedish_medical_ner is Named Entity Recognition dataset on medical text in Swedish. 
+It consists three subsets which are in turn derived from three different sources 
+respectively: the Swedish Wikipedia (a.k.a. wiki), Läkartidningen (a.k.a. lt), 
+and 1177 Vårdguiden (a.k.a. 1177). While the Swedish Wikipedia and Läkartidningen 
+subsets in total contains over 790000 sequences with 60 characters each, 
+the 1177 Vårdguiden subset is manually annotated and contains 927 sentences, 
+2740 annotations, out of which 1574 are disorder and findings, 546 are 
+pharmaceutical drug, and 620 are body structure.
+
+Texts from both Swedish Wikipedia and Läkartidningen were automatically annotated 
+using a list of medical seed terms. Sentences from 1177 Vårdguiden were manuually 
+annotated.
+"""
+
+_HOMEPAGE = "https://github.com/olofmogren/biomedical-ner-data-swedish/"
+
+_LICENSE = 'Creative Commons Attribution Share Alike 4.0 International'
+
+_URLS = {
+    "swedish_medical_ner_wiki": "https://raw.githubusercontent.com/olofmogren/biomedical-ner-data-swedish/master/Wiki_annotated_60.txt",
+    "swedish_medical_ner_lt": "https://raw.githubusercontent.com/olofmogren/biomedical-ner-data-swedish/master/LT_annotated_60.txt",
+    "swedish_medical_ner_1177": "https://raw.githubusercontent.com/olofmogren/biomedical-ner-data-swedish/master/1177_annotated_sentences.txt",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class SwedishMedicalNerDataset(datasets.GeneratorBasedBuilder):
+    """
+    Swedish medical named entity recognition
+
+    The dataset contains three subsets, namely "wiki", "lt" and "1177".
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = []
+    for subset in ["wiki", "lt", "1177"]:
+        BUILDER_CONFIGS.append(
+            BigBioConfig(
+                name=f"swedish_medical_ner_{subset}_source",
+                version=SOURCE_VERSION,
+                description="swedish_medical_ner source schema",
+                schema="source",
+                subset_id=f"swedish_medical_ner_{subset}",
+            )
+        )
+        BUILDER_CONFIGS.append(
+            BigBioConfig(
+                name=f"swedish_medical_ner_{subset}_bigbio_kb",
+                version=BIGBIO_VERSION,
+                description="swedish_medical_ner BigBio schema",
+                schema="bigbio_kb",
+                subset_id=f"swedish_medical_ner_{subset}",
+            )
+        )
+
+    DEFAULT_CONFIG_NAME = "swedish_medical_ner_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "sid": datasets.Value("string"),
+                    "sentence": datasets.Value("string"),
+                    "entities": [
+                        {
+                            "start": datasets.Value("int32"),
+                            "end": datasets.Value("int32"),
+                            "text": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(
+        self, dl_manager: datasets.DownloadManager
+    ) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS
+        filepath = dl_manager.download_and_extract(urls[self.config.subset_id])
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": filepath,
+                    "split": "train",
+                },
+            ),
+        ]
+
+    @staticmethod
+    def get_type(text):
+        """
+        Tagging format per the dataset authors
+        - Prenthesis, (): Disorder and Finding
+        - Brackets, []: Pharmaceutical Drug
+        - Curly brackets, {}: Body Structure
+
+        """
+        if text[0] == "(":
+            return "disorder_finding"
+        elif text[1] == "[":
+            return "pharma_drug"
+        return "body_structure"
+
+    @staticmethod
+    def get_source_example(uid, tagged):
+
+        ents, text = zip(*tagged)
+        text = list(text)
+
+        # build offsets
+        offsets = []
+        curr = 0
+        for span in text:
+            offsets.append((curr, curr + len(span)))
+            curr = curr + len(span)
+
+        text = "".join(text)
+        doc = {"sid": "s" + str(uid), "sentence": text, "entities": []}
+
+        # Create entities
+        for i, (start, end) in enumerate(offsets):
+            if ents[i] is not None:
+                doc["entities"].append(
+                    {
+                        "start": start,
+                        "end": end,
+                        "text": text[start:end],
+                        "type": ents[i],
+                    }
+                )
+
+        return uid, doc
+
+    @staticmethod
+    def get_bigbio_example(uid, tagged, remove_markup=True):
+        doc = {
+            "id": str(uid),
+            "document_id": "s" + str(uid),
+            "passages": [],
+            "entities": [],
+            "events": [],
+            "coreferences": [],
+            "relations": [],
+        }
+
+        ents, text = zip(*tagged)
+        text = list(text)
+        if remove_markup:
+            for i in range(len(ents)):
+                if ents[i] is not None:
+                    text[i] = re.sub(r"[(){}\[\]]", "", text[i]).strip()
+
+        # build offsets
+        offsets = []
+        curr = 0
+        for span in text:
+            offsets.append((curr, curr + len(span)))
+            curr = curr + len(span)
+
+        # Create passage
+        passage = "".join(text)
+        doc["passages"].append(
+            {
+                "id": str(uid) + "-passage-0",
+                "type": "sentence",
+                "text": [passage],
+                "offsets": [[0, len(passage)]],
+            }
+        )
+
+        # Create entities
+        ii = 0
+        for i, (start, end) in enumerate(offsets):
+            if ents[i] is not None:
+                doc["entities"].append(
+                    {
+                        "id": str(uid) + "-entity-" + str(ii),
+                        "type": ents[i],
+                        "text": [passage[start:end]],
+                        "offsets": [[start, end]],
+                        "normalized": [],
+                    }
+                )
+                ii += 1
+
+        return uid, doc
+
+    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        entity_rgx = re.compile(r"[(].+?[)]|[\[].+?[\]]|[{].+?[}]")
+
+        uid = 0
+        with open(filepath, "rt", encoding="utf-8") as file:
+            for i, row in enumerate(file):
+                row = row.replace("\n", "")
+                if row:
+                    curr = 0
+                    stack = []
+                    # match entities and build spans for sentence string
+                    for m in entity_rgx.finditer(row):
+                        span = m.group()
+                        if m.start() != 0:
+                            stack.append([None, row[curr : m.start()]])
+                        stack.append((self.get_type(span), span))
+                        curr = m.start() + len(span)
+                    stack.append([None, row[curr:]])
+
+                    if self.config.schema == "source":
+                        yield self.get_source_example(uid, stack)
+                    elif self.config.schema == "bigbio_kb":
+                        yield self.get_bigbio_example(uid, stack)
+                    uid += 1

--- a/hub/hubscripts/tmvar_v1_hub.py
+++ b/hub/hubscripts/tmvar_v1_hub.py
@@ -1,0 +1,249 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import itertools
+import os
+from pydoc import doc
+from typing import Dict, Iterator, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{wei2013tmvar,
+  title={tmVar: a text mining approach for extracting sequence variants in biomedical literature},
+  author={Wei, Chih-Hsuan and Harris, Bethany R and Kao, Hung-Yu and Lu, Zhiyong},
+  journal={Bioinformatics},
+  volume={29},
+  number={11},
+  pages={1433--1439},
+  year={2013},
+  publisher={Oxford University Press}
+}
+"""
+
+_DATASETNAME = "tmvar_v1"
+_DISPLAYNAME = "tmVar v1"
+
+_DESCRIPTION = """This dataset contains 500 PubMed articles manually annotated with mutation mentions of various kinds. It can be used for NER tasks only.
+The dataset is split into train(334) and test(166) splits"""
+
+_HOMEPAGE = "https://www.ncbi.nlm.nih.gov/research/bionlp/Tools/tmvar/"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: "https://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/tmTools/download/tmVar/tmVarCorpus.zip",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+logger = datasets.utils.logging.get_logger(__name__)
+
+
+class TmvarV1Dataset(datasets.GeneratorBasedBuilder):
+    """
+    The tmVar dataset contains 500 PubMed articles manually annotated with mutation
+    mentions of various kinds.
+    It can be used for biomedical NER tasks
+    """
+
+    DEFAULT_CONFIG_NAME = "tmvar_v1_source"
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = []
+    BUILDER_CONFIGS.append(
+        BigBioConfig(
+            name=f"{_DATASETNAME}_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=f"{_DATASETNAME}",
+        )
+    )
+    BUILDER_CONFIGS.append(
+        BigBioConfig(
+            name=f"{_DATASETNAME}_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description=f"{_DATASETNAME} BigBio schema",
+            schema="bigbio_kb",
+            subset_id=f"{_DATASETNAME}",
+        )
+    )
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "pmid": datasets.Value("string"),
+                    "passages": [
+                        {
+                            "type": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                            "offsets": [datasets.Value("int32")],
+                        }
+                    ],
+                    "entities": [
+                        {
+                            "text": datasets.Value("string"),
+                            "offsets": [datasets.Value("int32")],
+                            "concept_id": datasets.Value("string"),
+                            "semantic_type_id": datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        url = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(url)
+        train_filepath = os.path.join(data_dir, "tmVarCorpus", "train.PubTator.txt")
+        test_filepath = os.path.join(data_dir, "tmVarCorpus", "test.PubTator.txt")
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": train_filepath,
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": test_filepath,
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        if self.config.schema == "source":
+            with open(filepath, "r", encoding="utf8") as fstream:
+                for raw_document in self.generate_raw_docs(fstream):
+                    document = self.parse_raw_doc(raw_document)
+                    yield document["pmid"], document
+
+        elif self.config.schema == "bigbio_kb":
+            with open(filepath, "r", encoding="utf8") as fstream:
+                uid = itertools.count(0)
+                for raw_document in self.generate_raw_docs(fstream):
+                    document = self.parse_raw_doc(raw_document)
+                    pmid = document.pop("pmid")
+                    document["id"] = next(uid)
+                    document["document_id"] = pmid
+
+                    entities_ = []
+                    for entity in document["entities"]:
+                        entities_.append(
+                            {
+                                "id": next(uid),
+                                "type": entity["semantic_type_id"],
+                                "text": [entity["text"]],
+                                "normalized": [],
+                                "offsets": [entity["offsets"]],
+                            }
+                        )
+                    for passage in document["passages"]:
+                        passage["id"] = next(uid)
+
+                    document["entities"] = entities_
+                    document["relations"] = []
+                    document["events"] = []
+                    document["coreferences"] = []
+                    yield document["document_id"], document
+
+    def generate_raw_docs(self, fstream):
+        """
+        Given a filestream, this function yields documents from it
+        """
+        raw_document = []
+        for line in fstream:
+            if line.strip():
+                raw_document.append(line.strip())
+            elif raw_document:
+                yield raw_document
+                raw_document = []
+        if raw_document:
+            yield raw_document
+
+    def parse_raw_doc(self, raw_doc):
+        pmid, _, title = raw_doc[0].split("|")
+        pmid = int(pmid)
+        _, _, abstract = raw_doc[1].split("|")
+
+        if self.config.schema == "source":
+            passages = [
+                {"type": "title", "text": title, "offsets": [0, len(title)]},
+                {
+                    "type": "abstract",
+                    "text": abstract,
+                    "offsets": [len(title) + 1, len(title) + len(abstract) + 1],
+                },
+            ]
+        elif self.config.schema == "bigbio_kb":
+            passages = [
+                {"type": "title", "text": [title], "offsets": [[0, len(title)]]},
+                {
+                    "type": "abstract",
+                    "text": [abstract],
+                    "offsets": [[len(title) + 1, len(title) + len(abstract) + 1]],
+                },
+            ]
+
+        entities = []
+        for line in raw_doc[2:]:
+            mentions = line.split("\t")
+            (
+                pmid_,
+                start_idx,
+                end_idx,
+                mention,
+                semantic_type_id,
+                entity_id,
+            ) = mentions
+
+            entity = {
+                "offsets": [int(start_idx), int(end_idx)],
+                "text": mention,
+                "semantic_type_id": semantic_type_id,
+                "concept_id": entity_id,
+            }
+            entities.append(entity)
+
+        return {"pmid": pmid, "passages": passages, "entities": entities}

--- a/hub/hubscripts/tmvar_v2_hub.py
+++ b/hub/hubscripts/tmvar_v2_hub.py
@@ -1,0 +1,291 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import itertools
+import os
+from pydoc import doc
+from typing import Dict, Iterator, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{wei2018tmvar,
+title={tmVar 2.0: integrating genomic variant information from literature with dbSNP and ClinVar for precision medicine},
+author={Wei, Chih-Hsuan and Phan, Lon and Feltz, Juliana and Maiti, Rama and Hefferon, Tim and Lu, Zhiyong},
+journal={Bioinformatics},
+volume={34},
+number={1},
+pages={80--87},
+year={2018},
+publisher={Oxford University Press}
+}
+"""
+
+_DATASETNAME = "tmvar_v2"
+_DISPLAYNAME = "tmVar v2"
+
+_DESCRIPTION = """This dataset contains 158 PubMed articles manually annotated with mutation mentions of various kinds and dbsnp normalizations for each of them.
+It can be used for NER tasks and NED tasks, This dataset has a single split"""
+
+_HOMEPAGE = "https://www.ncbi.nlm.nih.gov/research/bionlp/Tools/tmvar/"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {
+    _DATASETNAME: "https://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/tmTools/download/tmVar/tmVar.Normalization.txt",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION]
+
+_SOURCE_VERSION = "2.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+logger = datasets.utils.logging.get_logger(__name__)
+
+
+class TmvarV2Dataset(datasets.GeneratorBasedBuilder):
+    """
+    This dataset contains 158 PubMed articles manually annotated with mutation mentions of various kinds and dbsnp normalizations for each of them.
+    """
+
+    DEFAULT_CONFIG_NAME = "tmvar_v2_source"
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = []
+    BUILDER_CONFIGS.append(
+        BigBioConfig(
+            name=f"{_DATASETNAME}_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=f"{_DATASETNAME}",
+        )
+    )
+    BUILDER_CONFIGS.append(
+        BigBioConfig(
+            name=f"{_DATASETNAME}_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description=f"{_DATASETNAME} BigBio schema",
+            schema="bigbio_kb",
+            subset_id=f"{_DATASETNAME}",
+        )
+    )
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "pmid": datasets.Value("string"),
+                    "passages": [
+                        {
+                            "type": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                            "offsets": [datasets.Value("int32")],
+                        }
+                    ],
+                    "entities": [
+                        {
+                            "text": datasets.Value("string"),
+                            "offsets": [datasets.Value("int32")],
+                            "concept_id": datasets.Value("string"),
+                            "semantic_type_id": datasets.Value("string"),
+                            "rsid": datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        url = _URLS[_DATASETNAME]
+        train_filepath = dl_manager.download(url)
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": train_filepath,
+                },
+            )
+        ]
+
+    def _generate_examples(self, filepath) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        if self.config.schema == "source":
+            with open(filepath, "r", encoding="utf8") as fstream:
+                for raw_document in self.generate_raw_docs(fstream):
+                    document = self.parse_raw_doc(raw_document)
+                    yield document["pmid"], document
+
+        elif self.config.schema == "bigbio_kb":
+            with open(filepath, "r", encoding="utf8") as fstream:
+                uid = itertools.count(0)
+                for raw_document in self.generate_raw_docs(fstream):
+                    document = self.parse_raw_doc(raw_document)
+                    document["id"] = next(uid)
+                    document["document_id"] = document.pop("pmid")
+
+                    entities_ = []
+                    for entity in document["entities"]:
+                        if entity.get("rsid", ""):
+                            normalized = [
+                                {
+                                    "db_name": "dbsnp",
+                                    "db_id": entity.get("rsid").split(":")[1],
+                                }
+                            ]
+                        else:
+                            normalized = []
+
+                        entities_.append(
+                            {
+                                "id": next(uid),
+                                "type": entity["semantic_type_id"],
+                                "text": [entity["text"]],
+                                "normalized": normalized,
+                                "offsets": [entity["offsets"]],
+                            }
+                        )
+                    for passage in document["passages"]:
+                        passage["id"] = next(uid)
+
+                    document["entities"] = entities_
+                    document["relations"] = []
+                    document["events"] = []
+                    document["coreferences"] = []
+
+                    yield document["document_id"], document
+
+    def generate_raw_docs(self, fstream):
+        """
+        Given a filestream, this function yields documents from it
+        """
+        raw_document = []
+        for line in fstream:
+            if line.strip():
+                raw_document.append(line.strip())
+            elif raw_document:
+                yield raw_document
+                raw_document = []
+        if raw_document:
+            yield raw_document
+
+    def parse_raw_doc(self, raw_doc):
+        pmid, _, title = raw_doc[0].split("|")
+        pmid = int(pmid)
+        _, _, abstract = raw_doc[1].split("|")
+
+        if self.config.schema == "source":
+            passages = [
+                {"type": "title", "text": title, "offsets": [0, len(title)]},
+                {
+                    "type": "abstract",
+                    "text": abstract,
+                    "offsets": [len(title) + 1, len(title) + len(abstract) + 1],
+                },
+            ]
+        elif self.config.schema == "bigbio_kb":
+            passages = [
+                {"type": "title", "text": [title], "offsets": [[0, len(title)]]},
+                {
+                    "type": "abstract",
+                    "text": [abstract],
+                    "offsets": [[len(title) + 1, len(title) + len(abstract) + 1]],
+                },
+            ]
+
+        entities = []
+        for count, line in enumerate(raw_doc[2:]):
+            line_pieces = line.split("\t")
+            if len(line_pieces) == 6:
+                if pmid == 18166824 and count == 0:
+                    # this example has the following text
+                    # 18166824    880    948    amino acid (proline) with a polar amino acid (serine) at position 29    p|SUB|P|29|S    RSID:2075789
+                    # it is missing the semantic_type_id between `... position 29` and `p|SUB|P|29|S`
+                    pmid_ = str(pmid)
+                    start_idx = "880"
+                    end_idx = "948"
+                    mention = "amino acid (proline) with a polar amino acid (serine) at position 29"
+                    semantic_type_id = "ProteinMutation"
+                    entity_id = "p|SUB|P|29|S"
+                    rsid = "RSID:2075789"
+                    assert line_pieces[0] == pmid_
+                    assert line_pieces[1] == start_idx
+                    assert line_pieces[2] == end_idx
+                    assert line_pieces[3] == mention
+                    assert line_pieces[4] == entity_id
+                    assert line_pieces[5] == rsid
+                    logger.info(
+                        f"Adding ProteinMutation semantic_type_id in Document ID: {pmid} Line: {line}"
+                    )
+                else:
+                    (
+                        pmid_,
+                        start_idx,
+                        end_idx,
+                        mention,
+                        semantic_type_id,
+                        entity_id,
+                    ) = line_pieces
+                    rsid = None
+
+            elif len(line_pieces) == 7:
+                (
+                    pmid_,
+                    start_idx,
+                    end_idx,
+                    mention,
+                    semantic_type_id,
+                    entity_id,
+                    rsid,
+                ) = line_pieces
+
+            else:
+                logger.info(
+                    f"Inconsistent entity format found. Skipping Document ID: {pmid} Line: {line}"
+                )
+                continue
+
+            entity = {
+                "offsets": [int(start_idx), int(end_idx)],
+                "text": mention,
+                "semantic_type_id": semantic_type_id,
+                "concept_id": entity_id,
+                "rsid": rsid,
+            }
+            entities.append(entity)
+
+        return {"pmid": pmid, "passages": passages, "entities": entities}

--- a/hub/hubscripts/tmvar_v3_hub.py
+++ b/hub/hubscripts/tmvar_v3_hub.py
@@ -1,0 +1,307 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This dataset contains 500 PubMed articles manually annotated with mutation
+mentions of various kinds and dbsnp normalizations for each of them.  In
+addition, it contains variant normalization options such as allele-specific
+identifiers from the ClinGen Allele Registry It can be used for NER tasks and
+NED tasks, This dataset does NOT have splits.
+"""
+import itertools
+
+import datasets
+from bioc import pubtator
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_CITATION = """\
+@misc{https://doi.org/10.48550/arxiv.2204.03637,
+  title        = {tmVar 3.0: an improved variant concept recognition and normalization tool},
+  author       = {
+    Wei, Chih-Hsuan and Allot, Alexis and Riehle, Kevin and Milosavljevic,
+    Aleksandar and Lu, Zhiyong
+  },
+  year         = 2022,
+  publisher    = {arXiv},
+  doi          = {10.48550/ARXIV.2204.03637},
+  url          = {https://arxiv.org/abs/2204.03637},
+  copyright    = {Creative Commons Attribution 4.0 International},
+  keywords     = {
+    Computation and Language (cs.CL), FOS: Computer and information sciences,
+    FOS: Computer and information sciences
+  }
+}
+
+"""
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+
+_DATASETNAME = "tmvar_v3"
+_DISPLAYNAME = "tmVar v3"
+
+_DESCRIPTION = """\
+This dataset contains 500 PubMed articles manually annotated with mutation \
+mentions of various kinds and dbsnp normalizations for each of them.  In \
+addition, it contains variant normalization options such as allele-specific \
+identifiers from the ClinGen Allele Registry It can be used for NER tasks and \
+NED tasks, This dataset does NOT have splits.
+"""
+
+_HOMEPAGE = "https://www.ncbi.nlm.nih.gov/research/bionlp/Tools/tmvar/"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = {_DATASETNAME: "ftp://ftp.ncbi.nlm.nih.gov/pub/lu/tmVar3/tmVar3Corpus.txt"}
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION]
+_SOURCE_VERSION = "3.0.0"
+_BIGBIO_VERSION = "1.0.0"
+logger = datasets.utils.logging.get_logger(__name__)
+
+
+class TmvarV3Dataset(datasets.GeneratorBasedBuilder):
+    """
+    This dataset contains 500 PubMed articles manually annotated with mutation mentions of various kinds and various normalizations for each of them.
+    """
+
+    DEFAULT_CONFIG_NAME = "tmvar_v3_source"
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+    BUILDER_CONFIGS = []
+    BUILDER_CONFIGS.append(
+        BigBioConfig(
+            name=f"{_DATASETNAME}_source",
+            version=SOURCE_VERSION,
+            description=f"{_DATASETNAME} source schema",
+            schema="source",
+            subset_id=f"{_DATASETNAME}",
+        )
+    )
+    BUILDER_CONFIGS.append(
+        BigBioConfig(
+            name=f"{_DATASETNAME}_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description=f"{_DATASETNAME} BigBio schema",
+            schema="bigbio_kb",
+            subset_id=f"{_DATASETNAME}",
+        )
+    )
+
+    def _info(self) -> datasets.DatasetInfo:
+        type_to_db_mapping = {
+            "CorrespondingGene": "NCBI Gene",
+            "tmVar": "tmVar",
+            "dbSNP": "dbSNP",
+            "VariantGroup": "VariantGroup",
+            "NCBI Taxonomy": "NCBI Taxonomy",
+        }
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "pmid": datasets.Value("string"),
+                    "passages": [
+                        {
+                            "type": datasets.Value("string"),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                        }
+                    ],
+                    "entities": [
+                        {
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "semantic_type_id": datasets.Sequence(
+                                datasets.Value("string")
+                            ),
+                            "normalized": {
+                                key: datasets.Sequence(datasets.Value("string"))
+                                for key in type_to_db_mapping.keys()
+                            },
+                        }
+                    ],
+                }
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+        url = _URLS[_DATASETNAME]
+        test_filepath = dl_manager.download(url)
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": test_filepath,
+                },
+            )
+        ]
+
+    def get_normalizations(self, id, type, doc_id):
+        """
+        Given a type and a number of normalizations ids, this function returns a dictionary of the normalized ids
+        """
+        base_dict = {
+            key: []
+            for key in [
+                "tmVar",
+                "CorrespondingGene",
+                "dbSNP",
+                "VariantGroup",
+                "NCBI Taxonomy",
+            ]
+        }
+        ids = id.split(";")
+        if type in ["CellLine", "Species"]:
+            id_vals = ids[0].split(",")
+            base_dict["NCBI Taxonomy"] = id_vals
+        elif type == "Gene":
+            id_vals = ids[0].split(",")
+            base_dict["CorrespondingGene"] = id_vals
+        else:
+            for id in ids:
+                if "|" in id:
+                    base_dict["tmVar"].append(id)
+                elif id[:2] == "rs":
+                    base_dict["dbSNP"].append(id[2:])
+                elif ":" in id:
+                    db_name, db_id = id.split(":")
+                    if db_name == "RS#":
+                        db_name = "dbSNP"
+                    # Hacky fix below for doc ID: 18272172
+                    elif db_name == "Va1iantGroup":
+                        db_name = "VariantGroup"
+                    elif db_name == "Gene":
+                        db_name = "CorrespondingGene"
+                    elif db_name == "Disease":
+                        continue
+                    db_ids = db_id.split(",")
+                    base_dict[db_name].extend(db_ids)
+                else:
+                    logger.info(
+                        f"Malformed normalization in Document {doc_id}. Type: {type}, Number: {id}"
+                    )
+                    continue
+        return base_dict
+
+    def pubtator_to_source(self, filepath):
+        """
+        Converts pubtator to source schema
+        """
+        with open(filepath, "r", encoding="utf8") as fstream:
+            for doc in pubtator.iterparse(fstream):
+                document = {}
+                document["pmid"] = doc.pmid
+                title = doc.title
+                abstract = doc.abstract
+                document["passages"] = [
+                    {"type": "title", "text": [title], "offsets": [[0, len(title)]]},
+                    {
+                        "type": "abstract",
+                        "text": [abstract],
+                        "offsets": [[len(title) + 1, len(title) + len(abstract) + 1]],
+                    },
+                ]
+                document["entities"] = [
+                    {
+                        "offsets": [[mention.start, mention.end]],
+                        "text": [mention.text],
+                        "semantic_type_id": [mention.type],
+                        "normalized": self.get_normalizations(
+                            mention.id,
+                            mention.type,
+                            doc.pmid,
+                        ),
+                    }
+                    for mention in doc.annotations
+                ]
+                yield document
+
+    def pubtator_to_bigbio_kb(self, filepath):
+        """
+        Converts pubtator to bigbio_kb schema
+        """
+        with open(filepath, "r", encoding="utf8") as fstream:
+            uid = itertools.count(0)
+            for doc in pubtator.iterparse(fstream):
+                document = {}
+                title = doc.title
+                abstract = doc.abstract
+                document["id"] = next(uid)
+                document["document_id"] = doc.pmid
+                document["passages"] = [
+                    {
+                        "id": next(uid),
+                        "type": "title",
+                        "text": [title],
+                        "offsets": [[0, len(title)]],
+                    },
+                    {
+                        "id": next(uid),
+                        "type": "abstract",
+                        "text": [abstract],
+                        "offsets": [[len(title) + 1, len(title) + len(abstract) + 1]],
+                    },
+                ]
+                document["entities"] = [
+                    {
+                        "id": next(uid),
+                        "offsets": [[mention.start, mention.end]],
+                        "text": [mention.text],
+                        "type": [mention.type],
+                        "normalized": self.get_normalizations(
+                            mention.id, mention.type, doc.pmid
+                        ),
+                    }
+                    for mention in doc.annotations
+                ]
+                db_id_mapping = {
+                    "dbSNP": "dbSNP",
+                    "CorrespondingGene": "NCBI Gene",
+                    "tmVar": "dbSNP",
+                }
+                for entity in document["entities"]:
+                    normalized_bigbio_kb = []
+                    for key, id_list in entity["normalized"].items():
+                        if key in db_id_mapping.keys():
+                            normalized_bigbio_kb.extend(
+                                [
+                                    {"db_name": db_id_mapping[key], "db_id": id}
+                                    for id in id_list
+                                ]
+                            )
+                    entity["normalized"] = normalized_bigbio_kb
+                document["relations"] = []
+                document["events"] = []
+                document["coreferences"] = []
+                yield document
+
+    def _generate_examples(self, filepath):
+        """Yields examples as (key, example) tuples."""
+        if self.config.schema == "source":
+            for source_example in self.pubtator_to_source(filepath):
+                yield source_example["pmid"], source_example
+        elif self.config.schema == "bigbio_kb":
+            for bigbio_example in self.pubtator_to_bigbio_kb(filepath):
+                yield bigbio_example["document_id"], bigbio_example

--- a/hub/hubscripts/twadrl_hub.py
+++ b/hub/hubscripts/twadrl_hub.py
@@ -1,0 +1,167 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import glob
+import os
+import re
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_DATASETNAME = "twadrl"
+_DISPLAYNAME = "TwADR-L"
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """
+@inproceedings{limsopatham-collier-2016-normalising,
+    title = "Normalising Medical Concepts in Social Media Texts by Learning Semantic Representation",
+    author = "Limsopatham, Nut  and
+      Collier, Nigel",
+    booktitle = "Proceedings of the 54th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
+    month = aug,
+    year = "2016",
+    address = "Berlin, Germany",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/P16-1096",
+    doi = "10.18653/v1/P16-1096",
+    pages = "1014--1023",
+}
+"""
+
+_DESCRIPTION = """
+The TwADR-L dataset contains medical concepts written on social media (Twitter) \
+mapped to how they are formally written in medical ontologies (SIDER 4). \
+"""
+
+_HOMEPAGE = "https://zenodo.org/record/55013"
+
+_LICENSE = 'Creative Commons Attribution 4.0 International'
+
+_URLs = "https://zenodo.org/record/55013/files/datasets.zip"
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION]
+_SOURCE_VERSION = "1.0.0"
+_BIGBIO_VERSION = "1.0.0"
+
+
+class TwADRL(datasets.GeneratorBasedBuilder):
+    """TwADR-L: Dataset for Normalising Medical Concepts on Twitter."""
+
+    DEFAULT_CONFIG_NAME = "twadrl_source"
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="twadrl_source",
+            version=SOURCE_VERSION,
+            description="TwADR-L source schema",
+            schema="source",
+            subset_id="twadrl",
+        ),
+        BigBioConfig(
+            name="twadrl_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="TwADR-L simplified BigBio schema",
+            schema="bigbio_kb",
+            subset_id="twadrl",
+        ),
+    ]
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "cui": datasets.Value("string"),
+                    "medical_concept": datasets.Value("string"),
+                    "social_media_text": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            supervised_keys=None,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        dl_dir = dl_manager.download_and_extract(_URLs)
+        dataset_dir = os.path.join(dl_dir, "datasets", "TwADR-L")
+        # dataset supports k-folds
+        splits = []
+        for split_name in [
+            datasets.Split.TRAIN,
+            datasets.Split.VALIDATION,
+            datasets.Split.TEST,
+        ]:
+            for fold_filepath in glob.glob(
+                os.path.join(dataset_dir, f"TwADR-L.fold-*.{split_name}.txt")
+            ):
+                fold_id = re.search("TwADR-L\.fold-(\d)\.", fold_filepath).group(1)
+                split_id = f"{split_name}_{fold_id}"
+                splits.append(
+                    datasets.SplitGenerator(
+                        name=split_id,
+                        gen_kwargs={"filepath": fold_filepath, "split_id": split_id},
+                    )
+                )
+        return splits
+
+    def _generate_examples(self, filepath, split_id):
+        with open(filepath, "r", encoding="latin-1") as f:
+            for i, line in enumerate(f):
+                id = f"{split_id}_{i}"
+                cui, medical_concept, social_media_text = line.strip().split("\t")
+                if self.config.schema == "source":
+                    yield id, {
+                        "cui": cui,
+                        "medical_concept": medical_concept,
+                        "social_media_text": social_media_text,
+                    }
+                elif self.config.schema == "bigbio_kb":
+                    text_type = "social_media_text"
+                    offset = (0, len(social_media_text))
+                    yield id, {
+                        "id": id,
+                        "document_id": id,
+                        "passages": [
+                            {
+                                "id": f"{id}_passage",
+                                "type": text_type,
+                                "text": [social_media_text],
+                                "offsets": [offset],
+                            }
+                        ],
+                        "entities": [
+                            {
+                                "id": f"{id}_entity",
+                                "type": text_type,
+                                "text": [social_media_text],
+                                "offsets": [offset],
+                                "normalized": [{"db_name": "SIDER 4", "db_id": cui}],
+                            }
+                        ],
+                        "events": [],
+                        "coreferences": [],
+                        "relations": [],
+                    }

--- a/hub/hubscripts/umnsrs_hub.py
+++ b/hub/hubscripts/umnsrs_hub.py
@@ -1,0 +1,186 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+UMNSRS, developed by Pakhomov, et al., consists of 725 clinical term pairs whose semantic similarity and relatedness.
+The similarity and relatedness of each term pair was annotated based on a continuous scale by having the resident touch
+a bar on a touch sensitive computer screen to indicate the degree of similarity or relatedness. The Intraclass
+Correlation Coefficient (ICC) for the reference standard tagged for similarity was 0.47, and 0.50 for relatedness.
+Therefore, as suggested by Pakhomov and colleagues, the subset below consists of 401 pairs for the similarity set and
+430 pairs for the relatedness set which each have an ICC equal to 0.73.
+"""
+
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import pairs_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@inproceedings{pakhomov2010semantic,
+  title={Semantic similarity and relatedness between clinical terms: an experimental study},
+  author={Pakhomov, Serguei and McInnes, Bridget and Adam, Terrence and Liu, Ying and Pedersen, Ted and Melton, \
+  Genevieve B},
+  booktitle={AMIA annual symposium proceedings},
+  volume={2010},
+  pages={572},
+  year={2010},
+  organization={American Medical Informatics Association}
+}
+"""
+
+_DATASETNAME = "umnsrs"
+_DISPLAYNAME = "UMNSRS"
+
+_DESCRIPTION = """\
+UMNSRS, developed by Pakhomov, et al., consists of 725 clinical term pairs whose semantic similarity and relatedness.
+The similarity and relatedness of each term pair was annotated based on a continuous scale by having the resident touch
+a bar on a touch sensitive computer screen to indicate the degree of similarity or relatedness.
+The following subsets are available:
+- similarity: A set of 566 UMLS concept pairs manually rated for semantic similarity (e.g. whale-dolphin) using a
+  continuous response scale.
+- relatedness: A set of 588 UMLS concept pairs manually rated for semantic relatedness (e.g. needle-thread) using a
+  continuous response scale.
+- similarity_mod: Modification of the UMNSRS-Similarity dataset to exclude control samples and those pairs that did not
+  match text in clinical, biomedical and general English corpora. Exact modifications are detailed in the paper (Corpus
+  Domain Effects on Distributional Semantic Modeling of Medical Terms. Serguei V.S. Pakhomov, Greg Finley, Reed McEwan,
+  Yan Wang, and Genevieve B. Melton. Bioinformatics. 2016; 32(23):3635-3644). The resulting dataset contains 449 pairs.
+- relatedness_mod: Modification of the UMNSRS-Relatedness dataset to exclude control samples and those pairs that did
+  not match text in clinical, biomedical and general English corpora. Exact modifications are detailed in the paper
+  (Corpus Domain Effects on Distributional Semantic Modeling of Medical Terms. Serguei V.S. Pakhomov, Greg Finley,
+  Reed McEwan, Yan Wang, and Genevieve B. Melton. Bioinformatics. 2016; 32(23):3635-3644).
+  The resulting dataset contains 458 pairs.
+"""
+
+_HOMEPAGE = "https://conservancy.umn.edu/handle/11299/196265/"
+
+_LICENSE = 'Creative Commons Zero v1.0 Universal'
+
+_BASE_URL = "https://conservancy.umn.edu/bitstream/handle/11299/196265/"
+
+_URLS = {
+    "umnsrs_similarity": _BASE_URL + "UMNSRS_similarity.csv",
+    "umnsrs_relatedness": _BASE_URL + "UMNSRS_relatedness.csv",
+    "umnsrs_similarity_mod": _BASE_URL + "UMNSRS_similarity_mod449_word2vec.csv",
+    "umnsrs_relatedness_mod": _BASE_URL + "UMNSRS_relatedness_mod458_word2vec.csv",
+}
+
+_SUPPORTED_TASKS = [Tasks.SEMANTIC_SIMILARITY]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class UmnsrsDataset(datasets.GeneratorBasedBuilder):
+    """UMNSRS, developed by Pakhomov, et al., contains clinical term pairs whose semantic similarity and
+    relatedness were scored by experts."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = []
+
+    for subset in ["similarity", "relatedness"]:
+        for mod in ["_mod", ""]:
+            BUILDER_CONFIGS.append(
+                BigBioConfig(
+                    name=f"umnsrs_{subset}{mod}_source",
+                    version=SOURCE_VERSION,
+                    description=f"UMNSRS {subset}{mod} source schema",
+                    schema="source",
+                    subset_id=f"umnsrs_{subset}{mod}",
+                )
+            )
+            BUILDER_CONFIGS.append(
+                BigBioConfig(
+                    name=f"umnsrs_{subset}{mod}_bigbio_pairs",
+                    version=BIGBIO_VERSION,
+                    description=f"UMNSRS {subset}{mod} BigBio schema",
+                    schema="bigbio_pairs",
+                    subset_id=f"umnsrs_{subset}{mod}",
+                )
+            )
+
+    DEFAULT_CONFIG_NAME = "umnsrs_similarity_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "mean_score": datasets.Value("float32"),
+                    "std_score": datasets.Value("float32"),
+                    "text_1": datasets.Value("string"),
+                    "text_2": datasets.Value("string"),
+                    "code_1": datasets.Value("string"),
+                    "code_2": datasets.Value("string"),
+                }
+            )
+
+        elif self.config.schema == "bigbio_pairs":
+            features = pairs_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[self.config.subset_id]
+        filepath = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": filepath,
+                },
+            )
+        ]
+
+    def _generate_examples(self, filepath) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        print(filepath)
+        data = pd.read_csv(
+            filepath,
+            sep=",",
+            header=0,
+            names=["mean_score", "std_score", "text_1", "text_2", "code_1", "code_2"],
+        )
+
+        if self.config.schema == "source":
+            for id_, row in data.iterrows():
+                yield id_, row.to_dict()
+        elif self.config.schema == "bigbio_pairs":
+            for id_, row in data.iterrows():
+                yield id_, {
+                    "id": id_,
+                    "document_id": id_,
+                    "text_1": row["text_1"],
+                    "text_2": row["text_2"],
+                    "label": row["mean_score"],
+                }

--- a/hub/hubscripts/verspoor_2013_hub.py
+++ b/hub/hubscripts/verspoor_2013_hub.py
@@ -1,0 +1,266 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This dataset contains annotations for a small corpus of full text journal
+publications on the subject of inherited colorectal cancer. It is suitable for
+Named Entity Recognition and Relation Extraction tasks. It uses the Variome
+Annotation Schema,  a schema that aims to capture the core concepts and
+relations relevant to cataloguing  and interpreting human genetic variation and
+its relationship to disease, as described in the published literature. The
+schema was inspired by the needs of the database curators of the International
+Society for Gastrointestinal Hereditary Tumours (InSiGHT) database, but is
+intended to have application to genetic variation information in a range of
+diseases.
+"""
+
+from pathlib import Path
+from shutil import rmtree
+from typing import Dict, List, Tuple
+
+import datasets
+
+from .bigbiohub import kb_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+_LANGUAGES = ['English']
+_PUBMED = True
+_LOCAL = False
+_CITATION = """\
+@article{verspoor2013annotating,
+  title        = {Annotating the biomedical literature for the human variome},
+  author       = {
+    Verspoor, Karin and Jimeno Yepes, Antonio and Cavedon, Lawrence and
+    McIntosh, Tara and Herten-Crabb, Asha and Thomas, Zo{"e} and Plazzer,
+    John-Paul
+  },
+  year         = 2013,
+  journal      = {Database},
+  publisher    = {Oxford Academic},
+  volume       = 2013
+}
+"""
+
+_DATASETNAME = "verspoor_2013"
+_DISPLAYNAME = "Verspoor 2013"
+
+_DESCRIPTION = """\
+This dataset contains annotations for a small corpus of full text journal \
+publications on the subject of inherited colorectal cancer. It is suitable for \
+Named Entity Recognition and Relation Extraction tasks. It uses the Variome \
+Annotation Schema,  a schema that aims to capture the core concepts and \
+relations relevant to cataloguing  and interpreting human genetic variation and \
+its relationship to disease, as described in the published literature. The \
+schema was inspired by the needs of the database curators of the International \
+Society for Gastrointestinal Hereditary Tumours (InSiGHT) database, but is \
+intended to have application to genetic variation information in a range of \
+diseases.
+"""
+
+
+_HOMEPAGE = "NA"
+
+_LICENSE = 'License information unavailable'
+
+_URLS = ["http://github.com/rockt/SETH/zipball/master/"]
+
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.RELATION_EXTRACTION,
+]
+
+_SOURCE_VERSION = "1.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class Verspoor2013Dataset(datasets.GeneratorBasedBuilder):
+    """\
+    This dataset contains annotations for a small corpus of full text journal publications
+    on the subject of inherited colorectal cancer. It is suitable for Named Entity Recognition and
+    Relation Extraction tasks. It uses the Variome Annotation Schema,  a schema that aims to
+    capture the core concepts and relations relevant to cataloguing  and interpreting human
+    genetic variation and its relationship to disease, as described in the published literature.
+    The schema was inspired by the needs of the database curators of the International Society
+    for Gastrointestinal Hereditary Tumours (InSiGHT) database, but is intended to have
+    application to genetic variation information in a range of diseases.
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="verspoor_2013_source",
+            version=SOURCE_VERSION,
+            description="verspoor_2013 source schema",
+            schema="source",
+            subset_id="verspoor_2013",
+        ),
+        BigBioConfig(
+            name="verspoor_2013_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="verspoor_2013 BigBio schema",
+            schema="bigbio_kb",
+            subset_id="verspoor_2013",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "verspoor_2013_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "events": [  # E line in brat
+                        {
+                            "trigger": datasets.Value(
+                                "string"
+                            ),  # refers to the text_bound_annotation of the trigger,
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "arguments": datasets.Sequence(
+                                {
+                                    "role": datasets.Value("string"),
+                                    "ref_id": datasets.Value("string"),
+                                }
+                            ),
+                        }
+                    ],
+                    "relations": [  # R line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "head": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "tail": {
+                                "ref_id": datasets.Value("string"),
+                                "role": datasets.Value("string"),
+                            },
+                            "type": datasets.Value("string"),
+                        }
+                    ],
+                    "equivalences": [  # Equiv line in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "ref_ids": datasets.Sequence(datasets.Value("string")),
+                        }
+                    ],
+                    "attributes": [  # M or A lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "value": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value(
+                                "string"
+                            ),  # Name of the resource, e.g. "Wikipedia"
+                            "cuid": datasets.Value(
+                                "string"
+                            ),  # ID in the resource, e.g. 534366
+                            "text": datasets.Value(
+                                "string"
+                            ),  # Human readable description/name of the entity, e.g. "Barack Obama"
+                        }
+                    ],
+                },
+            )
+
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        # Download gets entire git repo containing unused data from other datasets
+        repo_dir = Path(dl_manager.download_and_extract(_URLS[0]))
+        data_dir = repo_dir / "data"
+        data_dir.mkdir(exist_ok=True)
+
+        # Find the relevant files from Verspor2013 and move them to a new directory
+        verspoor_files = repo_dir.glob("*/*/*Verspoor2013/**/*")
+        for file in verspoor_files:
+            if file.is_file() and "readme" not in str(file):
+                file.rename(data_dir / file.name)
+
+        # Delete all unused files and directories from the original download
+        for x in repo_dir.glob("[!data]*"):
+            if x.is_file():
+                x.unlink()
+            elif x.is_dir():
+                rmtree(x)
+
+        data_files = {"text_files": list(data_dir.glob("*.txt"))}
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "data_files": data_files,
+                    "split": "train",
+                },
+            )
+        ]
+
+    def _generate_examples(self, data_files, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+
+        if self.config.schema == "source":
+            txt_files = data_files["text_files"]
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.parse_brat_file(txt_file)
+                example["id"] = str(guid)
+                yield guid, example
+
+        elif self.config.schema == "bigbio_kb":
+            txt_files = data_files["text_files"]
+            for guid, txt_file in enumerate(txt_files):
+                example = parsing.brat_parse_to_bigbio_kb(
+                    parsing.parse_brat_file(txt_file)
+                )
+                example["id"] = str(guid)
+                yield guid, example
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/hub/make_hub_script.py
+++ b/hub/make_hub_script.py
@@ -47,7 +47,7 @@ def fix_script(script: List[str]) -> List[str]:
         if "bigbio.utils" in line:
             start_idx.append(idx)
         elif "_LANGUAGES" in line:
-            new_lines.append("_LANGUAGES = ['" + language + "']\n")
+            new_lines.append("_LANGUAGES = [" + language + "]\n")
 
         # NOTE: this might fail if _LICENSE is used without spacing... so i checked
         # with also the Licenses. call
@@ -101,9 +101,14 @@ def get_language(lines: List[str]) -> str:
     if len(language) != 1:
         raise ValueError("Language not found")
     else:
-        language = lang_dict[language[0].split("Lang.")[1]]
+        language = language[0].split(",")
+        language = [lang_dict[i.split("Lang.")[1]] for i in language]
+        language = ["'" + str(i) + "'" for i in language]
 
-    return language
+        if len(language) == 1:
+            return language[0]
+        else:
+            return ", ".join(language)
 
 
 if __name__ == "__main__":

--- a/hub/make_hub_script.py
+++ b/hub/make_hub_script.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+
+"""
+Script to automate hub migration.
+Assumes `bigbiohub.py` script is present
+"""
+import argparse
+from bigbio.utils.constants import Lang
+from bigbio.utils.license import Licenses
+
+from typing import List
+
+lang_dict = {
+    key: getattr(Lang, key).value for key in dir(Lang) if "__" not in key
+}
+
+license_dict = {
+    key: getattr(Licenses, key).name
+    for key in dir(Licenses)
+    if "__" not in key
+}
+
+
+def fix_script(script: List[str]) -> List[str]:
+    """Converts all bigbio references to the bigbio hub
+    references
+    """
+    # Get task type
+    ft_type = get_task_features(script)
+
+    # Get license line
+    license = get_license(script)
+
+    # Get Language
+    language = get_language(script)
+
+    bblines = [
+        "from .bigbiohub import " + ft_type + "\n",
+        "from .bigbiohub import BigBioConfig\n"
+        "from .bigbiohub import Tasks\n",
+    ]
+
+    # Make changes within the lines
+    new_lines = []
+    start_idx = []
+    for idx, line in enumerate(script):
+        if "bigbio.utils" in line:
+            start_idx.append(idx)
+        elif "_LANGUAGES" in line:
+            new_lines.append("_LANGUAGES = ['" + language + "']\n")
+
+        # NOTE: this might fail if _LICENSE is used without spacing... so i checked
+        # with also the Licenses. call
+
+        elif ("_LICENSE" in line) and ("Licenses." in line):
+            new_lines.append("_LICENSE = '" + license + "'\n")
+        elif "features = schemas." in line:
+            new_lines.append(line.replace("schemas.", ""))
+        else:
+            new_lines.append(line)
+
+    new_lines = (
+        new_lines[: start_idx[0]] + bblines + new_lines[start_idx[0] :]
+    )
+
+    return new_lines
+
+
+def get_task_features(lines: List[str]) -> str:
+    """Get the feature type for schema"""
+    ft_type = [i.split("schemas.")[1] for i in lines if "schemas." in i]
+    if len(ft_type) < 1:
+        raise ValueError("Schema feature not identified")
+    else:
+        ft_type = ft_type[0].replace("\n", "")
+
+    return ft_type
+
+
+def get_license(lines: List[str]) -> str:
+    """Get the license information"""
+    license = [
+        i.split("Licenses.")[1].replace("\n", "")
+        for i in lines
+        if "_LICENSE = " in i
+    ]
+
+    if len(license) != 1:
+        raise ValueError("License not found")
+    else:
+        license = license_dict[license[0]]
+
+    return license
+
+
+def get_language(lines: List[str]) -> str:
+    """Get the language information"""
+    language = [
+        i.split("[")[1].split("]")[0] for i in lines if "_LANGUAGES" in i
+    ]
+    if len(language) != 1:
+        raise ValueError("Language not found")
+    else:
+        language = lang_dict[language[0].split("Lang.")[1]]
+
+    return language
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--script", help="path to dataloading script", required=True
+    )
+    parser.add_argument(
+        "--savename",
+        help="path to dataloading script",
+    )
+
+    args = parser.parse_args()
+
+    if args.savename is None:
+        args.savename = (
+            args.script.split(".py")[0].split("/")[-1] + "_hub.py"
+        )
+
+    with open(args.script, "r") as f:
+        scriptlines = f.readlines()
+
+    newlines = fix_script(scriptlines)
+
+    with open(args.savename, "w") as f:
+        f.writelines(newlines)

--- a/hub/manual_list.txt
+++ b/hub/manual_list.txt
@@ -1,0 +1,18 @@
+2022.10.20
+
+These are the scripts that need to be manually looked into to convert;
+they seem to fail because of usually license/language but otherwise only blurb fails to schema (And this is a multi-subset so we know it will)
+
+- blurb (schema)
+- cadec (License)
+- codiesp (license)
+- mantra_gsc (language)
+- mutation_finder (license)
+- n2c2_2014_risk_factors (license)
+- nagel (license)
+- pho_ner (license)
+- thomas2011 (license)
+
+The language failures originally were due to multi-language datasets. I have fixed this. Mantra_GSC has a couple of extra uses of _LANGUAGES that make it tricky. It is worth doing this by hand.
+
+The licenses are also simple - they are issues with custom license often taking more than one line. Worth doing the few by hand.


### PR DESCRIPTION
I propose the following script that allows biomedical scripts to be converted for hubuse.

The main points to be replaced are:
- the feature types (schemas.<features>)
- the language types need to be hard-encoded
- the license needs to be hard encoded
- all references to bigbio.utils need to be removed
The following (messy) script does by examining each line in the script - no guarantees for efficiency or prettyness, but it does work.

An example using scitail is here: https://huggingface.co/datasets/bigscience-biomedical/testing/tree/main

This will fail for something like blurb, since no schemas.<features> are used. 

Usage is as such:

```python
python make_hub_script.py --script <path_to_your_script> --savename <name_of_your_savefile.py>
```
ex:
```python
python make_hub_script.py --script bigbio/biodatasets/scitail/scitail.py --savename testing.py
```