### PR TITLE
Fix Hub preview error: ModuleNotFoundError: No module named 'bioc'

### DIFF
--- a/hub/bigbiohub.py
+++ b/hub/bigbiohub.py
@@ -4,11 +4,12 @@ from enum import Enum
 import logging
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Dict, Iterable, List, Tuple
+from typing import TYPE_CHECKING, Dict, Iterable, List, Tuple
 
-import bioc
 import datasets
 
+if TYPE_CHECKING:
+    import bioc
 
 logger = logging.getLogger(__name__)
 
@@ -162,7 +163,7 @@ kb_features = datasets.Features(
 )
 
 
-def get_texts_and_offsets_from_bioc_ann(ann: bioc.BioCAnnotation) -> Tuple:
+def get_texts_and_offsets_from_bioc_ann(ann: "bioc.BioCAnnotation") -> Tuple:
 
     offsets = [(loc.offset, loc.offset + loc.length) for loc in ann.locations]
 


### PR DESCRIPTION
Note that the library `bioc` is only used in `bigbiohub.py` to make a type hint annotation:
```python
def get_texts_and_offsets_from_bioc_ann(ann: bioc.BioCAnnotation):
```

In this case, the error can be fixed by:
- importing `bioc` only when used by static type checkers
- making the annotation a forward reference (encoded as a string literal) to hide it from regular runtime


Fix #751.
