### PR TITLE
remove Path.exists from bigbio to support streaming

### DIFF
--- a/bigbio/hub/bigbiohub.py
+++ b/bigbio/hub/bigbiohub.py
@@ -338,9 +338,11 @@ def parse_brat_file(
     ann_lines = []
     for suffix in annotation_file_suffixes:
         annotation_file = txt_file.with_suffix(suffix)
-        if annotation_file.exists():
+        try:
             with annotation_file.open() as f:
                 ann_lines.extend(f.readlines())
+        except Exception:
+            continue
 
     example["text_bound_annotations"] = []
     example["events"] = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ include_package_data = True
 python_requires = >=3.7,<3.11
 install_requires =
     bioc==2.0.post4
-    datasets>=2.0.0,<3.0.0
+    datasets>=2.8.0,<3.0.0
     numpy>=1.21.2
     openpyxl>=3.0.9,<3.1.0
     pandas>=1.3.3


### PR DESCRIPTION
makes the changes from @albertvillanova 's PR  https://github.com/bigscience-workshop/biomedical/pull/754/files

tl;dr this fixes a problem in `bigbiohub.parse_brat_file` that prevented using it in streaming mode. see

* https://huggingface.co/datasets/bigbio/chia/discussions/4

for more information. this new version of bigbiohub.py has been uploaded to all hub datasets. 