### PR TITLE
Fixed link to BC5CDR dataset (Closes #909)

### DIFF
--- a/bigbio/hub/hub_repos/bc5cdr/bc5cdr.py
+++ b/bigbio/hub/hub_repos/bc5cdr/bc5cdr.py
@@ -72,13 +72,13 @@ text corpus of human annotations of all chemicals, diseases and their \
 interactions in 1,500 PubMed articles.
 """
 
-_HOMEPAGE = "http://www.biocreative.org/tasks/biocreative-v/track-3-cdr/"
+_HOMEPAGE = "https://biocreative.bioinformatics.udel.edu/tasks/biocreative-v/track-3-cdr/"
 
 _LICENSE = 'Public Domain Mark 1.0'
 
 _URLs = {
-    "source": "http://www.biocreative.org/media/store/files/2016/CDR_Data.zip",
-    "bigbio_kb": "http://www.biocreative.org/media/store/files/2016/CDR_Data.zip",
+    "source": "https://github.com/JHnlp/BioCreative-V-CDR-Corpus/raw/master/CDR_Data.zip",
+    "bigbio_kb": "https://github.com/JHnlp/BioCreative-V-CDR-Corpus/raw/master/CDR_Data.zip",
 }
 
 _SUPPORTED_TASKS = [


### PR DESCRIPTION


- **Dataset:** *BC5CDR*
- **Description of the problem:** *The links to the bc5cdr dataset are no longer valid.*
- **Data:** [official](https://biocreative.bioinformatics.udel.edu/tasks/biocreative-v/track-3-cdr/), [mirror](https://github.com/JHnlp/BioCreative-V-CDR-Corpus)

**Solution**
I change the links of the data to [this mirrored](https://github.com/JHnlp/BioCreative-V-CDR-Corpus) repository since the [new domain](https://biocreative.bioinformatics.udel.edu/tasks/biocreative-v/track-3-cdr/) of BioCreative seems to still have problems.


### Checkbox

- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `hub/hub_repos/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_BIGBIO_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `BigBioConfig` for the source schema and one for a bigbio schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_bigbio_hub <dataset_name> [--data_dir /path/to/local/data] --test_local`.
