### PR TITLE
Added 11b version of BioASQ to existing bioasq_task_b.py. Closes #925 and #924

### DIFF
--- a/bigbio/hub/hub_repos/bioasq_task_b/bioasq_task_b.py
+++ b/bigbio/hub/hub_repos/bioasq_task_b/bioasq_task_b.py
@@ -715,7 +715,7 @@ class BioasqTaskBDataset(datasets.GeneratorBasedBuilder):
             "bioasq_7b": "BioASQ-training7b/trainining7b.json",
             "bioasq_8b": "training8b.json",  # HACK - this zipfile strips the dirname
             "bioasq_9b": "BioASQ-training9b/training9b.json",
-            "bioasq_10b": "BioASQ-training10b/training10b.json",
+            "bioasq_10b": "training10b.json",
             "bioasq_11b": "BioASQ-training11b/training11b.json",
         }
 

--- a/bigbio/hub/hub_repos/bioasq_task_b/bioasq_task_b.py
+++ b/bigbio/hub/hub_repos/bioasq_task_b/bioasq_task_b.py
@@ -61,6 +61,24 @@ _CITATION = """\
 _DATASETNAME = "bioasq_task_b"
 _DISPLAYNAME = "BioASQ Task B"
 
+_BIOASQ_11B_DESCRIPTION = """\
+The data are intended to be used as training and development data for BioASQ
+11, which will take place during 2023. There is one file containing the data:
+ - training11b.json
+
+The file contains the data of the first ten editions of the challenge: 4719
+questions [1] with their relevant documents, snippets, concepts and RDF
+triples, exact and ideal answers.
+
+Differences with BioASQ-training10b.json 
+	- 485 new questions added from BioASQ10
+		- The question with id 621ecf1a3a8413c653000061 had identical body with
+		5ac0a36f19833b0d7b000002. All relevant elements from both questions
+		are available in the merged question with id 5ac0a36f19833b0d7b000002.
+		
+[1] The distribution of 4719 questions : 1417 factoid, 1271 yesno, 1130 summary, 901 list
+"""
+
 _BIOASQ_10B_DESCRIPTION = """\
 The data are intended to be used as training and development data for BioASQ
 10, which will take place during 2022. There is one file containing the data:
@@ -361,6 +379,7 @@ See 'Domain-Specific Language Model Pretraining for Biomedical
 Natural Language Processing' """
 
 _DESCRIPTION = {
+    "bioasq_11b": _BIOASQ_11B_DESCRIPTION,
     "bioasq_10b": _BIOASQ_10B_DESCRIPTION,
     "bioasq_9b": _BIOASQ_9B_DESCRIPTION,
     "bioasq_8b": _BIOASQ_8B_DESCRIPTION,
@@ -380,6 +399,7 @@ _HOMEPAGE = "http://participants-area.bioasq.org/datasets/"
 _LICENSE = "NLM_LICENSE"
 
 _URLs = {
+    "bioasq_11b": ["BioASQ-training11b.zip", "Task11BGoldenEnriched.zip"],
     "bioasq_10b": ["BioASQ-training10b.zip", "Task10BGoldenEnriched.zip"],
     "bioasq_9b": ["BioASQ-training9b.zip", "Task9BGoldenEnriched.zip"],
     "bioasq_8b": ["BioASQ-training8b.zip", "Task8BGoldenEnriched.zip"],
@@ -489,9 +509,9 @@ class BioasqTaskBDataset(datasets.GeneratorBasedBuilder):
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
 
-    # BioASQ2 through BioASQ10
+    # BioASQ2 through BioASQ11
     BUILDER_CONFIGS = []
-    for version in range(2, 11):
+    for version in range(2, 12):
         BUILDER_CONFIGS.append(
             BigBioConfig(
                 name=f"bioasq_{version}b_source",
@@ -696,6 +716,7 @@ class BioasqTaskBDataset(datasets.GeneratorBasedBuilder):
             "bioasq_8b": "training8b.json",  # HACK - this zipfile strips the dirname
             "bioasq_9b": "BioASQ-training9b/training9b.json",
             "bioasq_10b": "BioASQ-training10b/training10b.json",
+            "bioasq_11b": "BioASQ-training11b/training11b.json",
         }
 
         # BLURB has custom train/dev/test splits based on Task 7B


### PR DESCRIPTION
Please name your PR after the issue it closes. You can use the following line: "Closes #ISSUE-NUMBER" where you replace the ISSUE-NUMBER with the one corresponding to your dataset.

Closes Issues #925 and #924 

If the following information is NOT present in the issue, please populate:

- **Name:** *name of the dataset*
- **Description:** *short description of the dataset (or link to social media or blog post)*
- **Paper:** *link to the dataset paper if available*
- **Data:** *link to the online home of the dataset*

### Checkbox

- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `hub/hub_repos/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_BIGBIO_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `BigBioConfig` for the source schema and one for a bigbio schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_bigbio_hub <dataset_name> [--data_dir /path/to/local/data] --test_local`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.

Output of `python -m tests.test_bigbio_hub bioasq_task_b --data_dir /home/robert/Desktop/bioasq --test_local`:
[tests.test_bigbio_hub_bioasq_task_b.txt](https://github.com/user-attachments/files/16029694/tests.test_bigbio_hub_bioasq_task_b.txt)
