### PR TITLE
Closes #927

### DIFF
--- a/bigbio/biodatasets/drugprot/drugprot.py
+++ b/bigbio/biodatasets/drugprot/drugprot.py
@@ -22,7 +22,7 @@ https://biocreative.bioinformatics.udel.edu/tasks/biocreative-vii/track-1/
 """
 import collections
 from pathlib import Path
-from typing import Dict, Iterator, Tuple
+from typing import Dict, Iterator, Tuple, Optional
 
 import datasets
 
@@ -140,32 +140,44 @@ class DrugProtDataset(datasets.GeneratorBasedBuilder):
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
-                gen_kwargs={"data_dir": data_dir, "split": "training"},
+                gen_kwargs={
+                    "abstracts_file": data_dir / "training" / "drugprot_training_abstracs.tsv",
+                    "entities_file": data_dir / "training" / "drugprot_training_entities.tsv",
+                    "relations_file": data_dir / "training" / "drugprot_training_relations.tsv",
+                },
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.VALIDATION,
-                gen_kwargs={"data_dir": data_dir, "split": "development"},
+                gen_kwargs={
+                    "abstracts_file": data_dir / "development" / "drugprot_development_abstracs.tsv",
+                    "entities_file": data_dir / "development" / "drugprot_development_entities.tsv",
+                    "relations_file": data_dir / "development" / "drugprot_development_relations.tsv",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split("test_background"),
+                gen_kwargs={
+                    "abstracts_file": data_dir / "test-background" / "test_background_abstracts.tsv",
+                    "entities_file": data_dir / "test-background" / "test_background_entities.tsv",
+                    "relations_file": None,
+                },
             ),
         ]
 
-    def _generate_examples(self, data_dir: Path, split: str) -> Iterator[Tuple[str, Dict]]:
+    def _generate_examples(self, **kwargs) -> Iterator[Tuple[str, Dict]]:
         if self.config.name == "drugprot_source":
-            documents = self._read_source_examples(data_dir, split)
+            documents = self._read_source_examples(**kwargs)
             for document_id, document in documents.items():
                 yield document_id, document
 
         elif self.config.name == "drugprot_bigbio_kb":
-            documents = self._read_source_examples(data_dir, split)
+            documents = self._read_source_examples(**kwargs)
             for document_id, document in documents.items():
                 yield document_id, self._transform_source_to_kb(document)
 
-    def _read_source_examples(self, input_dir: Path, split: str) -> Dict:
+    def _read_source_examples(self, abstracts_file: Path, entities_file: Path, relations_file: Optional[Path]) -> Dict:
         """ """
-        split_dir = input_dir / split
-        abstracts_file = split_dir / f"drugprot_{split}_abstracs.tsv"
-        entities_file = split_dir / f"drugprot_{split}_entities.tsv"
-        relations_file = split_dir / f"drugprot_{split}_relations.tsv"
-
+        # Note: The split "test-background" does not contain any relations
         document_to_entities = collections.defaultdict(list)
         for line in entities_file.read_text().splitlines():
             columns = line.split("\t")
@@ -181,20 +193,22 @@ class DrugProtDataset(datasets.GeneratorBasedBuilder):
             )
 
         document_to_relations = collections.defaultdict(list)
-        for line in relations_file.read_text().splitlines():
-            columns = line.split("\t")
-            document_id = columns[0]
 
-            document_relations = document_to_relations[document_id]
+        if relations_file is not None:
+            for line in relations_file.read_text().splitlines():
+                columns = line.split("\t")
+                document_id = columns[0]
 
-            document_relations.append(
-                {
-                    "id": document_id + "_" + str(len(document_relations)),
-                    "type": columns[1],
-                    "arg1_id": document_id + "_" + columns[2][5:],
-                    "arg2_id": document_id + "_" + columns[3][5:],
-                }
-            )
+                document_relations = document_to_relations[document_id]
+
+                document_relations.append(
+                    {
+                        "id": document_id + "_" + str(len(document_relations)),
+                        "type": columns[1],
+                        "arg1_id": document_id + "_" + columns[2][5:],
+                        "arg2_id": document_id + "_" + columns[3][5:],
+                    }
+                )
 
         document_to_source = {}
         for line in abstracts_file.read_text().splitlines():

--- a/bigbio/biodatasets/drugprot/drugprot.py
+++ b/bigbio/biodatasets/drugprot/drugprot.py
@@ -22,7 +22,7 @@ https://biocreative.bioinformatics.udel.edu/tasks/biocreative-vii/track-1/
 """
 import collections
 from pathlib import Path
-from typing import Dict, Iterator, Tuple, Optional
+from typing import Dict, Iterator, Tuple
 
 import datasets
 
@@ -140,44 +140,32 @@ class DrugProtDataset(datasets.GeneratorBasedBuilder):
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
-                gen_kwargs={
-                    "abstracts_file": data_dir / "training" / "drugprot_training_abstracs.tsv",
-                    "entities_file": data_dir / "training" / "drugprot_training_entities.tsv",
-                    "relations_file": data_dir / "training" / "drugprot_training_relations.tsv",
-                },
+                gen_kwargs={"data_dir": data_dir, "split": "training"},
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.VALIDATION,
-                gen_kwargs={
-                    "abstracts_file": data_dir / "development" / "drugprot_development_abstracs.tsv",
-                    "entities_file": data_dir / "development" / "drugprot_development_entities.tsv",
-                    "relations_file": data_dir / "development" / "drugprot_development_relations.tsv",
-                },
-            ),
-            datasets.SplitGenerator(
-                name=datasets.Split("test_background"),
-                gen_kwargs={
-                    "abstracts_file": data_dir / "test-background" / "test_background_abstracts.tsv",
-                    "entities_file": data_dir / "test-background" / "test_background_entities.tsv",
-                    "relations_file": None,
-                },
+                gen_kwargs={"data_dir": data_dir, "split": "development"},
             ),
         ]
 
-    def _generate_examples(self, **kwargs) -> Iterator[Tuple[str, Dict]]:
+    def _generate_examples(self, data_dir: Path, split: str) -> Iterator[Tuple[str, Dict]]:
         if self.config.name == "drugprot_source":
-            documents = self._read_source_examples(**kwargs)
+            documents = self._read_source_examples(data_dir, split)
             for document_id, document in documents.items():
                 yield document_id, document
 
         elif self.config.name == "drugprot_bigbio_kb":
-            documents = self._read_source_examples(**kwargs)
+            documents = self._read_source_examples(data_dir, split)
             for document_id, document in documents.items():
                 yield document_id, self._transform_source_to_kb(document)
 
-    def _read_source_examples(self, abstracts_file: Path, entities_file: Path, relations_file: Optional[Path]) -> Dict:
+    def _read_source_examples(self, input_dir: Path, split: str) -> Dict:
         """ """
-        # Note: The split "test-background" does not contain any relations
+        split_dir = input_dir / split
+        abstracts_file = split_dir / f"drugprot_{split}_abstracs.tsv"
+        entities_file = split_dir / f"drugprot_{split}_entities.tsv"
+        relations_file = split_dir / f"drugprot_{split}_relations.tsv"
+
         document_to_entities = collections.defaultdict(list)
         for line in entities_file.read_text().splitlines():
             columns = line.split("\t")
@@ -193,22 +181,20 @@ class DrugProtDataset(datasets.GeneratorBasedBuilder):
             )
 
         document_to_relations = collections.defaultdict(list)
+        for line in relations_file.read_text().splitlines():
+            columns = line.split("\t")
+            document_id = columns[0]
 
-        if relations_file is not None:
-            for line in relations_file.read_text().splitlines():
-                columns = line.split("\t")
-                document_id = columns[0]
+            document_relations = document_to_relations[document_id]
 
-                document_relations = document_to_relations[document_id]
-
-                document_relations.append(
-                    {
-                        "id": document_id + "_" + str(len(document_relations)),
-                        "type": columns[1],
-                        "arg1_id": document_id + "_" + columns[2][5:],
-                        "arg2_id": document_id + "_" + columns[3][5:],
-                    }
-                )
+            document_relations.append(
+                {
+                    "id": document_id + "_" + str(len(document_relations)),
+                    "type": columns[1],
+                    "arg1_id": document_id + "_" + columns[2][5:],
+                    "arg2_id": document_id + "_" + columns[3][5:],
+                }
+            )
 
         document_to_source = {}
         for line in abstracts_file.read_text().splitlines():

--- a/bigbio/hub/hub_repos/drugprot/drugprot.py
+++ b/bigbio/hub/hub_repos/drugprot/drugprot.py
@@ -30,7 +30,7 @@ from .bigbiohub import kb_features
 from .bigbiohub import BigBioConfig
 from .bigbiohub import Tasks
 
-_LANGUAGES = ['English']
+_LANGUAGES = ["English"]
 _PUBMED = True
 _LOCAL = False
 _CITATION = """\
@@ -55,9 +55,11 @@ between them corresponding to a specific set of biologically relevant relation t
 
 _HOMEPAGE = "https://biocreative.bioinformatics.udel.edu/tasks/biocreative-vii/track-1/"
 
-_LICENSE = 'Creative Commons Attribution 4.0 International'
+_LICENSE = "CC_BY_4p0"
 
-_URLS = {_DATASETNAME: "https://zenodo.org/record/5119892/files/drugprot-training-development-test-background.zip?download=1"}
+_URLS = {
+    _DATASETNAME: "https://zenodo.org/record/5119892/files/drugprot-training-development-test-background.zip?download=1"
+}
 
 _SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
 


### PR DESCRIPTION

- **Name:** Drugprot
- **Description:** *https://biocreative.bioinformatics.udel.edu/tasks/biocreative-vii/track-1/*
- **Paper:** *https://biocreative.bioinformatics.udel.edu/media/store/files/2021/Track1_pos_1_BC7_overview.pdf*
- **Data:** *https://zenodo.org/record/5119892/files/drugprot-training-development-test-background.zip?download=1*

Current version of `drugprot.py` only includes splits _train_ and _validation_. For this reason, I adjusted the `drugprot.py` data loading script to also load the `test-background`split, as the .tsv files are already present in the data folder. Note that the `test-background` split does not have any relations.

See also HuggingFace pull request:
*https://huggingface.co/datasets/bigbio/drugprot/discussions/1/files*
