### PR TITLE
Implement CoNECo dataset

### DIFF
--- a/bigbio/hub/hub_repos/coneco/README.md
+++ b/bigbio/hub/hub_repos/coneco/README.md
@@ -31,15 +31,27 @@ Complex Named Entity Corpus (CoNECo) is an annotated corpus for NER and NEN of p
 ## Citation Information
 
 ```
-@article {Nastou2024.05.18.594800,
-	author = {Nastou, Katerina and Koutrouli, Mikaela and Pyysalo, Sampo and Jensen, Lars Juhl},
-	title = {CoNECo: A Corpus for Named Entity recognition and normalization of protein Complexes},
-	elocation-id = {2024.05.18.594800},
-	year = {2024},
-	doi = {10.1101/2024.05.18.594800},
-	publisher = {Cold Spring Harbor Laboratory},
-	URL = {https://www.biorxiv.org/content/early/2024/05/29/2024.05.18.594800},
-	eprint = {https://www.biorxiv.org/content/early/2024/05/29/2024.05.18.594800.full.pdf},
-	journal = {bioRxiv}
+@article{10.1093/bioadv/vbae116,
+    author = {Nastou, Katerina and Koutrouli, Mikaela and Pyysalo, Sampo and Jensen, Lars Juhl},
+    title = "{CoNECo: A Corpus for Named Entity Recognition and Normalization of Protein Complexes}",
+    journal = {Bioinformatics Advances},
+    pages = {vbae116},
+    year = {2024},
+    month = {08},
+    abstract = "{Despite significant progress in biomedical information extraction, there is a lack of resources \
+for Named Entity Recognition (NER) and Normalization (NEN) of protein-containing complexes. Current resources \
+inadequately address the recognition of protein-containing complex names across different organisms, underscoring \
+the crucial need for a dedicated corpus.We introduce the Complex Named Entity Corpus (CoNECo), an annotated \
+corpus for NER and NEN of complexes. CoNECo comprises 1,621 documents with 2,052 entities, 1,976 of which are \
+normalized to Gene Ontology. We divided the corpus into training, development, and test sets and trained both a \
+transformer-based and dictionary-based tagger on them. Evaluation on the test set demonstrated robust performance, \
+with F-scores of 73.7\\% and 61.2\\%, respectively. Subsequently, we applied the best taggers for comprehensive \
+tagging of the entire openly accessible biomedical literature.All resources, including the annotated corpus, \
+training data, and code, are available to the community through Zenodo https://zenodo.org/records/11263147 and \
+GitHub https://zenodo.org/records/10693653.}",
+    issn = {2635-0041},
+    doi = {10.1093/bioadv/vbae116},
+    url = {https://doi.org/10.1093/bioadv/vbae116},
+    eprint = {https://academic.oup.com/bioinformaticsadvances/advance-article-pdf/doi/10.1093/bioadv/vbae116/58869902/vbae116.pdf},
 }
 ```

--- a/bigbio/hub/hub_repos/coneco/README.md
+++ b/bigbio/hub/hub_repos/coneco/README.md
@@ -1,0 +1,45 @@
+---
+language:
+  - en
+bigbio_language:
+  - English
+license: cc-by-4.0
+bigbio_license_shortname: CC_BY_4p0
+multilinguality: monolingual
+pretty_name: CoNECo
+homepage: https://zenodo.org/records/11263147
+bigbio_pubmed: false
+bigbio_public: true
+bigbio_tasks:
+  - NAMED_ENTITY_RECOGNITION
+  - NAMED_ENTITY_DISAMBIGUATION
+paperswithcode_id: coneco
+---
+
+
+# Dataset Card for CoNECo
+
+## Dataset Description
+
+- **Homepage:** https://zenodo.org/records/11263147
+- **Pubmed:** False
+- **Public:** True
+- **Tasks:** NER, NEN
+
+Complex Named Entity Corpus (CoNECo) is an annotated corpus for NER and NEN of protein-containing complexes. CoNECo comprises 1,621 documents with 2,052 entities, 1,976 of which are normalized to Gene Ontology. We divided the corpus into training, development, and test sets.
+
+## Citation Information
+
+```
+@article {Nastou2024.05.18.594800,
+	author = {Nastou, Katerina and Koutrouli, Mikaela and Pyysalo, Sampo and Jensen, Lars Juhl},
+	title = {CoNECo: A Corpus for Named Entity recognition and normalization of protein Complexes},
+	elocation-id = {2024.05.18.594800},
+	year = {2024},
+	doi = {10.1101/2024.05.18.594800},
+	publisher = {Cold Spring Harbor Laboratory},
+	URL = {https://www.biorxiv.org/content/early/2024/05/29/2024.05.18.594800},
+	eprint = {https://www.biorxiv.org/content/early/2024/05/29/2024.05.18.594800.full.pdf},
+	journal = {bioRxiv}
+}
+```

--- a/bigbio/hub/hub_repos/coneco/bigbiohub.py
+++ b/bigbio/hub/hub_repos/coneco/bigbiohub.py
@@ -1,0 +1,591 @@
+from collections import defaultdict
+from dataclasses import dataclass
+from enum import Enum
+import logging
+from pathlib import Path
+import re
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Dict, Iterable, List, Tuple
+
+import datasets
+
+if TYPE_CHECKING:
+    import bioc
+
+logger = logging.getLogger(__name__)
+
+
+BigBioValues = SimpleNamespace(NULL="<BB_NULL_STR>")
+
+
+@dataclass
+class BigBioConfig(datasets.BuilderConfig):
+    """BuilderConfig for BigBio."""
+
+    name: str = None
+    version: datasets.Version = None
+    description: str = None
+    schema: str = None
+    subset_id: str = None
+
+
+class Tasks(Enum):
+    NAMED_ENTITY_RECOGNITION = "NER"
+    NAMED_ENTITY_DISAMBIGUATION = "NED"
+    EVENT_EXTRACTION = "EE"
+    RELATION_EXTRACTION = "RE"
+    COREFERENCE_RESOLUTION = "COREF"
+    QUESTION_ANSWERING = "QA"
+    TEXTUAL_ENTAILMENT = "TE"
+    SEMANTIC_SIMILARITY = "STS"
+    TEXT_PAIRS_CLASSIFICATION = "TXT2CLASS"
+    PARAPHRASING = "PARA"
+    TRANSLATION = "TRANSL"
+    SUMMARIZATION = "SUM"
+    TEXT_CLASSIFICATION = "TXTCLASS"
+
+
+entailment_features = datasets.Features(
+    {
+        "id": datasets.Value("string"),
+        "premise": datasets.Value("string"),
+        "hypothesis": datasets.Value("string"),
+        "label": datasets.Value("string"),
+    }
+)
+
+pairs_features = datasets.Features(
+    {
+        "id": datasets.Value("string"),
+        "document_id": datasets.Value("string"),
+        "text_1": datasets.Value("string"),
+        "text_2": datasets.Value("string"),
+        "label": datasets.Value("string"),
+    }
+)
+
+qa_features = datasets.Features(
+    {
+        "id": datasets.Value("string"),
+        "question_id": datasets.Value("string"),
+        "document_id": datasets.Value("string"),
+        "question": datasets.Value("string"),
+        "type": datasets.Value("string"),
+        "choices": [datasets.Value("string")],
+        "context": datasets.Value("string"),
+        "answer": datasets.Sequence(datasets.Value("string")),
+    }
+)
+
+text_features = datasets.Features(
+    {
+        "id": datasets.Value("string"),
+        "document_id": datasets.Value("string"),
+        "text": datasets.Value("string"),
+        "labels": [datasets.Value("string")],
+    }
+)
+
+text2text_features = datasets.Features(
+    {
+        "id": datasets.Value("string"),
+        "document_id": datasets.Value("string"),
+        "text_1": datasets.Value("string"),
+        "text_2": datasets.Value("string"),
+        "text_1_name": datasets.Value("string"),
+        "text_2_name": datasets.Value("string"),
+    }
+)
+
+kb_features = datasets.Features(
+    {
+        "id": datasets.Value("string"),
+        "document_id": datasets.Value("string"),
+        "passages": [
+            {
+                "id": datasets.Value("string"),
+                "type": datasets.Value("string"),
+                "text": datasets.Sequence(datasets.Value("string")),
+                "offsets": datasets.Sequence([datasets.Value("int32")]),
+            }
+        ],
+        "entities": [
+            {
+                "id": datasets.Value("string"),
+                "type": datasets.Value("string"),
+                "text": datasets.Sequence(datasets.Value("string")),
+                "offsets": datasets.Sequence([datasets.Value("int32")]),
+                "normalized": [
+                    {
+                        "db_name": datasets.Value("string"),
+                        "db_id": datasets.Value("string"),
+                    }
+                ],
+            }
+        ],
+        "events": [
+            {
+                "id": datasets.Value("string"),
+                "type": datasets.Value("string"),
+                # refers to the text_bound_annotation of the trigger
+                "trigger": {
+                    "text": datasets.Sequence(datasets.Value("string")),
+                    "offsets": datasets.Sequence([datasets.Value("int32")]),
+                },
+                "arguments": [
+                    {
+                        "role": datasets.Value("string"),
+                        "ref_id": datasets.Value("string"),
+                    }
+                ],
+            }
+        ],
+        "coreferences": [
+            {
+                "id": datasets.Value("string"),
+                "entity_ids": datasets.Sequence(datasets.Value("string")),
+            }
+        ],
+        "relations": [
+            {
+                "id": datasets.Value("string"),
+                "type": datasets.Value("string"),
+                "arg1_id": datasets.Value("string"),
+                "arg2_id": datasets.Value("string"),
+                "normalized": [
+                    {
+                        "db_name": datasets.Value("string"),
+                        "db_id": datasets.Value("string"),
+                    }
+                ],
+            }
+        ],
+    }
+)
+
+
+TASK_TO_SCHEMA = {
+    Tasks.NAMED_ENTITY_RECOGNITION.name: "KB",
+    Tasks.NAMED_ENTITY_DISAMBIGUATION.name: "KB",
+    Tasks.EVENT_EXTRACTION.name: "KB",
+    Tasks.RELATION_EXTRACTION.name: "KB",
+    Tasks.COREFERENCE_RESOLUTION.name: "KB",
+    Tasks.QUESTION_ANSWERING.name: "QA",
+    Tasks.TEXTUAL_ENTAILMENT.name: "TE",
+    Tasks.SEMANTIC_SIMILARITY.name: "PAIRS",
+    Tasks.TEXT_PAIRS_CLASSIFICATION.name: "PAIRS",
+    Tasks.PARAPHRASING.name: "T2T",
+    Tasks.TRANSLATION.name: "T2T",
+    Tasks.SUMMARIZATION.name: "T2T",
+    Tasks.TEXT_CLASSIFICATION.name: "TEXT",
+}
+
+SCHEMA_TO_TASKS = defaultdict(set)
+for task, schema in TASK_TO_SCHEMA.items():
+    SCHEMA_TO_TASKS[schema].add(task)
+SCHEMA_TO_TASKS = dict(SCHEMA_TO_TASKS)
+
+VALID_TASKS = set(TASK_TO_SCHEMA.keys())
+VALID_SCHEMAS = set(TASK_TO_SCHEMA.values())
+
+SCHEMA_TO_FEATURES = {
+    "KB": kb_features,
+    "QA": qa_features,
+    "TE": entailment_features,
+    "T2T": text2text_features,
+    "TEXT": text_features,
+    "PAIRS": pairs_features,
+}
+
+
+def get_texts_and_offsets_from_bioc_ann(ann: "bioc.BioCAnnotation") -> Tuple:
+
+    offsets = [(loc.offset, loc.offset + loc.length) for loc in ann.locations]
+
+    text = ann.text
+
+    if len(offsets) > 1:
+        i = 0
+        texts = []
+        for start, end in offsets:
+            chunk_len = end - start
+            texts.append(text[i : chunk_len + i])
+            i += chunk_len
+            while i < len(text) and text[i] == " ":
+                i += 1
+    else:
+        texts = [text]
+
+    return offsets, texts
+
+
+def remove_prefix(a: str, prefix: str) -> str:
+    if a.startswith(prefix):
+        a = a[len(prefix) :]
+    return a
+
+
+def parse_brat_file(
+    txt_file: Path,
+    annotation_file_suffixes: List[str] = None,
+    parse_notes: bool = False,
+) -> Dict:
+    """
+    Parse a brat file into the schema defined below.
+    `txt_file` should be the path to the brat '.txt' file you want to parse, e.g. 'data/1234.txt'
+    Assumes that the annotations are contained in one or more of the corresponding '.a1', '.a2' or '.ann' files,
+    e.g. 'data/1234.ann' or 'data/1234.a1' and 'data/1234.a2'.
+    Will include annotator notes, when `parse_notes == True`.
+    brat_features = datasets.Features(
+        {
+            "id": datasets.Value("string"),
+            "document_id": datasets.Value("string"),
+            "text": datasets.Value("string"),
+            "text_bound_annotations": [  # T line in brat, e.g. type or event trigger
+                {
+                    "offsets": datasets.Sequence([datasets.Value("int32")]),
+                    "text": datasets.Sequence(datasets.Value("string")),
+                    "type": datasets.Value("string"),
+                    "id": datasets.Value("string"),
+                }
+            ],
+            "events": [  # E line in brat
+                {
+                    "trigger": datasets.Value(
+                        "string"
+                    ),  # refers to the text_bound_annotation of the trigger,
+                    "id": datasets.Value("string"),
+                    "type": datasets.Value("string"),
+                    "arguments": datasets.Sequence(
+                        {
+                            "role": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                        }
+                    ),
+                }
+            ],
+            "relations": [  # R line in brat
+                {
+                    "id": datasets.Value("string"),
+                    "head": {
+                        "ref_id": datasets.Value("string"),
+                        "role": datasets.Value("string"),
+                    },
+                    "tail": {
+                        "ref_id": datasets.Value("string"),
+                        "role": datasets.Value("string"),
+                    },
+                    "type": datasets.Value("string"),
+                }
+            ],
+            "equivalences": [  # Equiv line in brat
+                {
+                    "id": datasets.Value("string"),
+                    "ref_ids": datasets.Sequence(datasets.Value("string")),
+                }
+            ],
+            "attributes": [  # M or A lines in brat
+                {
+                    "id": datasets.Value("string"),
+                    "type": datasets.Value("string"),
+                    "ref_id": datasets.Value("string"),
+                    "value": datasets.Value("string"),
+                }
+            ],
+            "normalizations": [  # N lines in brat
+                {
+                    "id": datasets.Value("string"),
+                    "type": datasets.Value("string"),
+                    "ref_id": datasets.Value("string"),
+                    "resource_name": datasets.Value(
+                        "string"
+                    ),  # Name of the resource, e.g. "Wikipedia"
+                    "cuid": datasets.Value(
+                        "string"
+                    ),  # ID in the resource, e.g. 534366
+                    "text": datasets.Value(
+                        "string"
+                    ),  # Human readable description/name of the entity, e.g. "Barack Obama"
+                }
+            ],
+            ### OPTIONAL: Only included when `parse_notes == True`
+            "notes": [  # # lines in brat
+                {
+                    "id": datasets.Value("string"),
+                    "type": datasets.Value("string"),
+                    "ref_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                }
+            ],
+        },
+        )
+    """
+
+    example = {}
+    example["document_id"] = txt_file.with_suffix("").name
+    with txt_file.open() as f:
+        example["text"] = f.read()
+
+    # If no specific suffixes of the to-be-read annotation files are given - take standard suffixes
+    # for event extraction
+    if annotation_file_suffixes is None:
+        annotation_file_suffixes = [".a1", ".a2", ".ann"]
+
+    if len(annotation_file_suffixes) == 0:
+        raise AssertionError(
+            "At least one suffix for the to-be-read annotation files should be given!"
+        )
+
+    ann_lines = []
+    for suffix in annotation_file_suffixes:
+        annotation_file = txt_file.with_suffix(suffix)
+        if annotation_file.exists():
+            with annotation_file.open() as f:
+                ann_lines.extend(f.readlines())
+
+    example["text_bound_annotations"] = []
+    example["events"] = []
+    example["relations"] = []
+    example["equivalences"] = []
+    example["attributes"] = []
+    example["normalizations"] = []
+
+    if parse_notes:
+        example["notes"] = []
+
+    for line in ann_lines:
+        line = line.strip()
+        if not line:
+            continue
+
+        if line.startswith("T"):  # Text bound
+            ann = {}
+            fields = re.split(r"\t+", line)
+
+            ann["id"] = fields[0]
+            ann["type"] = fields[1].split()[0]
+            ann["offsets"] = []
+            span_str = remove_prefix(fields[1], (ann["type"] + " "))
+            text = fields[2]
+            for span in span_str.split(";"):
+                start, end = span.split()
+                ann["offsets"].append([int(start), int(end)])
+
+            # Heuristically split text of discontiguous entities into chunks
+            ann["text"] = []
+            if len(ann["offsets"]) > 1:
+                i = 0
+                for start, end in ann["offsets"]:
+                    chunk_len = end - start
+                    ann["text"].append(text[i : chunk_len + i])
+                    i += chunk_len
+                    while i < len(text) and text[i] == " ":
+                        i += 1
+            else:
+                ann["text"] = [text]
+
+            example["text_bound_annotations"].append(ann)
+
+        elif line.startswith("E"):
+            ann = {}
+            fields = re.split(r"\t+", line)
+
+            ann["id"] = fields[0]
+
+            ann["type"], ann["trigger"] = fields[1].split()[0].split(":")
+
+            ann["arguments"] = []
+            for role_ref_id in fields[1].split()[1:]:
+                argument = {
+                    "role": (role_ref_id.split(":"))[0],
+                    "ref_id": (role_ref_id.split(":"))[1],
+                }
+                ann["arguments"].append(argument)
+
+            example["events"].append(ann)
+
+        elif line.startswith("R"):
+            ann = {}
+            fields = re.split(r"\t+", line)
+
+            ann["id"] = fields[0]
+            ann["type"] = fields[1].split()[0]
+
+            ann["head"] = {
+                "role": fields[1].split()[1].split(":")[0],
+                "ref_id": fields[1].split()[1].split(":")[1],
+            }
+            ann["tail"] = {
+                "role": fields[1].split()[2].split(":")[0],
+                "ref_id": fields[1].split()[2].split(":")[1],
+            }
+
+            example["relations"].append(ann)
+
+        # '*' seems to be the legacy way to mark equivalences,
+        # but I couldn't find any info on the current way
+        # this might have to be adapted dependent on the brat version
+        # of the annotation
+        elif line.startswith("*"):
+            ann = {}
+            fields = re.split(r"\t+", line)
+
+            ann["id"] = fields[0]
+            ann["ref_ids"] = fields[1].split()[1:]
+
+            example["equivalences"].append(ann)
+
+        elif line.startswith("A") or line.startswith("M"):
+            ann = {}
+            fields = re.split(r"\t+", line)
+
+            ann["id"] = fields[0]
+
+            info = fields[1].split()
+            ann["type"] = info[0]
+            ann["ref_id"] = info[1]
+
+            if len(info) > 2:
+                ann["value"] = info[2]
+            else:
+                ann["value"] = ""
+
+            example["attributes"].append(ann)
+
+        elif line.startswith("N"):
+            ann = {}
+            fields = re.split(r"\t+", line)
+
+            ann["id"] = fields[0]
+            ann["text"] = fields[2] if len(fields) == 3 else BigBioValues.NULL
+
+            info = fields[1].split()
+
+            ann["type"] = info[0]
+            ann["ref_id"] = info[1]
+            ann["resource_name"] = info[2].split(":")[0]
+            ann["cuid"] = info[2].split(":")[1]
+            example["normalizations"].append(ann)
+
+        elif parse_notes and line.startswith("#"):
+            ann = {}
+            fields = re.split(r"\t+", line)
+
+            ann["id"] = fields[0]
+            ann["text"] = fields[2] if len(fields) == 3 else BigBioValues.NULL
+
+            info = fields[1].split()
+
+            ann["type"] = info[0]
+            ann["ref_id"] = info[1]
+            example["notes"].append(ann)
+
+    return example
+
+
+def brat_parse_to_bigbio_kb(brat_parse: Dict) -> Dict:
+    """
+    Transform a brat parse (conforming to the standard brat schema) obtained with
+    `parse_brat_file` into a dictionary conforming to the `bigbio-kb` schema (as defined in ../schemas/kb.py)
+    :param brat_parse:
+    """
+
+    unified_example = {}
+
+    # Prefix all ids with document id to ensure global uniqueness,
+    # because brat ids are only unique within their document
+    id_prefix = brat_parse["document_id"] + "_"
+
+    # identical
+    unified_example["document_id"] = brat_parse["document_id"]
+    unified_example["passages"] = [
+        {
+            "id": id_prefix + "_text",
+            "type": "abstract",
+            "text": [brat_parse["text"]],
+            "offsets": [[0, len(brat_parse["text"])]],
+        }
+    ]
+
+    # get normalizations
+    ref_id_to_normalizations = defaultdict(list)
+    for normalization in brat_parse["normalizations"]:
+        ref_id_to_normalizations[normalization["ref_id"]].append(
+            {
+                "db_name": normalization["resource_name"],
+                "db_id": normalization["cuid"],
+            }
+        )
+
+    # separate entities and event triggers
+    unified_example["events"] = []
+    non_event_ann = brat_parse["text_bound_annotations"].copy()
+    for event in brat_parse["events"]:
+        event = event.copy()
+        event["id"] = id_prefix + event["id"]
+        trigger = next(
+            tr
+            for tr in brat_parse["text_bound_annotations"]
+            if tr["id"] == event["trigger"]
+        )
+        if trigger in non_event_ann:
+            non_event_ann.remove(trigger)
+        event["trigger"] = {
+            "text": trigger["text"].copy(),
+            "offsets": trigger["offsets"].copy(),
+        }
+        for argument in event["arguments"]:
+            argument["ref_id"] = id_prefix + argument["ref_id"]
+
+        unified_example["events"].append(event)
+
+    unified_example["entities"] = []
+    anno_ids = [ref_id["id"] for ref_id in non_event_ann]
+    for ann in non_event_ann:
+        entity_ann = ann.copy()
+        entity_ann["id"] = id_prefix + entity_ann["id"]
+        entity_ann["normalized"] = ref_id_to_normalizations[ann["id"]]
+        unified_example["entities"].append(entity_ann)
+
+    # massage relations
+    unified_example["relations"] = []
+    skipped_relations = set()
+    for ann in brat_parse["relations"]:
+        if (
+            ann["head"]["ref_id"] not in anno_ids
+            or ann["tail"]["ref_id"] not in anno_ids
+        ):
+            skipped_relations.add(ann["id"])
+            continue
+        unified_example["relations"].append(
+            {
+                "arg1_id": id_prefix + ann["head"]["ref_id"],
+                "arg2_id": id_prefix + ann["tail"]["ref_id"],
+                "id": id_prefix + ann["id"],
+                "type": ann["type"],
+                "normalized": [],
+            }
+        )
+    if len(skipped_relations) > 0:
+        example_id = brat_parse["document_id"]
+        logger.info(
+            f"Example:{example_id}: The `bigbio_kb` schema allows `relations` only between entities."
+            f" Skip (for now): "
+            f"{list(skipped_relations)}"
+        )
+
+    # get coreferences
+    unified_example["coreferences"] = []
+    for i, ann in enumerate(brat_parse["equivalences"], start=1):
+        is_entity_cluster = True
+        for ref_id in ann["ref_ids"]:
+            if not ref_id.startswith("T"):  # not textbound -> no entity
+                is_entity_cluster = False
+            elif ref_id not in anno_ids:  # event trigger -> no entity
+                is_entity_cluster = False
+        if is_entity_cluster:
+            entity_ids = [id_prefix + i for i in ann["ref_ids"]]
+            unified_example["coreferences"].append(
+                {"id": id_prefix + str(i), "entity_ids": entity_ids}
+            )
+    return unified_example

--- a/bigbio/hub/hub_repos/coneco/coneco.py
+++ b/bigbio/hub/hub_repos/coneco/coneco.py
@@ -16,7 +16,9 @@
 """
 A dataset loading script for the Complex Named Entity Corpus (CoNECo.)
 
-CoNECo is an annotated corpus for NER and NEN of protein-containing complexes. CoNECo comprises 1,621 documents with 2,052 entities, 1,976 of which are normalized to Gene Ontology. We divided the corpus into training, development, and test sets.
+CoNECo is an annotated corpus for NER and NEN of protein-containing complexes. \
+CoNECo comprises 1,621 documents with 2,052 entities, 1,976 of which are normalized \
+to Gene Ontology. We divided the corpus into training, development, and test sets.
 """
 
 from pathlib import Path
@@ -26,26 +28,21 @@ import datasets
 
 from bigbio.utils.license import Licenses
 
-from .bigbiohub import (
-    BigBioConfig,
-    Tasks,
-    brat_parse_to_bigbio_kb,
-    kb_features,
-    parse_brat_file,
-)
+from .bigbiohub import (BigBioConfig, Tasks, brat_parse_to_bigbio_kb,
+                        kb_features, parse_brat_file)
 
 _LOCAL = False
 _CITATION = """\
 @article {Nastou2024.05.18.594800,
-	author = {Nastou, Katerina and Koutrouli, Mikaela and Pyysalo, Sampo and Jensen, Lars Juhl},
-	title = {CoNECo: A Corpus for Named Entity recognition and normalization of protein Complexes},
-	elocation-id = {2024.05.18.594800},
-	year = {2024},
-	doi = {10.1101/2024.05.18.594800},
-	publisher = {Cold Spring Harbor Laboratory},
-	URL = {https://www.biorxiv.org/content/early/2024/05/29/2024.05.18.594800},
-	eprint = {https://www.biorxiv.org/content/early/2024/05/29/2024.05.18.594800.full.pdf},
-	journal = {bioRxiv}
+    author = {Nastou, Katerina and Koutrouli, Mikaela and Pyysalo, Sampo and Jensen, Lars Juhl},
+    title = {CoNECo: A Corpus for Named Entity recognition and normalization of protein Complexes},
+    elocation-id = {2024.05.18.594800},
+    year = {2024},
+    doi = {10.1101/2024.05.18.594800},
+    publisher = {Cold Spring Harbor Laboratory},
+    URL = {https://www.biorxiv.org/content/early/2024/05/29/2024.05.18.594800},
+    eprint = {https://www.biorxiv.org/content/early/2024/05/29/2024.05.18.594800.full.pdf},
+    journal = {bioRxiv}
 }
 """
 
@@ -53,7 +50,9 @@ _DATASETNAME = "coneco"
 _DISPLAYNAME = "CoNECo"
 
 _DESCRIPTION = """\
-Complex Named Entity Corpus (CoNECo) is an annotated corpus for NER and NEN of protein-containing complexes. CoNECo comprises 1,621 documents with 2,052 entities, 1,976 of which are normalized to Gene Ontology. We divided the corpus into training, development, and test sets.
+Complex Named Entity Corpus (CoNECo) is an annotated corpus for NER and NEN of protein-containing complexes. \
+CoNECo comprises 1,621 documents with 2,052 entities, 1,976 of which are normalized to Gene Ontology. We \
+divided the corpus into training, development, and test sets.
 """
 
 _HOMEPAGE = "https://zenodo.org/records/11263147"
@@ -100,7 +99,6 @@ class ConecoDataset(datasets.GeneratorBasedBuilder):
     DEFAULT_CONFIG_NAME = "coneco_source"
 
     def _info(self) -> datasets.DatasetInfo:
-
         if self.config.schema == "source":
             features = datasets.Features(
                 {

--- a/bigbio/hub/hub_repos/coneco/coneco.py
+++ b/bigbio/hub/hub_repos/coneco/coneco.py
@@ -1,0 +1,191 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A dataset loading script for the Complex Named Entity Corpus (CoNECo.)
+
+CoNECo is an annotated corpus for NER and NEN of protein-containing complexes. CoNECo comprises 1,621 documents with 2,052 entities, 1,976 of which are normalized to Gene Ontology. We divided the corpus into training, development, and test sets.
+"""
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from bigbio.utils.license import Licenses
+
+from .bigbiohub import (
+    BigBioConfig,
+    Tasks,
+    brat_parse_to_bigbio_kb,
+    kb_features,
+    parse_brat_file,
+)
+
+_LOCAL = False
+_CITATION = """\
+@article {Nastou2024.05.18.594800,
+	author = {Nastou, Katerina and Koutrouli, Mikaela and Pyysalo, Sampo and Jensen, Lars Juhl},
+	title = {CoNECo: A Corpus for Named Entity recognition and normalization of protein Complexes},
+	elocation-id = {2024.05.18.594800},
+	year = {2024},
+	doi = {10.1101/2024.05.18.594800},
+	publisher = {Cold Spring Harbor Laboratory},
+	URL = {https://www.biorxiv.org/content/early/2024/05/29/2024.05.18.594800},
+	eprint = {https://www.biorxiv.org/content/early/2024/05/29/2024.05.18.594800.full.pdf},
+	journal = {bioRxiv}
+}
+"""
+
+_DATASETNAME = "coneco"
+_DISPLAYNAME = "CoNECo"
+
+_DESCRIPTION = """\
+Complex Named Entity Corpus (CoNECo) is an annotated corpus for NER and NEN of protein-containing complexes. CoNECo comprises 1,621 documents with 2,052 entities, 1,976 of which are normalized to Gene Ontology. We divided the corpus into training, development, and test sets.
+"""
+
+_HOMEPAGE = "https://zenodo.org/records/11263147"
+
+_LICENSE = Licenses.CC_BY_4p0
+
+_URLS = {
+    _DATASETNAME: "https://zenodo.org/records/11263147/files/CoNECo_corpus.tar.gz?download=1",
+}
+
+_SUPPORTED_TASKS = [
+    Tasks.NAMED_ENTITY_RECOGNITION,
+    Tasks.NAMED_ENTITY_DISAMBIGUATION,
+]
+
+_SOURCE_VERSION = "2.0.0"
+
+_BIGBIO_VERSION = "1.0.0"
+
+
+class ConecoDataset(datasets.GeneratorBasedBuilder):
+    """TODO: Short description of my dataset."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    BIGBIO_VERSION = datasets.Version(_BIGBIO_VERSION)
+
+    BUILDER_CONFIGS = [
+        BigBioConfig(
+            name="coneco_source",
+            version=SOURCE_VERSION,
+            description="coneco source schema",
+            schema="source",
+            subset_id="coneco",
+        ),
+        BigBioConfig(
+            name="coneco_bigbio_kb",
+            version=BIGBIO_VERSION,
+            description="coneco BigBio schema",
+            schema="bigbio_kb",
+            subset_id="coneco",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "coneco_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "document_id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "text_bound_annotations": [  # T line in brat, i.e. entities for NER task
+                        {
+                            "offsets": datasets.Sequence([datasets.Value("int32")]),
+                            "text": datasets.Sequence(datasets.Value("string")),
+                            "type": datasets.Value("string"),
+                            "id": datasets.Value("string"),
+                        }
+                    ],
+                    "normalizations": [  # N lines in brat, i.e. normalization for NEN task
+                        {
+                            "id": datasets.Value("string"),
+                            "type": datasets.Value("string"),
+                            "ref_id": datasets.Value("string"),
+                            "resource_name": datasets.Value("string"),
+                            "cuid": datasets.Value("string"),
+                            "text": datasets.Value("string"),
+                        }
+                    ],
+                }
+            )
+        elif self.config.schema == "bigbio_kb":
+            features = kb_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=str(_LICENSE),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        urls = _URLS[_DATASETNAME]
+        data_dir = Path(dl_manager.download_and_extract(urls))
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": data_dir / "train",
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": data_dir / "test",
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": data_dir / "dev",
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        if self.config.schema == "source":
+            for file in filepath.iterdir():
+                if file.suffix != ".txt":
+                    continue
+                brat_parsed = parse_brat_file(file)
+                brat_parsed["id"] = file.stem
+
+                yield brat_parsed["document_id"], brat_parsed
+
+        elif self.config.schema == "bigbio_kb":
+            for file in filepath.iterdir():
+                if file.suffix != ".txt":
+                    continue
+                brat_parsed = parse_brat_file(file)
+                bigbio_kb_example = brat_parse_to_bigbio_kb(brat_parsed)
+                bigbio_kb_example["id"] = file.stem
+
+                yield bigbio_kb_example["id"], bigbio_kb_example

--- a/bigbio/hub/hub_repos/coneco/coneco.py
+++ b/bigbio/hub/hub_repos/coneco/coneco.py
@@ -26,12 +26,10 @@ from typing import Dict, List, Tuple
 
 import datasets
 
-from bigbio.utils.license import Licenses
-
 from .bigbiohub import (BigBioConfig, Tasks, brat_parse_to_bigbio_kb,
                         kb_features, parse_brat_file)
 
-_LANGUAGES = ['English']
+_LANGUAGES = ["English"]
 _PUBMED = False
 _LOCAL = False
 _CITATION = """\
@@ -56,7 +54,8 @@ GitHub https://zenodo.org/records/10693653.}",
     issn = {2635-0041},
     doi = {10.1093/bioadv/vbae116},
     url = {https://doi.org/10.1093/bioadv/vbae116},
-    eprint = {https://academic.oup.com/bioinformaticsadvances/advance-article-pdf/doi/10.1093/bioadv/vbae116/58869902/vbae116.pdf},
+    eprint = {https://academic.oup.com/bioinformaticsadvances/advance-article-pdf/doi/10.1093/bioadv/vbae116/\
+58869902/vbae116.pdf},
 }
 """
 

--- a/bigbio/hub/hub_repos/coneco/coneco.py
+++ b/bigbio/hub/hub_repos/coneco/coneco.py
@@ -71,7 +71,7 @@ divided the corpus into training, development, and test sets.
 
 _HOMEPAGE = "https://zenodo.org/records/11263147"
 
-_LICENSE = "Creative Commons Attribution 4.0 International"
+_LICENSE = "CC_BY_4p0"
 
 _URLS = {
     _DATASETNAME: "https://zenodo.org/records/11263147/files/CoNECo_corpus.tar.gz?download=1",

--- a/bigbio/hub/hub_repos/coneco/coneco.py
+++ b/bigbio/hub/hub_repos/coneco/coneco.py
@@ -31,18 +31,32 @@ from bigbio.utils.license import Licenses
 from .bigbiohub import (BigBioConfig, Tasks, brat_parse_to_bigbio_kb,
                         kb_features, parse_brat_file)
 
+_LANGUAGES = ['English']
+_PUBMED = False
 _LOCAL = False
 _CITATION = """\
-@article {Nastou2024.05.18.594800,
+@article{10.1093/bioadv/vbae116,
     author = {Nastou, Katerina and Koutrouli, Mikaela and Pyysalo, Sampo and Jensen, Lars Juhl},
-    title = {CoNECo: A Corpus for Named Entity recognition and normalization of protein Complexes},
-    elocation-id = {2024.05.18.594800},
+    title = "{CoNECo: A Corpus for Named Entity Recognition and Normalization of Protein Complexes}",
+    journal = {Bioinformatics Advances},
+    pages = {vbae116},
     year = {2024},
-    doi = {10.1101/2024.05.18.594800},
-    publisher = {Cold Spring Harbor Laboratory},
-    URL = {https://www.biorxiv.org/content/early/2024/05/29/2024.05.18.594800},
-    eprint = {https://www.biorxiv.org/content/early/2024/05/29/2024.05.18.594800.full.pdf},
-    journal = {bioRxiv}
+    month = {08},
+    abstract = "{Despite significant progress in biomedical information extraction, there is a lack of resources \
+for Named Entity Recognition (NER) and Normalization (NEN) of protein-containing complexes. Current resources \
+inadequately address the recognition of protein-containing complex names across different organisms, underscoring \
+the crucial need for a dedicated corpus.We introduce the Complex Named Entity Corpus (CoNECo), an annotated \
+corpus for NER and NEN of complexes. CoNECo comprises 1,621 documents with 2,052 entities, 1,976 of which are \
+normalized to Gene Ontology. We divided the corpus into training, development, and test sets and trained both a \
+transformer-based and dictionary-based tagger on them. Evaluation on the test set demonstrated robust performance, \
+with F-scores of 73.7\\% and 61.2\\%, respectively. Subsequently, we applied the best taggers for comprehensive \
+tagging of the entire openly accessible biomedical literature.All resources, including the annotated corpus, \
+training data, and code, are available to the community through Zenodo https://zenodo.org/records/11263147 and \
+GitHub https://zenodo.org/records/10693653.}",
+    issn = {2635-0041},
+    doi = {10.1093/bioadv/vbae116},
+    url = {https://doi.org/10.1093/bioadv/vbae116},
+    eprint = {https://academic.oup.com/bioinformaticsadvances/advance-article-pdf/doi/10.1093/bioadv/vbae116/58869902/vbae116.pdf},
 }
 """
 
@@ -57,7 +71,7 @@ divided the corpus into training, development, and test sets.
 
 _HOMEPAGE = "https://zenodo.org/records/11263147"
 
-_LICENSE = Licenses.CC_BY_4p0
+_LICENSE = "Creative Commons Attribution 4.0 International"
 
 _URLS = {
     _DATASETNAME: "https://zenodo.org/records/11263147/files/CoNECo_corpus.tar.gz?download=1",
@@ -170,7 +184,7 @@ class ConecoDataset(datasets.GeneratorBasedBuilder):
     def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
         if self.config.schema == "source":
-            for file in filepath.iterdir():
+            for file in sorted(filepath.iterdir()):
                 if file.suffix != ".txt":
                     continue
                 brat_parsed = parse_brat_file(file)
@@ -179,7 +193,7 @@ class ConecoDataset(datasets.GeneratorBasedBuilder):
                 yield brat_parsed["document_id"], brat_parsed
 
         elif self.config.schema == "bigbio_kb":
-            for file in filepath.iterdir():
+            for file in sorted(filepath.iterdir()):
                 if file.suffix != ".txt":
                     continue
                 brat_parsed = parse_brat_file(file)

--- a/bigbio/hub/hub_repos/coneco/coneco.py
+++ b/bigbio/hub/hub_repos/coneco/coneco.py
@@ -180,6 +180,11 @@ class ConecoDataset(datasets.GeneratorBasedBuilder):
             ),
         ]
 
+    def _filter_oos_entities(self, brat_parse):
+        """Filter out entity annotations with out-of-scope type."""
+        brat_parse["text_bound_annotations"] = [a for a in brat_parse["text_bound_annotations"] if a["type"] != "OOS"]
+        return brat_parse
+
     def _generate_examples(self, filepath, split: str) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
         if self.config.schema == "source":
@@ -187,6 +192,7 @@ class ConecoDataset(datasets.GeneratorBasedBuilder):
                 if file.suffix != ".txt":
                     continue
                 brat_parsed = parse_brat_file(file)
+                brat_parsed = self._filter_oos_entities(brat_parsed)
                 brat_parsed["id"] = file.stem
 
                 yield brat_parsed["document_id"], brat_parsed
@@ -196,6 +202,7 @@ class ConecoDataset(datasets.GeneratorBasedBuilder):
                 if file.suffix != ".txt":
                     continue
                 brat_parsed = parse_brat_file(file)
+                brat_parsed = self._filter_oos_entities(brat_parsed)
                 bigbio_kb_example = brat_parse_to_bigbio_kb(brat_parsed)
                 bigbio_kb_example["id"] = file.stem
 


### PR DESCRIPTION
- **Name:** CoNECo
- **Description:** Complex Named Entity Corpus (CoNECo) is an annotated corpus for NER and NEN of protein-containing complexes. CoNECo comprises 1,621 documents divided into train, val and test splits with 2,052 entities, 1,976 of which are normalized to Gene Ontology.
- **Paper:** https://www.biorxiv.org/content/early/2024/05/29/2024.05.18.594800
- **Data:** https://zenodo.org/records/11263147

### Checkbox

- [ ] ~~Confirm that this PR is linked to the dataset issue.~~
- [x] Create the dataloader script `hub/hub_repos/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_BIGBIO_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [ ] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `BigBioConfig` for the source schema and one for a bigbio schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_bigbio_hub <dataset_name> [--data_dir /path/to/local/data] --test_local`.
- [ ] ~~If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.~~