### PR TITLE
Optimize parse_brat_file to make fewer filesystem calls

### DIFF
--- a/hub/bigbiohub.py
+++ b/hub/bigbiohub.py
@@ -307,7 +307,7 @@ def parse_brat_file(
         try:
             with annotation_file.open() as f:
                 ann_lines.extend(f.readlines())
-        except FileNotFoundError:
+        except Exception:
             continue
 
     example["text_bound_annotations"] = []

--- a/hub/bigbiohub.py
+++ b/hub/bigbiohub.py
@@ -304,9 +304,11 @@ def parse_brat_file(
     ann_lines = []
     for suffix in annotation_file_suffixes:
         annotation_file = txt_file.with_suffix(suffix)
-        if annotation_file.exists():
+        try:
             with annotation_file.open() as f:
                 ann_lines.extend(f.readlines())
+        except FileNotFoundError:
+            continue
 
     example["text_bound_annotations"] = []
     example["events"] = []


### PR DESCRIPTION
This PR optimizes the function `parse_brat_file` by applying the ["Easier to ask for forgiveness than permission"](https://docs.python.org/3/glossary.html#term-EAFP) principle.

With this PR, for each annotation file, it will call the underlying filesystem only once (`f.open()`) instead of 2 (`f.exists()` and `f.open()`. Please note that the underlying filesystem can be either local or remote (when streaming). And remote filesystem calls have an expensive cost (network HTTP request).

If the dataset loading script has to parse 500 annotation files, with this PR it will make 500 fewer calls.

This PR also partially fixes the issue in streaming mode with all datasets that use `parse_brat_file`.
