### PR TITLE
Closes #887 - Bug in GGPONC loader

### DIFF
--- a/bigbio/hub/hub_repos/ggponc2/ggponc2.py
+++ b/bigbio/hub/hub_repos/ggponc2/ggponc2.py
@@ -21,7 +21,7 @@ import pandas as pd
 import datasets
 from .bigbiohub import kb_features
 from .bigbiohub import BigBioConfig
-from bigbio.utils.constants import Tasks
+from .bigbiohub import Tasks
 
 _LOCAL = True
 _CITATION = """\


### PR DESCRIPTION
Closes issue #887 that was preventing GGPONC2 from loading from the HuggingFace hub with `load_dataset("bigbio/ggponc2")`.
