### PR TITLE
Revise implementation of BioRed corpus

### DIFF
--- a/bigbio/biodatasets/biored/biored.py
+++ b/bigbio/biodatasets/biored/biored.py
@@ -21,6 +21,7 @@ on a set of 600 PubMed articles
 
 import itertools
 import os
+from collections import defaultdict
 from typing import Dict, List, Tuple
 
 import datasets
@@ -72,7 +73,7 @@ _URLS = {
     _DATASETNAME: "https://ftp.ncbi.nlm.nih.gov/pub/lu/BioRED/BIORED.zip",
 }
 
-_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION, Tasks.RELATION_EXTRACTION]
 
 _SOURCE_VERSION = "1.0.0"
 
@@ -82,7 +83,8 @@ logger = datasets.utils.logging.get_logger(__name__)
 
 
 class BioredDataset(datasets.GeneratorBasedBuilder):
-    """Relation Extraction corpus with multiple entity types (e.g., gene/protein, disease, chemical) and relation pairs (e.g., gene-disease; chemical-chemical), on a set of 600 PubMed articles"""
+    """Relation Extraction corpus with multiple entity types (e.g., gene/protein, disease, chemical) and
+    relation pairs (e.g., gene-disease; chemical-chemical), on a set of 600 PubMed articles"""
 
     # For bigbio_kb, this dataset uses a naming convention as
     # uid_[title/abstract/relation/entity_id]_[entity/relation_uid]
@@ -109,6 +111,15 @@ class BioredDataset(datasets.GeneratorBasedBuilder):
 
     DEFAULT_CONFIG_NAME = _DATASETNAME + "_source"
 
+    TYPE_TO_DATABASE = {
+        "CellLine": "Cellosaurus",
+        "ChemicalEntity": "Medical Subject Headings (MESH)",
+        "DiseaseOrPhenotypicFeature": "Medical Subject Headings (MESH) / Online Mendelian Inheritance in Man (OMIM)",
+        "GeneOrGeneProduct": "NCBI Gene",
+        "OrganismTaxon": "NCBI Taxonomy",
+        "SequenceVariant": "dbSNP / custom",
+    }
+
     def _info(self) -> datasets.DatasetInfo:
 
         if self.config.schema == "source":
@@ -128,9 +139,7 @@ class BioredDataset(datasets.GeneratorBasedBuilder):
                             "text": datasets.Sequence(datasets.Value("string")),
                             "offsets": datasets.Sequence([datasets.Value("int32")]),
                             "concept_id": datasets.Value("string"),
-                            "semantic_type_id": datasets.Sequence(
-                                datasets.Value("string")
-                            ),
+                            "semantic_type_id": datasets.Value("string"),
                         }
                     ],
                     "relations": [
@@ -199,51 +208,66 @@ class BioredDataset(datasets.GeneratorBasedBuilder):
             with open(filepath, "r", encoding="utf8") as fstream:
                 uid = itertools.count(0)
                 for raw_document in self.generate_raw_docs(fstream):
-                    entities_in_doc = dict()
                     document = self.parse_raw_doc(raw_document)
-                    pmid = document.pop("pmid")
+                    pmid = str(document.pop("pmid"))
                     document["id"] = str(next(uid))
                     document["document_id"] = pmid
-                    entities_ = []
-                    relations_ = []
-                    for entity in document["entities"]:
-                        temp_id = document["id"] + "_" + str(entity["concept_id"])
-                        curr_entity_count = entities_in_doc.get(temp_id, 0)
-                        entities_.append(
+
+                    # Parse entities
+                    entities = []
+                    entity_id_to_mentions = defaultdict(list)  # Maps database ids to mention ids
+                    for i, entity in enumerate(document["entities"]):
+                        internal_id = pmid + "_" + str(i)
+
+                        entity_type = entity["semantic_type_id"]
+                        db_name = self.TYPE_TO_DATABASE[entity_type]
+
+                        # Some entities are normalized to multiple database ids, therefore we
+                        # may have multiple identifiers per mention
+                        normalized_entity_ids = []
+                        for database_id in entity["concept_id"].split(","):
+                            normalized_entity_ids.append({"db_name": db_name, "db_id": database_id})
+                            entity_id_to_mentions[database_id].append(internal_id)
+
+                        entities.append(
                             {
-                                "id": temp_id + "_" + str(curr_entity_count),
-                                "type": entity["semantic_type_id"],
+                                "id": internal_id,
+                                "type": entity_type,
                                 "text": entity["text"],
-                                "normalized": [],
+                                "normalized": normalized_entity_ids,
                                 "offsets": entity["offsets"],
                             }
                         )
-                        entities_in_doc[temp_id] = curr_entity_count + 1
+
+                    # BioRed provides abstract-level annotations for entity-linked relation pairs rather than
+                    # materializing links between all surface form mentions of relation. For example document 11009181
+                    # in train has (Positive_Correlation, D007980, D004409). Analogous to BC5CDR we enumerate all
+                    # mention pairs concerning the entities in the triple.
+                    relations = []
                     rel_uid = itertools.count(0)
                     for relation in document["relations"]:
-                        relations_.append(
-                            {
-                                "id": document["id"]
-                                + "_relation_"
-                                + str(next(rel_uid)),
-                                "type": relation["type"],
-                                "arg1_id": document["id"]
-                                + "_"
-                                + str(relation["concept_1"])
-                                + "_0",
-                                "arg2_id": document["id"]
-                                + "_"
-                                + str(relation["concept_2"])
-                                + "_0",
-                                "normalized": [],
-                            }
-                        )
+                        head_mentions = entity_id_to_mentions[str(relation["concept_1"])]
+                        tail_mentions = entity_id_to_mentions[str(relation["concept_2"])]
+
+                        for head, tail in itertools.product(head_mentions, tail_mentions):
+                            relations.append(
+                                {
+                                    "id": document["id"] + "_relation_" + str(next(rel_uid)),
+                                    "type": relation["type"],
+                                    "arg1_id": head,
+                                    "arg2_id": tail,
+                                    "normalized": [],
+                                }
+                            )
+
                     for passage in document["passages"]:
                         passage["id"] = document["id"] + "_" + passage["type"]
-                    document["entities"] = entities_
-                    document["relations"] = relations_
+
+                    document["entities"] = entities
+                    document["relations"] = relations
                     document["events"] = []
                     document["coreferences"] = []
+
                     yield document["document_id"], document
 
     def generate_raw_docs(self, fstream):
@@ -302,20 +326,16 @@ class BioredDataset(datasets.GeneratorBasedBuilder):
                 # Entities handled here
                 start_idx = _type_ind
                 end_idx, mention, semantic_type_id, entity_ids = rest
-                entity = [
+                entities.append(
                     {
                         "offsets": [[int(start_idx), int(end_idx)]],
                         "text": [mention],
-                        "semantic_type_id": semantic_type_id.split(","),
-                        "concept_id": entity_id,
+                        "semantic_type_id": semantic_type_id,
+                        "concept_id": entity_ids,
                     }
-                    for entity_id in entity_ids.split(",")
-                ]
-                entities.extend(entity)
-            else:
-                logger.warn(
-                    f"Skipping annotation in Document ID: {_pmid}. Unexpected format"
                 )
+            else:
+                logger.warn(f"Skipping annotation in Document ID: {_pmid}. Unexpected format")
         return {
             "pmid": pmid,
             "passages": passages,

--- a/hub/hubscripts/biored_hub.py
+++ b/hub/hubscripts/biored_hub.py
@@ -21,6 +21,7 @@ on a set of 600 PubMed articles
 
 import itertools
 import os
+from collections import defaultdict
 from typing import Dict, List, Tuple
 
 import datasets
@@ -71,7 +72,7 @@ _URLS = {
     _DATASETNAME: "https://ftp.ncbi.nlm.nih.gov/pub/lu/BioRED/BIORED.zip",
 }
 
-_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.NAMED_ENTITY_DISAMBIGUATION, Tasks.RELATION_EXTRACTION]
 
 _SOURCE_VERSION = "1.0.0"
 
@@ -81,7 +82,8 @@ logger = datasets.utils.logging.get_logger(__name__)
 
 
 class BioredDataset(datasets.GeneratorBasedBuilder):
-    """Relation Extraction corpus with multiple entity types (e.g., gene/protein, disease, chemical) and relation pairs (e.g., gene-disease; chemical-chemical), on a set of 600 PubMed articles"""
+    """Relation Extraction corpus with multiple entity types (e.g., gene/protein, disease, chemical) and
+    relation pairs (e.g., gene-disease; chemical-chemical), on a set of 600 PubMed articles"""
 
     # For bigbio_kb, this dataset uses a naming convention as
     # uid_[title/abstract/relation/entity_id]_[entity/relation_uid]
@@ -108,6 +110,15 @@ class BioredDataset(datasets.GeneratorBasedBuilder):
 
     DEFAULT_CONFIG_NAME = _DATASETNAME + "_source"
 
+    TYPE_TO_DATABASE = {
+        "CellLine": "Cellosaurus",
+        "ChemicalEntity": "Medical Subject Headings (MESH)",
+        "DiseaseOrPhenotypicFeature": "Medical Subject Headings (MESH) / Online Mendelian Inheritance in Man (OMIM)",
+        "GeneOrGeneProduct": "NCBI Gene",
+        "OrganismTaxon": "NCBI Taxonomy",
+        "SequenceVariant": "dbSNP / custom",
+    }
+
     def _info(self) -> datasets.DatasetInfo:
 
         if self.config.schema == "source":
@@ -127,9 +138,7 @@ class BioredDataset(datasets.GeneratorBasedBuilder):
                             "text": datasets.Sequence(datasets.Value("string")),
                             "offsets": datasets.Sequence([datasets.Value("int32")]),
                             "concept_id": datasets.Value("string"),
-                            "semantic_type_id": datasets.Sequence(
-                                datasets.Value("string")
-                            ),
+                            "semantic_type_id": datasets.Value("string"),
                         }
                     ],
                     "relations": [
@@ -198,51 +207,66 @@ class BioredDataset(datasets.GeneratorBasedBuilder):
             with open(filepath, "r", encoding="utf8") as fstream:
                 uid = itertools.count(0)
                 for raw_document in self.generate_raw_docs(fstream):
-                    entities_in_doc = dict()
                     document = self.parse_raw_doc(raw_document)
-                    pmid = document.pop("pmid")
+                    pmid = str(document.pop("pmid"))
                     document["id"] = str(next(uid))
                     document["document_id"] = pmid
-                    entities_ = []
-                    relations_ = []
-                    for entity in document["entities"]:
-                        temp_id = document["id"] + "_" + str(entity["concept_id"])
-                        curr_entity_count = entities_in_doc.get(temp_id, 0)
-                        entities_.append(
+
+                    # Parse entities
+                    entities = []
+                    entity_id_to_mentions = defaultdict(list)  # Maps database ids to mention ids
+                    for i, entity in enumerate(document["entities"]):
+                        internal_id = pmid + "_" + str(i)
+
+                        entity_type = entity["semantic_type_id"]
+                        db_name = self.TYPE_TO_DATABASE[entity_type]
+
+                        # Some entities are normalized to multiple database ids, therefore we
+                        # may have multiple identifiers per mention
+                        normalized_entity_ids = []
+                        for database_id in entity["concept_id"].split(","):
+                            normalized_entity_ids.append({"db_name": db_name, "db_id": database_id})
+                            entity_id_to_mentions[database_id].append(internal_id)
+
+                        entities.append(
                             {
-                                "id": temp_id + "_" + str(curr_entity_count),
-                                "type": entity["semantic_type_id"],
+                                "id": internal_id,
+                                "type": entity_type,
                                 "text": entity["text"],
-                                "normalized": [],
+                                "normalized": normalized_entity_ids,
                                 "offsets": entity["offsets"],
                             }
                         )
-                        entities_in_doc[temp_id] = curr_entity_count + 1
+
+                    # BioRed provides abstract-level annotations for entity-linked relation pairs rather than
+                    # materializing links between all surface form mentions of relation. For example document 11009181
+                    # in train has (Positive_Correlation, D007980, D004409). Analogous to BC5CDR we enumerate all
+                    # mention pairs concerning the entities in the triple.
+                    relations = []
                     rel_uid = itertools.count(0)
                     for relation in document["relations"]:
-                        relations_.append(
-                            {
-                                "id": document["id"]
-                                + "_relation_"
-                                + str(next(rel_uid)),
-                                "type": relation["type"],
-                                "arg1_id": document["id"]
-                                + "_"
-                                + str(relation["concept_1"])
-                                + "_0",
-                                "arg2_id": document["id"]
-                                + "_"
-                                + str(relation["concept_2"])
-                                + "_0",
-                                "normalized": [],
-                            }
-                        )
+                        head_mentions = entity_id_to_mentions[str(relation["concept_1"])]
+                        tail_mentions = entity_id_to_mentions[str(relation["concept_2"])]
+
+                        for head, tail in itertools.product(head_mentions, tail_mentions):
+                            relations.append(
+                                {
+                                    "id": document["id"] + "_relation_" + str(next(rel_uid)),
+                                    "type": relation["type"],
+                                    "arg1_id": head,
+                                    "arg2_id": tail,
+                                    "normalized": [],
+                                }
+                            )
+
                     for passage in document["passages"]:
                         passage["id"] = document["id"] + "_" + passage["type"]
-                    document["entities"] = entities_
-                    document["relations"] = relations_
+
+                    document["entities"] = entities
+                    document["relations"] = relations
                     document["events"] = []
                     document["coreferences"] = []
+
                     yield document["document_id"], document
 
     def generate_raw_docs(self, fstream):
@@ -301,20 +325,16 @@ class BioredDataset(datasets.GeneratorBasedBuilder):
                 # Entities handled here
                 start_idx = _type_ind
                 end_idx, mention, semantic_type_id, entity_ids = rest
-                entity = [
+                entities.append(
                     {
                         "offsets": [[int(start_idx), int(end_idx)]],
                         "text": [mention],
-                        "semantic_type_id": semantic_type_id.split(","),
-                        "concept_id": entity_id,
+                        "semantic_type_id": semantic_type_id,
+                        "concept_id": entity_ids,
                     }
-                    for entity_id in entity_ids.split(",")
-                ]
-                entities.extend(entity)
-            else:
-                logger.warn(
-                    f"Skipping annotation in Document ID: {_pmid}. Unexpected format"
                 )
+            else:
+                logger.warn(f"Skipping annotation in Document ID: {_pmid}. Unexpected format")
         return {
             "pmid": pmid,
             "passages": passages,


### PR DESCRIPTION
This PR improves the implementation of the BioRed corpus:

- In the previous implementation a unique entity was created per entity mention **and** database identifier. This was fixed to a single entity mention having multiple database ids.
- Furthermore, the name of the database a entity is linked to was added
- BioRed only provides abstract-level annotations for entity-linked relation pairs rather than materializing links between all surface form mentions of relation. Analogous to BC5CDR we enumerate all mention pairs concerning the entities in the triple.
