### PR TITLE
bioid: fix(entity_type): map Cellosaurus to "cellline"

### DIFF
--- a/bigbio/hub/hub_repos/bioid/bioid.py
+++ b/bigbio/hub/hub_repos/bioid/bioid.py
@@ -110,7 +110,7 @@ class BioidDataset(datasets.GeneratorBasedBuilder):
         "PubChem": "chemical",
         "Rfam": "rna",  # https://rfam.org/
         "Uberon": "anatomy",
-        "Cellosaurus": "cell",
+        "Cellosaurus": "cellline",
         "NCBI gene": "gene",
         "NCBI taxon": "species",
         "Uniprot": "protein",


### PR DESCRIPTION
Use entity type `cellline` for mentions linked to Cellosaurus, to distinguish them from those linked to "CL", which are simple "cell types". 
