### PR TITLE
Update unit tests + contribution guidelines to support HFhub submissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 conhelpers.md
 
 # Ignore temp testing files
-bigbio/hub/hub_repos/test_scitail/*
+#bigbio/hub/hub_repos/test_scitail/*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 conhelpers.md
 
 # Ignore temp testing files
-biomeddatasets/testdata/testdata.py
+bigbio/hub/hub_repos/test_scitail/*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ Make sure your `pip` package points to your environment's source.
 
 ### 3. Prepare the folder in `biodatasets` for your dataloader
 
-Make a new directory within the `biomedical/bigbio/biodatasets` directory:
+Make a new directory within the `biomedical/bigbio/hub/hub_repos/` directory:
 
     mkdir bigbio/biodatasets/<dataset_name>
 
@@ -156,7 +156,7 @@ Make sure your dataset is implemented correctly by checking in python the follow
 ```python
 from datasets import load_dataset
 
-data = load_dataset("bigbio/biodatasets/<dataset_name>/<dataset_name>.py", name="<dataset_name>_bigbio_<schema>")
+data = load_dataset("bigbio/hub/hub_repos/<dataset_name>/<dataset_name>.py", name="<dataset_name>_bigbio_<schema>")
 ```
 
 Run these commands from the top level of the `biomedical` repo (i.e. the same directory that contains the `requirements.txt` file).
@@ -164,21 +164,30 @@ Run these commands from the top level of the `biomedical` repo (i.e. the same di
 Once this is done, please also check if your dataloader satisfies our unit tests as follows by using this command in the terminal:
 
 ```bash
-python -m tests.test_bigbio bigbio/biodatasets/<dataset_name>/<dataset_name>.py [--data_dir /path/to/local/data]
+python -m tests.test_bigbio_hub <dataset_name> [--data_dir /path/to/local/data] --test_local
 ```
 
-Your particular dataset may require use of some of the other command line args in the test script.
-To view full usage instructions you can use the `--help` command,
+You MUST include the `--test_local` flag to specifically test the script for your PR, otherwise the script will default to downloading a dataloader script from the Hub. Your particular dataset may require use of some of the other command line args in the test script (ex: `--data_dir` for dataloaders that read local files).
+<br>
+To view full usage instructions you can use the `--help` command:
 
 ```bash
 python -m tests.test_bigbio --help
 ```
+This will explain the types of arguments you may need to test for. A brief annotation is as such:
+
+- `dataset_name`: Name of the dataset you want to test
+- `data_dir`: The location of the data for datasets where `LOCAL_ = True`
+- `config_name`: Name of the configuration you want to test. By default, the script will test all configs, but if you can use this to debug a specific split, or if your data is prohibitively large.
+- `ishub`: Use this when unit testing scripts that are not yet uploaded to the hub (this is True for most cases)
+
+If you need advanced arguments (i.e. skipping a key from a specific data split), please contact admins. You are welcome to make a PR and ask admin for help if your code does not pass the unit tests. 
 
 ### 5. Format your code
 
 From the main directory, run the Makefile via the following command:
 
-    make check_file=bigbio/biodatasets/<dataset_name>/<dataset_name>.py
+    make check_file=bigbio/hub/hub_repos/<dataset_name>/<dataset_name>.py
 
 This runs the black formatter, isort, and lints to ensure that the code is readable and looks nice. Flake8 linting errors may require manual changes.
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ TBA - Links may not be applicable yet!
 
 - Have your own idea? Contact an admin in the form of an [issue](https://github.com/bigscience-workshop/biomedical/issues/new?assignees=&labels=&template=add-dataset.md&title=).
 
-- Implement your idea following guidelines set by the [official contributing guide](contributing.md)
+- Implement your idea following guidelines set by the [official contributing guide](CONTRIBUTING.md)
 
 - Wait for admin approval; approval is iterative, but if accepted will belong to the main repository.
 

--- a/bigbio/hub/hub_repos/test_scitail/bigbiohub.py
+++ b/bigbio/hub/hub_repos/test_scitail/bigbiohub.py
@@ -1,0 +1,590 @@
+from collections import defaultdict
+from dataclasses import dataclass
+from enum import Enum
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Dict, Iterable, List, Tuple
+
+import datasets
+
+if TYPE_CHECKING:
+    import bioc
+
+logger = logging.getLogger(__name__)
+
+
+BigBioValues = SimpleNamespace(NULL="<BB_NULL_STR>")
+
+
+@dataclass
+class BigBioConfig(datasets.BuilderConfig):
+    """BuilderConfig for BigBio."""
+
+    name: str = None
+    version: datasets.Version = None
+    description: str = None
+    schema: str = None
+    subset_id: str = None
+
+
+class Tasks(Enum):
+    NAMED_ENTITY_RECOGNITION = "NER"
+    NAMED_ENTITY_DISAMBIGUATION = "NED"
+    EVENT_EXTRACTION = "EE"
+    RELATION_EXTRACTION = "RE"
+    COREFERENCE_RESOLUTION = "COREF"
+    QUESTION_ANSWERING = "QA"
+    TEXTUAL_ENTAILMENT = "TE"
+    SEMANTIC_SIMILARITY = "STS"
+    TEXT_PAIRS_CLASSIFICATION = "TXT2CLASS"
+    PARAPHRASING = "PARA"
+    TRANSLATION = "TRANSL"
+    SUMMARIZATION = "SUM"
+    TEXT_CLASSIFICATION = "TXTCLASS"
+
+
+entailment_features = datasets.Features(
+    {
+        "id": datasets.Value("string"),
+        "premise": datasets.Value("string"),
+        "hypothesis": datasets.Value("string"),
+        "label": datasets.Value("string"),
+    }
+)
+
+pairs_features = datasets.Features(
+    {
+        "id": datasets.Value("string"),
+        "document_id": datasets.Value("string"),
+        "text_1": datasets.Value("string"),
+        "text_2": datasets.Value("string"),
+        "label": datasets.Value("string"),
+    }
+)
+
+qa_features = datasets.Features(
+    {
+        "id": datasets.Value("string"),
+        "question_id": datasets.Value("string"),
+        "document_id": datasets.Value("string"),
+        "question": datasets.Value("string"),
+        "type": datasets.Value("string"),
+        "choices": [datasets.Value("string")],
+        "context": datasets.Value("string"),
+        "answer": datasets.Sequence(datasets.Value("string")),
+    }
+)
+
+text_features = datasets.Features(
+    {
+        "id": datasets.Value("string"),
+        "document_id": datasets.Value("string"),
+        "text": datasets.Value("string"),
+        "labels": [datasets.Value("string")],
+    }
+)
+
+text2text_features = datasets.Features(
+    {
+        "id": datasets.Value("string"),
+        "document_id": datasets.Value("string"),
+        "text_1": datasets.Value("string"),
+        "text_2": datasets.Value("string"),
+        "text_1_name": datasets.Value("string"),
+        "text_2_name": datasets.Value("string"),
+    }
+)
+
+kb_features = datasets.Features(
+    {
+        "id": datasets.Value("string"),
+        "document_id": datasets.Value("string"),
+        "passages": [
+            {
+                "id": datasets.Value("string"),
+                "type": datasets.Value("string"),
+                "text": datasets.Sequence(datasets.Value("string")),
+                "offsets": datasets.Sequence([datasets.Value("int32")]),
+            }
+        ],
+        "entities": [
+            {
+                "id": datasets.Value("string"),
+                "type": datasets.Value("string"),
+                "text": datasets.Sequence(datasets.Value("string")),
+                "offsets": datasets.Sequence([datasets.Value("int32")]),
+                "normalized": [
+                    {
+                        "db_name": datasets.Value("string"),
+                        "db_id": datasets.Value("string"),
+                    }
+                ],
+            }
+        ],
+        "events": [
+            {
+                "id": datasets.Value("string"),
+                "type": datasets.Value("string"),
+                # refers to the text_bound_annotation of the trigger
+                "trigger": {
+                    "text": datasets.Sequence(datasets.Value("string")),
+                    "offsets": datasets.Sequence([datasets.Value("int32")]),
+                },
+                "arguments": [
+                    {
+                        "role": datasets.Value("string"),
+                        "ref_id": datasets.Value("string"),
+                    }
+                ],
+            }
+        ],
+        "coreferences": [
+            {
+                "id": datasets.Value("string"),
+                "entity_ids": datasets.Sequence(datasets.Value("string")),
+            }
+        ],
+        "relations": [
+            {
+                "id": datasets.Value("string"),
+                "type": datasets.Value("string"),
+                "arg1_id": datasets.Value("string"),
+                "arg2_id": datasets.Value("string"),
+                "normalized": [
+                    {
+                        "db_name": datasets.Value("string"),
+                        "db_id": datasets.Value("string"),
+                    }
+                ],
+            }
+        ],
+    }
+)
+
+
+TASK_TO_SCHEMA = {
+    Tasks.NAMED_ENTITY_RECOGNITION.name: "KB",
+    Tasks.NAMED_ENTITY_DISAMBIGUATION.name: "KB",
+    Tasks.EVENT_EXTRACTION.name: "KB",
+    Tasks.RELATION_EXTRACTION.name: "KB",
+    Tasks.COREFERENCE_RESOLUTION.name: "KB",
+    Tasks.QUESTION_ANSWERING.name: "QA",
+    Tasks.TEXTUAL_ENTAILMENT.name: "TE",
+    Tasks.SEMANTIC_SIMILARITY.name: "PAIRS",
+    Tasks.TEXT_PAIRS_CLASSIFICATION.name: "PAIRS",
+    Tasks.PARAPHRASING.name: "T2T",
+    Tasks.TRANSLATION.name: "T2T",
+    Tasks.SUMMARIZATION.name: "T2T",
+    Tasks.TEXT_CLASSIFICATION.name: "TEXT",
+}
+
+SCHEMA_TO_TASKS = defaultdict(set)
+for task, schema in TASK_TO_SCHEMA.items():
+    SCHEMA_TO_TASKS[schema].add(task)
+SCHEMA_TO_TASKS = dict(SCHEMA_TO_TASKS)
+
+VALID_TASKS = set(TASK_TO_SCHEMA.keys())
+VALID_SCHEMAS = set(TASK_TO_SCHEMA.values())
+
+SCHEMA_TO_FEATURES = {
+    "KB": kb_features,
+    "QA": qa_features,
+    "TE": entailment_features,
+    "T2T": text2text_features,
+    "TEXT": text_features,
+    "PAIRS": pairs_features,
+}
+
+
+def get_texts_and_offsets_from_bioc_ann(ann: "bioc.BioCAnnotation") -> Tuple:
+
+    offsets = [(loc.offset, loc.offset + loc.length) for loc in ann.locations]
+
+    text = ann.text
+
+    if len(offsets) > 1:
+        i = 0
+        texts = []
+        for start, end in offsets:
+            chunk_len = end - start
+            texts.append(text[i : chunk_len + i])
+            i += chunk_len
+            while i < len(text) and text[i] == " ":
+                i += 1
+    else:
+        texts = [text]
+
+    return offsets, texts
+
+
+def remove_prefix(a: str, prefix: str) -> str:
+    if a.startswith(prefix):
+        a = a[len(prefix) :]
+    return a
+
+
+def parse_brat_file(
+    txt_file: Path,
+    annotation_file_suffixes: List[str] = None,
+    parse_notes: bool = False,
+) -> Dict:
+    """
+    Parse a brat file into the schema defined below.
+    `txt_file` should be the path to the brat '.txt' file you want to parse, e.g. 'data/1234.txt'
+    Assumes that the annotations are contained in one or more of the corresponding '.a1', '.a2' or '.ann' files,
+    e.g. 'data/1234.ann' or 'data/1234.a1' and 'data/1234.a2'.
+    Will include annotator notes, when `parse_notes == True`.
+    brat_features = datasets.Features(
+        {
+            "id": datasets.Value("string"),
+            "document_id": datasets.Value("string"),
+            "text": datasets.Value("string"),
+            "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                {
+                    "offsets": datasets.Sequence([datasets.Value("int32")]),
+                    "text": datasets.Sequence(datasets.Value("string")),
+                    "type": datasets.Value("string"),
+                    "id": datasets.Value("string"),
+                }
+            ],
+            "events": [  # E line in brat
+                {
+                    "trigger": datasets.Value(
+                        "string"
+                    ),  # refers to the text_bound_annotation of the trigger,
+                    "id": datasets.Value("string"),
+                    "type": datasets.Value("string"),
+                    "arguments": datasets.Sequence(
+                        {
+                            "role": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                        }
+                    ),
+                }
+            ],
+            "relations": [  # R line in brat
+                {
+                    "id": datasets.Value("string"),
+                    "head": {
+                        "ref_id": datasets.Value("string"),
+                        "role": datasets.Value("string"),
+                    },
+                    "tail": {
+                        "ref_id": datasets.Value("string"),
+                        "role": datasets.Value("string"),
+                    },
+                    "type": datasets.Value("string"),
+                }
+            ],
+            "equivalences": [  # Equiv line in brat
+                {
+                    "id": datasets.Value("string"),
+                    "ref_ids": datasets.Sequence(datasets.Value("string")),
+                }
+            ],
+            "attributes": [  # M or A lines in brat
+                {
+                    "id": datasets.Value("string"),
+                    "type": datasets.Value("string"),
+                    "ref_id": datasets.Value("string"),
+                    "value": datasets.Value("string"),
+                }
+            ],
+            "normalizations": [  # N lines in brat
+                {
+                    "id": datasets.Value("string"),
+                    "type": datasets.Value("string"),
+                    "ref_id": datasets.Value("string"),
+                    "resource_name": datasets.Value(
+                        "string"
+                    ),  # Name of the resource, e.g. "Wikipedia"
+                    "cuid": datasets.Value(
+                        "string"
+                    ),  # ID in the resource, e.g. 534366
+                    "text": datasets.Value(
+                        "string"
+                    ),  # Human readable description/name of the entity, e.g. "Barack Obama"
+                }
+            ],
+            ### OPTIONAL: Only included when `parse_notes == True`
+            "notes": [  # # lines in brat
+                {
+                    "id": datasets.Value("string"),
+                    "type": datasets.Value("string"),
+                    "ref_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                }
+            ],
+        },
+        )
+    """
+
+    example = {}
+    example["document_id"] = txt_file.with_suffix("").name
+    with txt_file.open() as f:
+        example["text"] = f.read()
+
+    # If no specific suffixes of the to-be-read annotation files are given - take standard suffixes
+    # for event extraction
+    if annotation_file_suffixes is None:
+        annotation_file_suffixes = [".a1", ".a2", ".ann"]
+
+    if len(annotation_file_suffixes) == 0:
+        raise AssertionError(
+            "At least one suffix for the to-be-read annotation files should be given!"
+        )
+
+    ann_lines = []
+    for suffix in annotation_file_suffixes:
+        annotation_file = txt_file.with_suffix(suffix)
+        if annotation_file.exists():
+            with annotation_file.open() as f:
+                ann_lines.extend(f.readlines())
+
+    example["text_bound_annotations"] = []
+    example["events"] = []
+    example["relations"] = []
+    example["equivalences"] = []
+    example["attributes"] = []
+    example["normalizations"] = []
+
+    if parse_notes:
+        example["notes"] = []
+
+    for line in ann_lines:
+        line = line.strip()
+        if not line:
+            continue
+
+        if line.startswith("T"):  # Text bound
+            ann = {}
+            fields = line.split("\t")
+
+            ann["id"] = fields[0]
+            ann["type"] = fields[1].split()[0]
+            ann["offsets"] = []
+            span_str = remove_prefix(fields[1], (ann["type"] + " "))
+            text = fields[2]
+            for span in span_str.split(";"):
+                start, end = span.split()
+                ann["offsets"].append([int(start), int(end)])
+
+            # Heuristically split text of discontiguous entities into chunks
+            ann["text"] = []
+            if len(ann["offsets"]) > 1:
+                i = 0
+                for start, end in ann["offsets"]:
+                    chunk_len = end - start
+                    ann["text"].append(text[i : chunk_len + i])
+                    i += chunk_len
+                    while i < len(text) and text[i] == " ":
+                        i += 1
+            else:
+                ann["text"] = [text]
+
+            example["text_bound_annotations"].append(ann)
+
+        elif line.startswith("E"):
+            ann = {}
+            fields = line.split("\t")
+
+            ann["id"] = fields[0]
+
+            ann["type"], ann["trigger"] = fields[1].split()[0].split(":")
+
+            ann["arguments"] = []
+            for role_ref_id in fields[1].split()[1:]:
+                argument = {
+                    "role": (role_ref_id.split(":"))[0],
+                    "ref_id": (role_ref_id.split(":"))[1],
+                }
+                ann["arguments"].append(argument)
+
+            example["events"].append(ann)
+
+        elif line.startswith("R"):
+            ann = {}
+            fields = line.split("\t")
+
+            ann["id"] = fields[0]
+            ann["type"] = fields[1].split()[0]
+
+            ann["head"] = {
+                "role": fields[1].split()[1].split(":")[0],
+                "ref_id": fields[1].split()[1].split(":")[1],
+            }
+            ann["tail"] = {
+                "role": fields[1].split()[2].split(":")[0],
+                "ref_id": fields[1].split()[2].split(":")[1],
+            }
+
+            example["relations"].append(ann)
+
+        # '*' seems to be the legacy way to mark equivalences,
+        # but I couldn't find any info on the current way
+        # this might have to be adapted dependent on the brat version
+        # of the annotation
+        elif line.startswith("*"):
+            ann = {}
+            fields = line.split("\t")
+
+            ann["id"] = fields[0]
+            ann["ref_ids"] = fields[1].split()[1:]
+
+            example["equivalences"].append(ann)
+
+        elif line.startswith("A") or line.startswith("M"):
+            ann = {}
+            fields = line.split("\t")
+
+            ann["id"] = fields[0]
+
+            info = fields[1].split()
+            ann["type"] = info[0]
+            ann["ref_id"] = info[1]
+
+            if len(info) > 2:
+                ann["value"] = info[2]
+            else:
+                ann["value"] = ""
+
+            example["attributes"].append(ann)
+
+        elif line.startswith("N"):
+            ann = {}
+            fields = line.split("\t")
+
+            ann["id"] = fields[0]
+            ann["text"] = fields[2]
+
+            info = fields[1].split()
+
+            ann["type"] = info[0]
+            ann["ref_id"] = info[1]
+            ann["resource_name"] = info[2].split(":")[0]
+            ann["cuid"] = info[2].split(":")[1]
+            example["normalizations"].append(ann)
+
+        elif parse_notes and line.startswith("#"):
+            ann = {}
+            fields = line.split("\t")
+
+            ann["id"] = fields[0]
+            ann["text"] = fields[2] if len(fields) == 3 else BigBioValues.NULL
+
+            info = fields[1].split()
+
+            ann["type"] = info[0]
+            ann["ref_id"] = info[1]
+            example["notes"].append(ann)
+
+    return example
+
+
+def brat_parse_to_bigbio_kb(brat_parse: Dict) -> Dict:
+    """
+    Transform a brat parse (conforming to the standard brat schema) obtained with
+    `parse_brat_file` into a dictionary conforming to the `bigbio-kb` schema (as defined in ../schemas/kb.py)
+    :param brat_parse:
+    """
+
+    unified_example = {}
+
+    # Prefix all ids with document id to ensure global uniqueness,
+    # because brat ids are only unique within their document
+    id_prefix = brat_parse["document_id"] + "_"
+
+    # identical
+    unified_example["document_id"] = brat_parse["document_id"]
+    unified_example["passages"] = [
+        {
+            "id": id_prefix + "_text",
+            "type": "abstract",
+            "text": [brat_parse["text"]],
+            "offsets": [[0, len(brat_parse["text"])]],
+        }
+    ]
+
+    # get normalizations
+    ref_id_to_normalizations = defaultdict(list)
+    for normalization in brat_parse["normalizations"]:
+        ref_id_to_normalizations[normalization["ref_id"]].append(
+            {
+                "db_name": normalization["resource_name"],
+                "db_id": normalization["cuid"],
+            }
+        )
+
+    # separate entities and event triggers
+    unified_example["events"] = []
+    non_event_ann = brat_parse["text_bound_annotations"].copy()
+    for event in brat_parse["events"]:
+        event = event.copy()
+        event["id"] = id_prefix + event["id"]
+        trigger = next(
+            tr
+            for tr in brat_parse["text_bound_annotations"]
+            if tr["id"] == event["trigger"]
+        )
+        if trigger in non_event_ann:
+            non_event_ann.remove(trigger)
+        event["trigger"] = {
+            "text": trigger["text"].copy(),
+            "offsets": trigger["offsets"].copy(),
+        }
+        for argument in event["arguments"]:
+            argument["ref_id"] = id_prefix + argument["ref_id"]
+
+        unified_example["events"].append(event)
+
+    unified_example["entities"] = []
+    anno_ids = [ref_id["id"] for ref_id in non_event_ann]
+    for ann in non_event_ann:
+        entity_ann = ann.copy()
+        entity_ann["id"] = id_prefix + entity_ann["id"]
+        entity_ann["normalized"] = ref_id_to_normalizations[ann["id"]]
+        unified_example["entities"].append(entity_ann)
+
+    # massage relations
+    unified_example["relations"] = []
+    skipped_relations = set()
+    for ann in brat_parse["relations"]:
+        if (
+            ann["head"]["ref_id"] not in anno_ids
+            or ann["tail"]["ref_id"] not in anno_ids
+        ):
+            skipped_relations.add(ann["id"])
+            continue
+        unified_example["relations"].append(
+            {
+                "arg1_id": id_prefix + ann["head"]["ref_id"],
+                "arg2_id": id_prefix + ann["tail"]["ref_id"],
+                "id": id_prefix + ann["id"],
+                "type": ann["type"],
+                "normalized": [],
+            }
+        )
+    if len(skipped_relations) > 0:
+        example_id = brat_parse["document_id"]
+        logger.info(
+            f"Example:{example_id}: The `bigbio_kb` schema allows `relations` only between entities."
+            f" Skip (for now): "
+            f"{list(skipped_relations)}"
+        )
+
+    # get coreferences
+    unified_example["coreferences"] = []
+    for i, ann in enumerate(brat_parse["equivalences"], start=1):
+        is_entity_cluster = True
+        for ref_id in ann["ref_ids"]:
+            if not ref_id.startswith("T"):  # not textbound -> no entity
+                is_entity_cluster = False
+            elif ref_id not in anno_ids:  # event trigger -> no entity
+                is_entity_cluster = False
+        if is_entity_cluster:
+            entity_ids = [id_prefix + i for i in ann["ref_ids"]]
+            unified_example["coreferences"].append(
+                {"id": id_prefix + str(i), "entity_ids": entity_ids}
+            )
+    return unified_example

--- a/bigbio/hub/hub_repos/test_scitail/test_scitail.py
+++ b/bigbio/hub/hub_repos/test_scitail/test_scitail.py
@@ -1,0 +1,180 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The SciTail dataset is an entailment dataset created from multiple-choice science exams and
+web sentences. Each question and the correct answer choice are converted into an assertive
+statement to form the hypothesis. We use information retrieval to obtain relevant text from
+a large text corpus of web sentences, and use these sentences as a premise P. We crowdsource
+the annotation of such premise-hypothesis pair as supports (entails) or not (neutral), in order
+to create the SciTail dataset. The dataset contains 27,026 examples with 10,101 examples with
+entails label and 16,925 examples with neutral label.
+"""
+import os
+
+import datasets
+import pandas as pd
+
+from .bigbiohub import entailment_features
+from .bigbiohub import BigBioConfig
+from .bigbiohub import Tasks
+
+# Testing
+#_LANGUAGES = ["English"]
+
+_LANGUAGES = ["EnGlISH"]  # This will fail
+
+_PUBMED = False
+_LOCAL = False
+_CITATION = """\
+@inproceedings{scitail,
+    author = {Tushar Khot and Ashish Sabharwal and Peter Clark},
+    booktitle = {AAAI}
+    title = {SciTail: A Textual Entailment Dataset from Science Question Answering},
+    year = {2018}
+}
+"""
+
+_DATASETNAME = "scitail"
+_DISPLAYNAME = "SciTail"
+
+_DESCRIPTION = """\
+The SciTail dataset is an entailment dataset created from multiple-choice science exams and
+web sentences. Each question and the correct answer choice are converted into an assertive
+statement to form the hypothesis. We use information retrieval to obtain relevant text from
+a large text corpus of web sentences, and use these sentences as a premise P. We crowdsource
+the annotation of such premise-hypothesis pair as supports (entails) or not (neutral), in order
+to create the SciTail dataset. The dataset contains 27,026 examples with 10,101 examples with
+entails label and 16,925 examples with neutral label.
+"""
+
+_HOMEPAGE = "https://allenai.org/data/scitail"
+
+# Testing
+_LICENSE = "Apple Public Source License 2.0"
+
+#_LICENSE = "APACHE_2p0"  # This will fail
+
+_URLS = {
+    _DATASETNAME: "https://ai2-public-datasets.s3.amazonaws.com/scitail/SciTailV1.1.zip",
+}
+
+_SUPPORTED_TASKS = [Tasks.TEXTUAL_ENTAILMENT]
+
+_SOURCE_VERSION = "1.1.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+LABEL_MAP = {"entails": "entailment", "neutral": "neutral"}
+
+
+class TestSciTailDataset(datasets.GeneratorBasedBuilder):
+    """TODO: Short description of my dataset."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="scitail_source",
+            version=SOURCE_VERSION,
+            description="SciTail source schema",
+            schema="source",
+            subset_id="scitail",
+        ),
+        BigBioConfig(
+            name="scitail_bigbio_te",
+            version=BIGBIO_VERSION,
+            description="SciTail BigBio schema",
+            schema="bigbio_te",
+            subset_id="scitail",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "scitail_source"
+
+    def _info(self):
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "premise": datasets.Value("string"),
+                    "hypothesis": datasets.Value("string"),
+                    "label": datasets.Value("string"),
+                }
+            )
+
+        elif self.config.schema == "bigbio_te":
+            features = entailment_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "SciTailV1.1", "tsv_format", "scitail_1.0_train.tsv"
+                    ),
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "SciTailV1.1", "tsv_format", "scitail_1.0_test.tsv"
+                    ),
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(
+                        data_dir, "SciTailV1.1", "tsv_format", "scitail_1.0_dev.tsv"
+                    ),
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath):
+        # since examples can contain quotes mid text set quoting to QUOTE_NONE (3) when reading tsv
+        # e.g.: ... and apply specific "tools" to examples and ...
+        data = pd.read_csv(
+            filepath, sep="\t", names=["premise", "hypothesis", "label"], quoting=3
+        )
+        data["id"] = data.index
+
+        if self.config.schema == "source":
+            for _, row in data.iterrows():
+                yield row["id"], row.to_dict()
+
+        elif self.config.schema == "bigbio_te":
+            # normalize labels
+            data["label"] = data["label"].apply(lambda x: LABEL_MAP[x])
+            for _, row in data.iterrows():
+                yield row["id"], row.to_dict()

--- a/bigbio/hub/hub_repos/test_scitail/test_scitail.py
+++ b/bigbio/hub/hub_repos/test_scitail/test_scitail.py
@@ -32,9 +32,8 @@ from .bigbiohub import BigBioConfig
 from .bigbiohub import Tasks
 
 # Testing
-#_LANGUAGES = ["English"]
-
-_LANGUAGES = ["EnGlISH"]  # This will fail
+_LANGUAGES = ["English"]
+#_LANGUAGES = ["EnGlISH"]  # This will fail
 
 _PUBMED = False
 _LOCAL = False
@@ -63,8 +62,7 @@ entails label and 16,925 examples with neutral label.
 _HOMEPAGE = "https://allenai.org/data/scitail"
 
 # Testing
-_LICENSE = "Apple Public Source License 2.0"
-
+_LICENSE = "Apache License 2.0"
 #_LICENSE = "APACHE_2p0"  # This will fail
 
 _URLS = {

--- a/bigbio/hub/hub_repos/test_scitail/test_scitail.py
+++ b/bigbio/hub/hub_repos/test_scitail/test_scitail.py
@@ -62,8 +62,8 @@ entails label and 16,925 examples with neutral label.
 _HOMEPAGE = "https://allenai.org/data/scitail"
 
 # Testing
-_LICENSE = "Apache License 2.0"
-#_LICENSE = "APACHE_2p0"  # This will fail
+# _LICENSE = "Apache License 2.0" # This will fail (need to use short name)
+_LICENSE = "APACHE_2p0"  
 
 _URLS = {
     _DATASETNAME: "https://ai2-public-datasets.s3.amazonaws.com/scitail/SciTailV1.1.zip",

--- a/tests/test_bigbio_hub.py
+++ b/tests/test_bigbio_hub.py
@@ -21,14 +21,12 @@ from huggingface_hub import HfApi
 
 # from bigbio.utils.constants import METADATA
 from bigbio.hub import bigbiohub
-
-currdir = Path(__file__).parents[1].resolve() / "bigbio/utils/resources"
-
-with open(currdir / "languages.json") as f:
-    lang_keys = set(json.load(f).values())
-
-with open(currdir / "licenses.json") as f:
-    license_keys = set(json.load(f).values())
+from bigbio.utils.license import Licenses                                                                            
+from bigbio.utils.constants import Lang                                                                              
+                                                                                                                     
+                                                                                                                     
+lang_keys = set([el.value for el in Lang])                                                                           
+license_keys = set(Licenses.__dict__) 
 
 
 logger = logging.getLogger(__name__)
@@ -188,7 +186,7 @@ class TestDataLoader(unittest.TestCase):
 
             if metadata_name == "_LICENSE":
                 if metadata_attr not in license_keys:
-                    raise AssertionError(f"Dataloader attribute '{metadata_name}' not valid for {metadata_attr}`!")
+                    raise AssertionError(f"Dataloader attribute '{metadata_attr}' not valid for {metadata_name}`!")
 
     def get_feature_statistics(self, features: Features) -> Dict:
         """

--- a/tests/test_bigbio_hub.py
+++ b/tests/test_bigbio_hub.py
@@ -7,21 +7,17 @@ import argparse
 import importlib
 import logging
 import re
-import sys
 import unittest
 from collections import defaultdict
-from pathlib import Path
 from types import ModuleType
-from typing import Dict, Iterable, Iterator, List, Optional, Union
+from typing import Dict, Iterable, Iterator, List, Optional
 
 import datasets
 from datasets import DatasetDict, Features
 from huggingface_hub import HfApi
 
-#from bigbio.utils.constants import METADATA
+# from bigbio.utils.constants import METADATA
 from bigbio.hub import bigbiohub
-
-
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +42,7 @@ def _get_example_text(example: dict) -> str:
     """
     Concatenate all text from passages in an example of a KB schema
     :param example: An instance of the KB schema
-    """
+    """  # noqa
     return " ".join([t for p in example["passages"] for t in p["text"]])
 
 
@@ -63,7 +59,7 @@ _CONNECTORS = re.compile(r"\+|\,|\||\;")
 class TestDataLoader(unittest.TestCase):
     """
     Test a single config from a dataloader script.
-    """
+    """  # noqa
 
     DATASET_NAME: str
     CONFIG_NAME: str
@@ -92,13 +88,9 @@ class TestDataLoader(unittest.TestCase):
         valid_tasks = set([mem.name for mem in bigbiohub.Tasks])
         invalid_tasks = set(self._SUPPORTED_TASKS) - valid_tasks
         if len(invalid_tasks) > 0:
-            raise ValueError(
-                f"Found invalid supported tasks {invalid_tasks}. Must be one of {bigbiohub.VALID_TASKS}"
-            )
+            raise ValueError(f"Found invalid supported tasks {invalid_tasks}. Must be one of {bigbiohub.VALID_TASKS}")
 
-        self._MAPPED_SCHEMAS = set(
-            [bigbiohub.TASK_TO_SCHEMA[task] for task in self._SUPPORTED_TASKS]
-        )
+        self._MAPPED_SCHEMAS = set([bigbiohub.TASK_TO_SCHEMA[task] for task in self._SUPPORTED_TASKS])
         logger.info(f"_SUPPORTED_TASKS implies _MAPPED_SCHEMAS={self._MAPPED_SCHEMAS}")
 
         logger.info(f"Checking load_dataset with config name {config_name}")
@@ -146,13 +138,11 @@ class TestDataLoader(unittest.TestCase):
     def test_metadata(self, module: ModuleType):
         """
         Check if all metadata for a dataloader are present
-        """
+        """  # noqa
 
         for metadata_name, metadata_type in METADATA.items():
             if not hasattr(module, metadata_name):
-                raise AssertionError(
-                    f"Required dataloader attribute '{metadata_name}' is not defined!"
-                )
+                raise AssertionError(f"Required dataloader attribute '{metadata_name}' is not defined!")
 
             metadata_attr = getattr(module, metadata_name)
 
@@ -243,7 +233,7 @@ class TestDataLoader(unittest.TestCase):
     def test_are_ids_globally_unique(self, dataset_bigbio: DatasetDict):
         """
         Tests each example in a split has a unique ID.
-        """
+        """  # noqa
         logger.info("Checking global ID uniqueness")
         for split_name, split in dataset_bigbio.items():
 
@@ -292,7 +282,7 @@ class TestDataLoader(unittest.TestCase):
     def test_do_all_referenced_ids_exist(self, dataset_bigbio: DatasetDict):
         """
         Checks if referenced IDs are correctly labeled.
-        """
+        """  # noqa
         logger.info("Checking if referenced IDs are properly mapped")
         for split_name, split in dataset_bigbio.items():
 
@@ -316,10 +306,7 @@ class TestDataLoader(unittest.TestCase):
                         continue
 
                     if ref_type == "event":
-                        if not (
-                            (ref_id, "entity") in existing_ids
-                            or (ref_id, "event") in existing_ids
-                        ):
+                        if not ((ref_id, "entity") in existing_ids or (ref_id, "event") in existing_ids):
                             logger.warning(
                                 f"Referenced element ({ref_id}, entity/event) could not be "
                                 f"found in existing ids {existing_ids}. Please make sure that "
@@ -363,9 +350,7 @@ class TestDataLoader(unittest.TestCase):
                         text = passage["text"]
                         offsets = passage["offsets"]
 
-                        self._test_is_list(
-                            msg="Text in passages must be a list", field=text
-                        )
+                        self._test_is_list(msg="Text in passages must be a list", field=text)
 
                         self._test_is_list(
                             msg="Offsets in passages must be a list",
@@ -422,10 +407,7 @@ class TestDataLoader(unittest.TestCase):
         )
 
         with self.subTest(
-            (
-                f"Split:{split} - Example:{example_id} - "
-                f"All offsets must be in the form [(lo1, hi1), ...]"
-            ),
+            (f"Split:{split} - Example:{example_id} - " f"All offsets must be in the form [(lo1, hi1), ...]"),
             offsets=offsets,
         ):
             self.assertTrue(all(len(o) == 2 for o in offsets))
@@ -479,9 +461,7 @@ class TestDataLoader(unittest.TestCase):
                         ):
 
                             entity_id = entity["id"]
-                            errors.append(
-                                f"Example:{example_id} - entity:{entity_id} " + msg
-                            )
+                            errors.append(f"Example:{example_id} - entity:{entity_id} " + msg)
 
         if len(errors) > 0:
             logger.warning(msg="\n".join(errors) + OFFSET_ERROR_MSG)
@@ -490,7 +470,7 @@ class TestDataLoader(unittest.TestCase):
         """
         Verify that the events' trigger offsets are correct,
         i.e.: trigger text == text extracted via the trigger offsets
-        """
+        """  # noqa
         logger.info("KB ONLY: Checking event offsets")
         errors = []
 
@@ -523,9 +503,7 @@ class TestDataLoader(unittest.TestCase):
                         ):
 
                             event_id = event["id"]
-                            errors.append(
-                                f"Example:{example_id} - event:{event_id} " + msg
-                            )
+                            errors.append(f"Example:{example_id} - event:{event_id} " + msg)
 
         if len(errors) > 0:
             logger.warning(msg="\n".join(errors) + OFFSET_ERROR_MSG)
@@ -564,7 +542,7 @@ class TestDataLoader(unittest.TestCase):
     def test_multiple_choice(self, dataset_bigbio: DatasetDict):
         """
         Verify that each answer in a multiple choice Q/A task is in choices.
-        """
+        """  # noqa
         logger.info("QA ONLY: Checking multiple choice")
         for split in dataset_bigbio:
 
@@ -576,9 +554,7 @@ class TestDataLoader(unittest.TestCase):
             for example in dataset_bigbio[split]:
 
                 if self._skipkey_or_keysplit("choices", split):
-                    logger.warning(
-                        "Skipping multiple choice for key=choices, split='{split}'"
-                    )
+                    logger.warning("Skipping multiple choice for key=choices, split='{split}'")
                     continue
 
                 else:
@@ -596,22 +572,18 @@ class TestDataLoader(unittest.TestCase):
                         ), f"type is 'multiple_choice' or 'yesno' but no values in 'choices' {example}"
 
                         if self._skipkey_or_keysplit("answer", split):
-                            logger.warning(
-                                "Skipping multiple choice for key=answer, split='{split}'"
-                            )
+                            logger.warning("Skipping multiple choice for key=answer, split='{split}'")
                             continue
 
                         else:
                             for answer in example["answer"]:
-                                assert (
-                                    answer in example["choices"]
-                                ), f"answer is not present in 'choices' {example}"
+                                assert answer in example["choices"], f"answer is not present in 'choices' {example}"
 
     def test_entities_multilabel_db(self, dataset_bigbio: DatasetDict):
         """
         Check if `db_name` or `db_id` of `normalized` field in entities have multiple values joined with common connectors.
         Raises a warning ONLY ONCE per connector type.
-        """
+        """  # noqa
         logger.info("KB ONLY: multi-label `db_id`")
 
         warning_raised = {}
@@ -669,7 +641,7 @@ class TestDataLoader(unittest.TestCase):
         """
         Check if features with `type` field contain multilabel values
         and raise a warning ONLY ONCE for feature type (e.g. passages)
-        """
+        """  # noqa
 
         logger.info("KB ONLY: multi-label `type` fields")
 
@@ -687,15 +659,10 @@ class TestDataLoader(unittest.TestCase):
             for feature_name in features_with_type:
 
                 if self._skipkey_or_keysplit(feature_name, split):
-                    logger.warning(
-                        f"Skipping multilabel type for splitkey = '{(split, feature_name)}'"
-                    )
+                    logger.warning(f"Skipping multilabel type for splitkey = '{(split, feature_name)}'")
                     continue
 
-                if (
-                    feature_name not in dataset_bigbio[split].features
-                    or warning_raised[feature_name]
-                ):
+                if feature_name not in dataset_bigbio[split].features or warning_raised[feature_name]:
                     continue
 
                 for example_index, example in enumerate(dataset_bigbio[split]):
@@ -732,7 +699,7 @@ class TestDataLoader(unittest.TestCase):
                             break
 
     def test_schema(self, schema: str):
-        """Search supported tasks within a dataset and verify big-bio schema"""
+        """Search supported tasks within a dataset and verify big-bio schema"""  # noqa
 
         non_empty_features = set()
         if schema == "KB":
@@ -765,15 +732,11 @@ class TestDataLoader(unittest.TestCase):
             for non_empty_feature in non_empty_features:
 
                 if self._skipkey_or_keysplit(non_empty_feature, split_name):
-                    logger.warning(
-                        f"Skipping schema for split, key = '{(split_name, non_empty_feature)}'"
-                    )
+                    logger.warning(f"Skipping schema for split, key = '{(split_name, non_empty_feature)}'")
                     continue
 
                 if split_to_feature_counts[split_name][non_empty_feature] == 0:
-                    raise AssertionError(
-                        f"Required key '{non_empty_feature}' does not have any instances"
-                    )
+                    raise AssertionError(f"Required key '{non_empty_feature}' does not have any instances")
 
             for feature, count in split_to_feature_counts[split_name].items():
                 if (
@@ -810,12 +773,8 @@ class TestDataLoader(unittest.TestCase):
             logger.warning(f"Keys ignored = '{self.BYPASS_KEYS}'")
 
         if len(self.BYPASS_SPLIT_KEY_PAIRS) > 0:
-            logger.warning(
-                f"Split and key pairs ignored ='{self.BYPASS_SPLIT_KEY_PAIRS}'"
-            )
-            self.BYPASS_SPLIT_KEY_PAIRS = [
-                i.split(",") for i in self.BYPASS_SPLIT_KEY_PAIRS
-            ]
+            logger.warning(f"Split and key pairs ignored ='{self.BYPASS_SPLIT_KEY_PAIRS}'")
+            self.BYPASS_SPLIT_KEY_PAIRS = [i.split(",") for i in self.BYPASS_SPLIT_KEY_PAIRS]
 
     def _skipkey_or_keysplit(self, key: str, split: str):
         """Check if key or (split, key) pair should be omitted"""
@@ -874,22 +833,42 @@ if __name__ == "__main__":
         help="Skip a key in a data split (e.g. skip 'entities' in 'test'). List all key-pairs comma separated. (ex: --bypass_split_key_pairs test,entities train, events)",
     )
 
+    # If specified as `True`, bypass hub download and check local script.
+    parser.add_argument(
+        "--test_local",
+        action="store_true",
+        help="Unit testing on local script instead of hub (ONLY USE FOR PRs)",
+    )
+
     args = parser.parse_args()
     logger.info(f"args: {args}")
 
-    org_and_dataset_name = f"bigbio/{args.dataset_name}"
+    if not args.test_local:
+        logger.info("Running Hub Unit Test")
+        org_and_dataset_name = f"bigbio/{args.dataset_name}"
 
-    api = HfApi()
-    ds_info = api.dataset_info(org_and_dataset_name)
-    print(ds_info)
+        api = HfApi()
+        ds_info = api.dataset_info(org_and_dataset_name)
+        print(ds_info)
 
-    dataset_module = datasets.load.dataset_module_factory(org_and_dataset_name)
-    print(dataset_module)
+        dataset_module = datasets.load.dataset_module_factory(org_and_dataset_name)
+        print(dataset_module)
 
-    builder_cls = datasets.load.import_main_class(dataset_module.module_path)
-    all_config_names = [el.name for el in builder_cls.BUILDER_CONFIGS]
-    logger.info(f"all_config_names: {all_config_names}")
+        builder_cls = datasets.load.import_main_class(dataset_module.module_path)
+        all_config_names = [el.name for el in builder_cls.BUILDER_CONFIGS]
+        logger.info(f"all_config_names: {all_config_names}")
 
+    else:
+        logger.info("Running (Local) Unit Test")
+        org_and_dataset_name = f"bigbio/hub/hub_repos/{args.dataset_name}/{args.dataset_name}.py"
+        print("Dataset = ", args.dataset_name)
+
+        module = datasets.load.dataset_module_factory(org_and_dataset_name)
+        print(module)
+
+        builder_cls = datasets.load.import_main_class(module.module_path)
+        all_config_names = [el.name for el in builder_cls.BUILDER_CONFIGS]
+        logger.info(f"all_config_names: {all_config_names}")
 
     if args.config_name is not None:
         run_config_names = [args.config_name]

--- a/tests/test_bigbio_hub.py
+++ b/tests/test_bigbio_hub.py
@@ -25,10 +25,10 @@ from bigbio.hub import bigbiohub
 currdir = Path(__file__).parents[1].resolve() / "bigbio/utils/resources"
 
 with open(currdir / "languages.json") as f:
-    lang_keys = set(json.load(f).keys())
+    lang_keys = set(json.load(f).values())
 
 with open(currdir / "licenses.json") as f:
-    license_keys = set(json.load(f).keys())
+    license_keys = set(json.load(f).values())
 
 
 logger = logging.getLogger(__name__)
@@ -178,7 +178,8 @@ class TestDataLoader(unittest.TestCase):
                         )
 
                     if elem not in lang_keys:
-                        raise AssertionError(f"Dataloader attribute '{metadata_name}' not valid example`!")
+                        print(elem)
+                        raise AssertionError(f"Dataloader attribute '{metadata_name}' not valid for {elem}`!")
             else:
                 if not isinstance(metadata_attr, metadata_type):
                     raise AssertionError(
@@ -187,7 +188,7 @@ class TestDataLoader(unittest.TestCase):
 
             if metadata_name == "_LICENSE":
                 if metadata_attr not in license_keys:
-                    raise AssertionError(f"Dataloader attribute '{metadata_name}' not valid example`!")
+                    raise AssertionError(f"Dataloader attribute '{metadata_name}' not valid for {metadata_attr}`!")
 
     def get_feature_statistics(self, features: Features) -> Dict:
         """


### PR DESCRIPTION
Supercedes #850 

**TLDR:**

- keeps the biodatasets and test_bigbio script
- adapts the test_bigbio_hub script to use the `--test_local` flag in order to test hub submissions
- fixes minor broken hyperlink in README for contributions guideline
- adapt contribution guidelines for new hub-forward scripting
- includes new unit test that checks for language + license metadata to be explicitly standardized by the values in `languages.json` and `licenses.json`

**How to run:**

1) There is a test folder here: `bigbio/hub/hub_repos/test_scitail`. This includes a dataloading script and a copy of the bigbiohub.

2) You can test the unit tests **in the main bigbio directory (parent of the `tests` folder)** by running the following command:
```
python -m tests.test_bigbio_hub test_scitail --test_local
```

**This will pass**, but you can test the metadata works as intended by modifying the `_LANGUAGES` and `_LICENSES` category. I made 2 examples

**NOTES**

- I found that the default test script has a weird license? `APACHE_p2.0`; we should look into this?

 - `test_metadata` now explicitly checks the elements of `_LANGUAGES` and `_LICENSES` for the *content*; this explicitly reads `languages.json` and `licenses.json` to ensure that all metadata elements adhere to our curated list. **Currently, this is a AssertionError**, we may want to think about making this flexible, because a test will fail unless we have already seen this license + language before. 
