### PR TITLE
[FIX]: bioid: load annotations

### DIFF
--- a/bigbio/hub/hub_repos/bioid/bioid.py
+++ b/bigbio/hub/hub_repos/bioid/bioid.py
@@ -117,7 +117,6 @@ class BioidDataset(datasets.GeneratorBasedBuilder):
     }
 
     def _info(self) -> datasets.DatasetInfo:
-
         # Create the source schema; this schema will keep all keys/information/labels as close to the original dataset as possible.
         # You can arbitrarily nest lists and dictionaries.
         # For iterables, use lists over tuples or `datasets.Sequence`
@@ -205,15 +204,13 @@ class BioidDataset(datasets.GeneratorBasedBuilder):
         annotations: Dict[str, Dict] = {}
 
         for record in df.to_dict("records"):
-
             article_id = str(record["don_article"])
+            figure = str(record["figure"])
 
             if article_id not in annotations:
                 annotations[article_id] = {}
 
-            figure = record["figure"]
-
-            if figure not in annotations:
+            if figure not in annotations[article_id]:
                 annotations[article_id][figure] = []
 
             annotations[article_id][figure].append(record)
@@ -235,14 +232,13 @@ class BioidDataset(datasets.GeneratorBasedBuilder):
         data = []
 
         for file_name in os.listdir(text_dir):
-
+            # skip hidden files: what are they doing there anyway?
             if file_name.startswith(".") or not file_name.endswith(".xml"):
                 continue
 
             collection = bioc.load(os.path.join(text_dir, file_name))
 
             for document in collection.documents:
-
                 item = document.infons
 
                 assert (
@@ -325,11 +321,9 @@ class BioidDataset(datasets.GeneratorBasedBuilder):
                 yield uid, document
 
         elif self.config.schema == "bigbio_kb":
-
             uid = 0  # global unique id
 
             for document in data:
-
                 kb_document = {
                     "id": uid,
                     "document_id": document["pmc_id"],
@@ -354,7 +348,6 @@ class BioidDataset(datasets.GeneratorBasedBuilder):
                     uid += 1
 
                     for a in passage["annotations"]:
-
                         entity_type, normalized = self.get_entity(a["obj"])
 
                         kb_document["entities"].append(


### PR DESCRIPTION
This fixes loading data from `annotations.csv`.
Due to an error in creating a nested dictionary only the annotations for the last figure caption were loaded.

@davidkartchner since you [expressed intertest](https://github.com/bigscience-workshop/biomedical/issues/861) for this dataset, please make sure to use this updated version when it gets merged!

Hats off to @mariosaenger for catching this!

I tested correctness against `pmcid` 4772957 and `figure` Figure_1-G. 

```bash
$ cat > test.txt <<EOL 
 sdPaper1440,10.15252/emmm.201505613,4772957,Figure_1-G,5,51,138,143,5,6,,β-gal,,GO:0009341,,,
sdPaper1440,10.15252/emmm.201505613,4772957,Figure_1-G,11,62,428,431,3,3,,RPE,,Uberon:UBERON:0001782,,,
sdPaper1440,10.15252/emmm.201505613,4772957,Figure_1-G,2,45,43,49,6,6,,VEGF-A,,Uniprot:Q00731,,,
sdPaper1440,10.15252/emmm.201505613,4772957,Figure_1-G,12,63,433,459,26,26,,retinal pigment epithelium,,Uberon:UBERON:0001782,,,
sdPaper1440,10.15252/emmm.201505613,4772957,Figure_1-G,10,61,420,426,6,6,,retina,,Uberon:UBERON:0000966,,,
sdPaper1440,10.15252/emmm.201505613,4772957,Figure_1-G,9,57,224,229,5,5,,F4/80,,Uniprot:Q61549,,,
sdPaper1440,10.15252/emmm.201505613,4772957,Figure_1-G,6,52,151,157,6,6,,retina,,Uberon:UBERON:0000966,,,
sdPaper1440,10.15252/emmm.201505613,4772957,Figure_1-G,16,68,357,370,13,13,,retinal cells,,CL:0009004,,,
sdPaper1440,10.15252/emmm.201505613,4772957,Figure_1-G,3,47,51,56,5,6,,β-gal,,GO:0009341,,,
sdPaper1440,10.15252/emmm.201505613,4772957,Figure_1-G,14,65,492,511,19,19,,inner nuclear layer,,Uberon:UBERON:0001791,,,
sdPaper1440,10.15252/emmm.201505613,4772957,Figure_1-G,8,55,188,193,5,5,Ahyper,mouse,,NCBI taxon:10090,,,
sdPaper1440,10.15252/emmm.201505613,4772957,Figure_1-G,1,44,3,6,3,3,,RPE,,Uberon:UBERON:0001782,,,
sdPaper1440,10.15252/emmm.201505613,4772957,Figure_1-G,7,53,177,183,6,6,,VEGF-A,hypermouse,NCBI gene:22339,,,
sdPaper1440,10.15252/emmm.201505613,4772957,Figure_1-G,4,48,86,92,6,6,,retina,,Uberon:UBERON:0000966,,,
sdPaper1440,10.15252/emmm.201505613,4772957,Figure_1-G,15,67,378,397,19,19,,inner nuclear layer,,Uberon:UBERON:0001791,,,
sdPaper1440,10.15252/emmm.201505613,4772957,Figure_1-G,13,64,466,485,19,19,,outer nuclear layer,,Uberon:UBERON:0001789,,,
EOL
```

```bash
$ wc -l test.txt
16 test.txt
```

```python
from datasets import load_dataset
ds = load_dataset('./bigbio/hub/hub_repos/bioid/bioid.py', 'bioid_bigbio_kb')
figures_captions = [d for d in ds["train"] if d["document_id"] == "4772957"]
test_case = [f for f in figures_captions if f["passages"][0]["text"][0].startswith("G. RPE cells")][0]
assert len(test_case["entitities"])==16
```